### PR TITLE
Remove unused imports and line breaks on typealias definitions

### DIFF
--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/ui/AuthorizationActivity.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/ui/AuthorizationActivity.kt
@@ -1,7 +1,6 @@
 package com.jeanbarrossilva.orca.core.mastodon.auth.authorization.ui
 
 import android.content.Context
-import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.activity.viewModels

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/cache/MastodonProfileStore.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/cache/MastodonProfileStore.kt
@@ -22,8 +22,7 @@ import kotlin.time.ExperimentalTime
 private typealias MastodonProfileFetcher = Fetcher<String, MastodonProfileEntity>
 
 /** [MastodonProfileStore]'s [SourceOfTruth]. **/
-private typealias MastodonProfileSourceOfTruth =
-    SourceOfTruth<String, MastodonProfileEntity, Optional<Profile>>
+private typealias MastodonProfileSourceOfTruth = SourceOfTruth<String, MastodonProfileEntity, Optional<Profile>> // ktlint-disable max-line-length
 
 /** [Store] for storing [Profile]s. **/
 internal typealias MastodonProfileStore = Store<String, Optional<Profile>>

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/search/cache/MastodonProfileSearchResultStore.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/search/cache/MastodonProfileSearchResultStore.kt
@@ -21,12 +21,10 @@ import io.ktor.client.request.parameter
 import kotlin.time.ExperimentalTime
 
 /** [ProfileSearchResultsStore]'s [Fetcher]. **/
-private typealias ProfileSearchResultsFetcher =
-    Fetcher<String, List<ProfileSearchResultEntity>>
+private typealias ProfileSearchResultsFetcher = Fetcher<String, List<ProfileSearchResultEntity>>
 
 /** [ProfileSearchResultsStore]'s [SourceOfTruth]. **/
-private typealias ProfileSearchResultsSourceOfTruth =
-    SourceOfTruth<String, List<ProfileSearchResultEntity>, List<ProfileSearchResult>>
+private typealias ProfileSearchResultsSourceOfTruth = SourceOfTruth<String, List<ProfileSearchResultEntity>, List<ProfileSearchResult>> // ktlint-disable max-line-length
 
 /** [Store] for [ProfileSearchResult]s. **/
 typealias ProfileSearchResultsStore = Store<String, List<ProfileSearchResult>>


### PR DESCRIPTION
How did these get there?