### PR TITLE
Start activities through `ActivityStarter`

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -44,6 +44,7 @@ object Dependencies {
         "com.jeanbarrossilva.loadable:loadable-placeholder-test:${Versions.LOADABLE}"
     const val LOTTIE_COMPOSE = "com.airbnb.android:lottie-compose:${Versions.LOTTIE}"
     const val MATERIAL = "com.google.android.material:material:${Versions.MATERIAL}"
+    const val MOCKITO = "org.mockito:mockito-core:${Versions.MOCKITO}"
     const val NAVIGATION_FRAGMENT = "androidx.navigation:navigation-fragment:${Versions.NAVIGATION}"
     const val PAGINATE = "com.chrynan.paginate:paginate-core:${Versions.PAGINATE}"
     const val ROBOLECTRIC = "org.robolectric:robolectric:${Versions.ROBOLECTRIC}"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -26,6 +26,7 @@ object Versions {
     const val LOADABLE = "1.6.5"
     const val LOTTIE = "6.1.0"
     const val MATERIAL = "1.9.0"
+    const val MOCKITO = "5.4.0"
     const val NAVIGATION = "2.6.0"
     const val PAGINATE = "0.3.0"
     const val ROBOLECTRIC = "4.10.3"

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authentication/ui/activity/AuthenticationActivity.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authentication/ui/activity/AuthenticationActivity.kt
@@ -1,15 +1,14 @@
 package com.jeanbarrossilva.orca.core.mastodon.auth.authentication.ui.activity
 
 import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
 import com.jeanbarrossilva.orca.core.mastodon.auth.authentication.MastodonAuthenticator
 import com.jeanbarrossilva.orca.core.mastodon.auth.authentication.ui.Authentication
 import com.jeanbarrossilva.orca.core.mastodon.auth.authentication.ui.AuthenticationViewModel
-import com.jeanbarrossilva.orca.platform.ui.core.Intent
 import com.jeanbarrossilva.orca.platform.ui.core.composable.ComposableActivity
+import com.jeanbarrossilva.orca.platform.ui.core.on
 import org.koin.android.ext.android.inject
 
 internal class AuthenticationActivity : ComposableActivity() {
@@ -40,12 +39,11 @@ internal class AuthenticationActivity : ComposableActivity() {
         private const val AUTHORIZATION_CODE_KEY = "authorization-code"
 
         fun start(context: Context, authorizationCode: String) {
-            val intent = Intent<AuthenticationActivity>(
-                context,
-                AUTHORIZATION_CODE_KEY to authorizationCode
-            )
-                .apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK }
-            context.startActivity(intent)
+            context
+                .on<AuthenticationActivity>()
+                .asNewTask()
+                .with(AUTHORIZATION_CODE_KEY to authorizationCode)
+                .start()
         }
     }
 }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/ui/AuthorizationActivity.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/ui/AuthorizationActivity.kt
@@ -9,6 +9,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.runtime.Composable
 import com.jeanbarrossilva.orca.core.mastodon.auth.authorization.MastodonAuthorizer
 import com.jeanbarrossilva.orca.platform.ui.core.composable.ComposableActivity
+import com.jeanbarrossilva.orca.platform.ui.core.on
 import org.koin.android.ext.android.inject
 
 internal class AuthorizationActivity : ComposableActivity() {
@@ -46,9 +47,7 @@ internal class AuthorizationActivity : ComposableActivity() {
 
     companion object {
         fun start(context: Context) {
-            val intent = Intent(context, AuthorizationActivity::class.java)
-                .apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK }
-            context.startActivity(intent)
+            context.on<AuthorizationActivity>().asNewTask().start()
         }
     }
 }

--- a/feature/auth/src/main/java/com/jeanbarrossilva/orca/feature/auth/AuthActivity.kt
+++ b/feature/auth/src/main/java/com/jeanbarrossilva/orca/feature/auth/AuthActivity.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
 import com.jeanbarrossilva.orca.core.auth.Authenticator
-import com.jeanbarrossilva.orca.platform.ui.core.Intent
 import com.jeanbarrossilva.orca.platform.ui.core.composable.ComposableActivity
+import com.jeanbarrossilva.orca.platform.ui.core.on
 import org.koin.android.ext.android.inject
 
 class AuthActivity internal constructor() : ComposableActivity() {
@@ -21,8 +21,7 @@ class AuthActivity internal constructor() : ComposableActivity() {
 
     companion object {
         fun start(context: Context) {
-            val intent = Intent<AuthActivity>(context)
-            context.startActivity(intent)
+            context.on<AuthActivity>().start()
         }
     }
 }

--- a/platform/ui/build.gradle.kts
+++ b/platform/ui/build.gradle.kts
@@ -59,5 +59,6 @@ dependencies {
     testImplementation(project(":platform:ui-test"))
     testImplementation(Dependencies.COMPOSE_UI_TEST_JUNIT_4)
     testImplementation(Dependencies.COMPOSE_UI_TEST_MANIFEST)
+    testImplementation(Dependencies.MOCKITO)
     testImplementation(Dependencies.ROBOLECTRIC)
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/ActivityStarter.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/ActivityStarter.kt
@@ -1,0 +1,61 @@
+package com.jeanbarrossilva.orca.platform.ui.core
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import kotlin.reflect.KClass
+
+/**
+ * Starts an [Activity] with the configured settings.
+ *
+ * @param T [Activity] to be started.
+ * @param context [Context] from which the [Activity] will be started.
+ * @param activityClass [KClass] of the [Activity].
+ **/
+class ActivityStarter<T : Activity> @PublishedApi internal constructor(
+    private val context: Context,
+    private val activityClass: KClass<T>
+) {
+    /** Arguments to be passed to the [Intent]'s [extras][Intent.getExtras]. **/
+    private val args = hashMapOf<String, Any?>()
+
+    /** [Intent]'s [flags][Intent.getFlags]. **/
+    private var flags = 0
+
+    /**
+     * Defines the [Activity] as the first task of a new [Activity] group to be created. Useful for
+     * when it isn't started from another [Activity].
+     *
+     * @see Intent.FLAG_ACTIVITY_NEW_TASK
+     **/
+    fun asNewTask(): ActivityStarter<T> {
+        return apply {
+            flags = flags or Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+    }
+
+    /**
+     * Defines the arguments to be passed to the [Intent]'s [extras][Intent.getExtras].
+     *
+     * @param args Key-value [Pair]s representing the arguments for the [Activity].
+     **/
+    fun with(vararg args: Pair<String, Any?>): ActivityStarter<T> {
+        return apply {
+            args.forEach {
+                this.args[it.first] = it.second
+            }
+        }
+    }
+
+    /**
+     * Starts the [Activity].
+     *
+     * @see Context.startActivity
+     **/
+    fun start() {
+        val argsAsArray = args.map { (key, value) -> key to value }.toTypedArray()
+        val extras = bundleOf(*argsAsArray)
+        val intent = Intent(context, activityClass.java).putExtras(extras).addFlags(flags)
+        context.startActivity(intent)
+    }
+}

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Bundle.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Bundle.extensions.kt
@@ -1,0 +1,16 @@
+package com.jeanbarrossilva.orca.platform.ui.core
+
+import android.os.Bundle
+import androidx.core.os.bundleOf
+
+/**
+ * Creates a [Bundle] with the given key-value [pairs] put into it.
+ *
+ * @param pairs Elements to be put into the resulting [Bundle].
+ * @return [Bundle], or `null` if [pairs] is empty.
+ **/
+@PublishedApi
+internal fun bundleOf(vararg pairs: Pair<String, Any?>): Bundle? {
+    val hasArgs = pairs.isNotEmpty()
+    return if (hasArgs) bundleOf(*pairs) else null
+}

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Context.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Context.extensions.kt
@@ -1,0 +1,14 @@
+package com.jeanbarrossilva.orca.platform.ui.core
+
+import android.app.Activity
+import android.content.Context
+
+/**
+ * Creates an [ActivityStarter] for the [Activity], from which it can be set up and started.
+ *
+ * @param T [Activity] whose start-up may be configured.
+ * @see ActivityStarter.start
+ **/
+inline fun <reified T : Activity> Context.on(): ActivityStarter<T> {
+    return ActivityStarter(this, T::class)
+}

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Intent.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Intent.extensions.kt
@@ -4,8 +4,18 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import androidx.core.os.bundleOf
+import android.os.Bundle
 import java.net.URL
+
+/**
+ * Puts [extras] into this [Intent] if it isn't `null`.
+ *
+ * @param extras Extras [Bundle] to be put.
+ **/
+@PublishedApi
+internal fun Intent.putExtras(extras: Bundle?): Intent {
+    return extras?.let(::putExtras) ?: this
+}
 
 /**
  * [Intent] through which the [Activity] can be started.

--- a/platform/ui/src/test/java/com/jeanbarrossilva/orca/platform/ui/core/ActivityStarterTests.kt
+++ b/platform/ui/src/test/java/com/jeanbarrossilva/orca/platform/ui/core/ActivityStarterTests.kt
@@ -1,0 +1,23 @@
+package com.jeanbarrossilva.orca.platform.ui.core
+
+import android.app.Activity
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.any
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class ActivityStarterTests {
+    private class TestActivity : Activity()
+
+    @Test
+    fun `GIVEN an Activity WHEN starting it THEN it's started`() {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val mockedContext = spy(context)
+        mockedContext.on<TestActivity>().asNewTask().start()
+        verify(mockedContext).startActivity(any())
+    }
+}


### PR DESCRIPTION
Adds an alternative and more legible API for starting activities.

Before:

```kotlin
val intent = Intent<Activity>(context, "message" to "Hello!").addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
context.startActivity(intent)
```

Now:

```kotlin
context.on<Activity>().asNewTask().with("message" to "Hello!").start()
```