### PR TITLE
Fix blank Mastodon feed

### DIFF
--- a/core/mastodon/build.gradle.kts
+++ b/core/mastodon/build.gradle.kts
@@ -73,4 +73,6 @@ dependencies {
     releaseImplementation(Dependencies.SLF4J) {
         because("Ktor references \"StaticLoggerBinder\" and it is missing on minification.")
     }
+
+    testImplementation(Dependencies.JUNIT)
 }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/client/MastodonHttpClient.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/client/MastodonHttpClient.kt
@@ -8,6 +8,7 @@ import com.jeanbarrossilva.orca.core.mastodon.Mastodon
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpResponseValidator
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.observer.ResponseObserver
@@ -145,6 +146,11 @@ private fun HttpClientConfig<*>.setUpResponseLogging() {
             Log.i(TAG, it.format())
         } else {
             Log.e(TAG, it.format())
+        }
+    }
+    HttpResponseValidator {
+        handleResponseExceptionWithRequest { cause, _ ->
+            Log.e(TAG, cause.message, cause)
         }
     }
 }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/FeedTootPaginateSource.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/FeedTootPaginateSource.kt
@@ -1,0 +1,7 @@
+package com.jeanbarrossilva.orca.core.mastodon.feed
+
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.TootPaginateSource
+
+object FeedTootPaginateSource : TootPaginateSource() {
+    override val route = "/api/v1/timelines/home"
+}

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/MastodonFeedProvider.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/MastodonFeedProvider.kt
@@ -8,18 +8,10 @@ import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.TootPaginateSource
 import kotlinx.coroutines.flow.Flow
 
-class MastodonFeedProvider(
-    private val actorProvider: ActorProvider,
-    private val paginateSource: PaginateSource
-) : FeedProvider() {
-    private val flow = paginateSource.loadAllPagesItems(TootPaginateSource.DEFAULT_COUNT)
-
-    class PaginateSource : TootPaginateSource() {
-        override val route = "/api/v1/timelines/home"
-    }
-
+class MastodonFeedProvider(private val actorProvider: ActorProvider) : FeedProvider() {
+    private val flow = FeedTootPaginateSource.loadAllPagesItems(TootPaginateSource.DEFAULT_COUNT)
     override suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>> {
-        paginateSource.paginateTo(page)
+        FeedTootPaginateSource.paginateTo(page)
         return flow
     }
 

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/MastodonFeedProvider.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/MastodonFeedProvider.kt
@@ -1,20 +1,18 @@
 package com.jeanbarrossilva.orca.core.mastodon.feed
 
+import com.chrynan.paginate.core.loadAllPagesItems
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.auth.actor.ActorProvider
 import com.jeanbarrossilva.orca.core.feed.FeedProvider
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.TootPaginateSource
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 
 class MastodonFeedProvider(
     private val actorProvider: ActorProvider,
     private val paginateSource: PaginateSource
 ) : FeedProvider() {
-    private val flow = paginateSource.loadPages(TootPaginateSource.DEFAULT_COUNT).map {
-        it.items
-    }
+    private val flow = paginateSource.loadAllPagesItems(TootPaginateSource.DEFAULT_COUNT)
 
     class PaginateSource : TootPaginateSource() {
         override val route = "/api/v1/timelines/home"

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/MastodonProfile.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/MastodonProfile.kt
@@ -9,7 +9,7 @@ import java.net.URL
 import kotlinx.coroutines.flow.Flow
 
 internal data class MastodonProfile(
-    private val tootPaginateSource: TootPaginateSource,
+    private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider,
     override val id: String,
     override val account: Account,
     override val avatarURL: URL,
@@ -19,6 +19,7 @@ internal data class MastodonProfile(
     override val followingCount: Int,
     override val url: URL
 ) : Profile {
+    private val tootPaginateSource = tootPaginateSourceProvider.provide(id)
     private val tootsFlow = tootPaginateSource.loadAllPagesItems(TootPaginateSource.DEFAULT_COUNT)
 
     override suspend fun getToots(page: Int): Flow<List<Toot>> {

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/MastodonProfile.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/MastodonProfile.kt
@@ -1,12 +1,12 @@
 package com.jeanbarrossilva.orca.core.mastodon.feed.profile
 
+import com.chrynan.paginate.core.loadAllPagesItems
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
 import com.jeanbarrossilva.orca.core.feed.profile.account.Account
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.TootPaginateSource
 import java.net.URL
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 
 internal data class MastodonProfile(
     private val tootPaginateSource: TootPaginateSource,
@@ -19,9 +19,7 @@ internal data class MastodonProfile(
     override val followingCount: Int,
     override val url: URL
 ) : Profile {
-    private val tootsFlow = tootPaginateSource.loadPages(TootPaginateSource.DEFAULT_COUNT).map {
-        it.items
-    }
+    private val tootsFlow = tootPaginateSource.loadAllPagesItems(TootPaginateSource.DEFAULT_COUNT)
 
     override suspend fun getToots(page: Int): Flow<List<Toot>> {
         tootPaginateSource.paginateTo(page)

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/ProfileTootPaginateSource.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/ProfileTootPaginateSource.kt
@@ -1,0 +1,11 @@
+package com.jeanbarrossilva.orca.core.mastodon.feed.profile
+
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.TootPaginateSource
+
+class ProfileTootPaginateSource(id: String) : TootPaginateSource() {
+    override val route = "/api/v1/accounts/$id/statuses"
+
+    fun interface Provider {
+        fun provide(id: String): ProfileTootPaginateSource
+    }
+}

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/account/MastodonAccount.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/account/MastodonAccount.kt
@@ -6,7 +6,7 @@ import com.jeanbarrossilva.orca.core.feed.profile.toot.Author
 import com.jeanbarrossilva.orca.core.feed.profile.type.followable.Follow
 import com.jeanbarrossilva.orca.core.mastodon.client.MastodonHttpClient
 import com.jeanbarrossilva.orca.core.mastodon.client.authenticateAndGet
-import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.TootPaginateSource
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.ProfileTootPaginateSource
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.type.editable.MastodonEditableProfile
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.type.followable.MastodonFollowableProfile
 import io.ktor.client.call.body
@@ -33,11 +33,11 @@ internal data class MastodonAccount(
         return Author(id, avatarURL, displayName, account, profileURL)
     }
 
-    suspend fun toProfile(tootPaginateSource: TootPaginateSource): Profile {
+    suspend fun toProfile(tootPaginateSourceProvider: ProfileTootPaginateSource.Provider): Profile {
         return if (isOwner()) {
-            toEditableProfile(tootPaginateSource)
+            toEditableProfile(tootPaginateSourceProvider)
         } else {
-            toFollowableProfile(tootPaginateSource)
+            toFollowableProfile(tootPaginateSourceProvider)
         }
     }
 
@@ -52,12 +52,13 @@ internal data class MastodonAccount(
         return id == credentialAccount.id
     }
 
-    private fun toEditableProfile(tootPaginateSource: TootPaginateSource): MastodonEditableProfile {
+    private fun toEditableProfile(tootPaginateSourceProvider: ProfileTootPaginateSource.Provider):
+        MastodonEditableProfile {
         val account = toAccount()
         val avatarURL = URL(avatar)
         val url = URL(url)
         return MastodonEditableProfile(
-            tootPaginateSource,
+            tootPaginateSourceProvider,
             id,
             account,
             avatarURL,
@@ -69,8 +70,9 @@ internal data class MastodonAccount(
         )
     }
 
-    private suspend fun toFollowableProfile(tootPaginateSource: TootPaginateSource):
-        MastodonFollowableProfile<Follow> {
+    private suspend fun toFollowableProfile(
+        tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
+    ): MastodonFollowableProfile<Follow> {
         val account = toAccount()
         val avatarURL = URL(avatar)
         val url = URL(url)
@@ -80,7 +82,7 @@ internal data class MastodonAccount(
             .first()
             .toFollow(this)
         return MastodonFollowableProfile(
-            tootPaginateSource,
+            tootPaginateSourceProvider,
             id,
             account,
             avatarURL,

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/cache/ProfileFetcher.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/cache/ProfileFetcher.kt
@@ -3,17 +3,17 @@ package com.jeanbarrossilva.orca.core.mastodon.feed.profile.cache
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
 import com.jeanbarrossilva.orca.core.mastodon.client.MastodonHttpClient
 import com.jeanbarrossilva.orca.core.mastodon.client.authenticateAndGet
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.ProfileTootPaginateSource
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.account.MastodonAccount
-import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.TootPaginateSource
 import com.jeanbarrossilva.orca.std.cache.Fetcher
 import io.ktor.client.call.body
 
-class ProfileFetcher(private val tootPaginateSource: TootPaginateSource) :
+class ProfileFetcher(private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider) :
     Fetcher<String, Profile>() {
     override suspend fun onFetch(key: String): Profile {
         return MastodonHttpClient
             .authenticateAndGet("/api/v1/accounts/$key")
             .body<MastodonAccount>()
-            .toProfile(tootPaginateSource)
+            .toProfile(tootPaginateSourceProvider)
     }
 }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/cache/storage/ProfileEntity.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/cache/storage/ProfileEntity.kt
@@ -7,7 +7,7 @@ import androidx.room.PrimaryKey
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
 import com.jeanbarrossilva.orca.core.feed.profile.account.Account
 import com.jeanbarrossilva.orca.core.feed.profile.type.followable.Follow
-import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.TootPaginateSource
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.ProfileTootPaginateSource
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.type.editable.MastodonEditableProfile
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.type.followable.MastodonFollowableProfile
 import java.net.URL
@@ -28,21 +28,23 @@ data class ProfileEntity internal constructor(
     @IntDef(EDITABLE_TYPE, FOLLOWABLE_TYPE)
     internal annotation class Type
 
-    internal fun toProfile(tootPaginateSource: TootPaginateSource): Profile {
+    internal fun toProfile(tootPaginateSourceProvider: ProfileTootPaginateSource.Provider):
+        Profile {
         return when (type) {
-            EDITABLE_TYPE -> toMastodonEditableProfile(tootPaginateSource)
-            FOLLOWABLE_TYPE -> toMastodonFollowableProfile(tootPaginateSource)
+            EDITABLE_TYPE -> toMastodonEditableProfile(tootPaginateSourceProvider)
+            FOLLOWABLE_TYPE -> toMastodonFollowableProfile(tootPaginateSourceProvider)
             else -> throw IllegalStateException("Unknown profile entity type: $type.")
         }
     }
 
-    private fun toMastodonEditableProfile(tootPaginateSource: TootPaginateSource):
-        MastodonEditableProfile {
+    private fun toMastodonEditableProfile(
+        tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
+    ): MastodonEditableProfile {
         val account = Account.of(account)
         val avatarURL = URL(avatarURL)
         val url = URL(url)
         return MastodonEditableProfile(
-            tootPaginateSource,
+            tootPaginateSourceProvider,
             id,
             account,
             avatarURL,
@@ -54,14 +56,15 @@ data class ProfileEntity internal constructor(
         )
     }
 
-    private fun toMastodonFollowableProfile(tootPaginateSource: TootPaginateSource):
-        MastodonFollowableProfile<Follow> {
+    private fun toMastodonFollowableProfile(
+        tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
+    ): MastodonFollowableProfile<Follow> {
         val account = Account.of(account)
         val avatarURL = URL(avatarURL)
         val follow = Follow.of(checkNotNull(follow))
         val url = URL(url)
         return MastodonFollowableProfile(
-            tootPaginateSource,
+            tootPaginateSourceProvider,
             id,
             account,
             avatarURL,

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/cache/storage/ProfileEntity.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/cache/storage/ProfileEntity.kt
@@ -28,8 +28,9 @@ data class ProfileEntity internal constructor(
     @IntDef(EDITABLE_TYPE, FOLLOWABLE_TYPE)
     internal annotation class Type
 
-    internal fun toProfile(tootPaginateSourceProvider: ProfileTootPaginateSource.Provider):
-        Profile {
+    internal fun toProfile(
+        tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
+    ): Profile {
         return when (type) {
             EDITABLE_TYPE -> toMastodonEditableProfile(tootPaginateSourceProvider)
             FOLLOWABLE_TYPE -> toMastodonFollowableProfile(tootPaginateSourceProvider)

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/cache/storage/ProfileStorage.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/cache/storage/ProfileStorage.kt
@@ -1,13 +1,13 @@
 package com.jeanbarrossilva.orca.core.mastodon.feed.profile.cache.storage
 
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.ProfileTootPaginateSource
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.cache.toMastodonProfileEntity
-import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.TootPaginateSource
 import com.jeanbarrossilva.orca.std.cache.Storage
 import kotlinx.coroutines.flow.first
 
 class ProfileStorage(
-    private val tootPaginateSource: TootPaginateSource,
+    private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider,
     private val entityDao: ProfileEntityDao
 ) : Storage<String, Profile>() {
     override suspend fun onStore(key: String, value: Profile) {
@@ -20,7 +20,7 @@ class ProfileStorage(
     }
 
     override suspend fun onGet(key: String): Profile {
-        return entityDao.getByID(key).first().toProfile(tootPaginateSource)
+        return entityDao.getByID(key).first().toProfile(tootPaginateSourceProvider)
     }
 
     override suspend fun onRemove(key: String) {

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/search/cache/ProfileSearchResultsFetcher.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/search/cache/ProfileSearchResultsFetcher.kt
@@ -4,18 +4,19 @@ import com.jeanbarrossilva.orca.core.feed.profile.search.ProfileSearchResult
 import com.jeanbarrossilva.orca.core.feed.profile.search.toProfileSearchResult
 import com.jeanbarrossilva.orca.core.mastodon.client.MastodonHttpClient
 import com.jeanbarrossilva.orca.core.mastodon.client.authenticateAndGet
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.ProfileTootPaginateSource
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.account.MastodonAccount
-import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.TootPaginateSource
 import com.jeanbarrossilva.orca.std.cache.Fetcher
 import io.ktor.client.call.body
 import io.ktor.client.request.parameter
 
-class ProfileSearchResultsFetcher(private val tootPaginateSource: TootPaginateSource) :
-    Fetcher<String, List<ProfileSearchResult>>() {
+class ProfileSearchResultsFetcher(
+    private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
+) : Fetcher<String, List<ProfileSearchResult>>() {
     override suspend fun onFetch(key: String): List<ProfileSearchResult> {
         return MastodonHttpClient
             .authenticateAndGet("/api/v1/accounts/search") { parameter("q", key) }
             .body<List<MastodonAccount>>()
-            .map { it.toProfile(tootPaginateSource).toProfileSearchResult() }
+            .map { it.toProfile(tootPaginateSourceProvider).toProfileSearchResult() }
     }
 }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/Context.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/Context.kt
@@ -1,5 +1,7 @@
 package com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot
 
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.Status
+import kotlinx.serialization.Serializable
 
+@Serializable
 internal data class Context(val ancestors: List<Status>, val descendants: List<Status>)

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/Headers.extensions.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/Headers.extensions.kt
@@ -3,16 +3,22 @@ package com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.LinkHeader
+import io.ktor.util.filter
+import io.ktor.util.toMap
 
 /**
  * Parametrized URIs present in the Link header, each represented by a [LinkHeader].
  *
- * **NOTE**: Only suited for rel-parametrized URIs.
- *
  * @see HttpHeaders.Link
- * @see LinkHeader.Parameters.Rel
  **/
 internal val Headers.links
-    get() = get(HttpHeaders.Link)?.split(',')?.map { it.split(';') }?.map {
-        LinkHeader(uri = it.first().removePrefix("<").removeSuffix(">"), it[1].removePrefix("rel="))
-    }
+    get() = filter { key, _ -> key == HttpHeaders.Link }
+        .toMap()
+        .values
+        .flatten()
+        .map {
+            LinkHeader(
+                uri = it.substringAfter('<').substringBefore('>'),
+                rel = it.substringAfter("rel=\"").substringBeforeLast('"')
+            )
+        }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/Status.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/Status.kt
@@ -4,7 +4,9 @@ import com.jeanbarrossilva.orca.core.mastodon.feed.profile.account.MastodonAccou
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.MastodonToot
 import java.net.URL
 import java.time.ZonedDateTime
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class Status internal constructor(
     internal val id: String,
     internal val createdAt: String,
@@ -13,7 +15,7 @@ data class Status internal constructor(
     internal val favouritesCount: Int,
     internal val repliesCount: Int,
     internal val url: String,
-    internal val text: String,
+    internal val content: String,
     @Suppress("SpellCheckingInspection") internal val favourited: Boolean?,
     internal val reblogged: Boolean?
 ) {
@@ -24,7 +26,7 @@ data class Status internal constructor(
         return MastodonToot(
             id,
             author,
-            text,
+            content,
             publicationDateTime,
             repliesCount,
             favourited == true,

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/TootPaginateSource.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/TootPaginateSource.kt
@@ -24,29 +24,29 @@ abstract class TootPaginateSource internal constructor() : BasePaginateSource<Ur
     ): PagedResult<Url, Toot> {
         val response = getStatusesResponse(key)
         val headerLinks = response.headers.links
-        val previousUrl = headerLinks.firstOrNull()?.uri?.let(::Url)
         val nextUrl = headerLinks.getOrNull(1)?.uri?.let(::Url)
-        val statuses = response.body<List<Status>>().map { it.toToot() }
+        val toots = response.body<List<Status>>().map(Status::toToot)
+        val firstKey = toots.firstOrNull()?.url?.toString()?.let(::Url)
+        val lastKey = toots.lastOrNull()?.url?.toString()?.let(::Url)
         val pageInfo = PageInfo(
             index,
             hasPreviousPage = index > 0,
             hasNextPage = nextUrl != null,
-            firstKey = previousUrl,
-            lastKey = nextUrl
+            firstKey,
+            lastKey
         )
         updateIndex(direction)
-        return PagedResult(pageInfo, statuses)
+        return PagedResult(pageInfo, toots)
     }
 
     internal suspend fun paginateTo(page: Int, count: Int = DEFAULT_COUNT) {
-        var current = currentPage?.info?.index ?: -1
-        while (current != page) {
-            if (current < page) {
+        while (index != page) {
+            if (index < page) {
                 next(count)
-                current++
+                index++
             } else {
                 previous(count)
-                current--
+                index--
             }
         }
     }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/TootPaginateSource.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/TootPaginateSource.kt
@@ -24,8 +24,8 @@ abstract class TootPaginateSource internal constructor() : BasePaginateSource<Ur
     ): PagedResult<Url, Toot> {
         val response = getStatusesResponse(key)
         val headerLinks = response.headers.links
-        val previousUrl = headerLinks?.first()?.uri?.let(::Url)
-        val nextUrl = headerLinks?.get(1)?.uri?.let(::Url)
+        val previousUrl = headerLinks.firstOrNull()?.uri?.let(::Url)
+        val nextUrl = headerLinks.getOrNull(1)?.uri?.let(::Url)
         val statuses = response.body<List<Status>>().map { it.toToot() }
         val pageInfo = PageInfo(
             index,

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/type/editable/MastodonEditableProfile.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/type/editable/MastodonEditableProfile.kt
@@ -4,11 +4,11 @@ import com.jeanbarrossilva.orca.core.feed.profile.Profile
 import com.jeanbarrossilva.orca.core.feed.profile.account.Account
 import com.jeanbarrossilva.orca.core.feed.profile.type.editable.EditableProfile
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.MastodonProfile
-import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.TootPaginateSource
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.ProfileTootPaginateSource
 import java.net.URL
 
 internal data class MastodonEditableProfile(
-    private val tootPaginateSource: TootPaginateSource,
+    private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider,
     override val id: String,
     override val account: Account,
     override val avatarURL: URL,
@@ -19,7 +19,7 @@ internal data class MastodonEditableProfile(
     override val url: URL
 ) :
     Profile by MastodonProfile(
-        tootPaginateSource,
+        tootPaginateSourceProvider,
         id,
         account,
         avatarURL,

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/type/followable/MastodonFollowableProfile.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/type/followable/MastodonFollowableProfile.kt
@@ -7,23 +7,23 @@ import com.jeanbarrossilva.orca.core.feed.profile.type.followable.FollowableProf
 import com.jeanbarrossilva.orca.core.mastodon.client.MastodonHttpClient
 import com.jeanbarrossilva.orca.core.mastodon.client.authenticateAndPost
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.MastodonProfile
-import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.TootPaginateSource
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.ProfileTootPaginateSource
 import java.net.URL
 
 internal data class MastodonFollowableProfile<T : Follow>(
-    private val tootPaginateSource: TootPaginateSource,
+    private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider,
     override val id: String,
     override val account: Account,
     override val avatarURL: URL,
     override val name: String,
     override val bio: String,
-    override val follow: Follow,
+    override val follow: T,
     override val followerCount: Int,
     override val followingCount: Int,
     override val url: URL
 ) :
     Profile by MastodonProfile(
-        tootPaginateSource,
+        tootPaginateSourceProvider,
         id,
         account,
         avatarURL,
@@ -33,8 +33,8 @@ internal data class MastodonFollowableProfile<T : Follow>(
         followingCount,
         url
     ),
-    FollowableProfile<Follow>() {
-    override suspend fun onChangeFollowTo(follow: Follow) {
+    FollowableProfile<T>() {
+    override suspend fun onChangeFollowTo(follow: T) {
         val toggledRoute = follow.getToggledRoute(this)
         MastodonHttpClient.authenticateAndPost(toggledRoute)
     }

--- a/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/HeadersExtensionsTests.kt
+++ b/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/HeadersExtensionsTests.kt
@@ -1,0 +1,22 @@
+package com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot
+
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.links
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headers
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class HeadersExtensionsTests {
+    @Test
+    fun `GIVEN String Link headers WHEN converting each into a LinkHeader THEN they're converted`() { // ktlint-disable max-line-length
+        val headers = headers {
+            append(HttpHeaders.Link, """<https://example.com/next>; rel="next"""")
+            append(HttpHeaders.Link, """<https://example.com/previous>; rel="previous"""")
+        }
+            .links
+        assertEquals("https://example.com/next", headers.first().uri)
+        assertEquals("https://example.com/previous", headers[1].uri)
+        assertEquals("next", headers.first().parameter("rel"))
+        assertEquals("previous", headers[1].parameter("rel"))
+    }
+}

--- a/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedViewModel.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.jeanbarrossilva.loadable.list.SerializableList
 import com.jeanbarrossilva.loadable.list.flow.listLoadable
 import com.jeanbarrossilva.loadable.list.toSerializableList
 import com.jeanbarrossilva.orca.core.feed.FeedProvider
@@ -17,11 +16,10 @@ import com.jeanbarrossilva.orca.platform.ui.core.context.ContextProvider
 import com.jeanbarrossilva.orca.platform.ui.core.context.share
 import java.net.URL
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -31,11 +29,13 @@ internal class FeedViewModel(
     private val tootProvider: TootProvider,
     private val userID: String
 ) : ViewModel() {
-    private val indexMutableFlow = MutableStateFlow(0)
+    private val indexFlow = MutableStateFlow(0)
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val tootPreviewsLoadableFlow = indexMutableFlow
-        .flatMapConcat { getTootPreviewsAt(it) }
+    val tootPreviewsLoadableFlow = indexFlow
+        .flatMapLatest { feedProvider.provide(userID, page = it) }
+        .map { it.map(Toot::toTootPreview) }
+        .map(List<TootPreview>::toSerializableList)
         .listLoadable(viewModelScope, SharingStarted.WhileSubscribed())
 
     fun favorite(tootID: String) {
@@ -55,13 +55,7 @@ internal class FeedViewModel(
     }
 
     fun loadTootsAt(index: Int) {
-        indexMutableFlow.value = index
-    }
-
-    private suspend fun getTootPreviewsAt(index: Int): Flow<SerializableList<TootPreview>> {
-        return feedProvider.provide(userID, index).map { it.map(Toot::toTootPreview) }.map(
-            List<TootPreview>::toSerializableList
-        )
+        indexFlow.value = index
     }
 
     companion object {

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/html/span/SpanConverterFactory.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/html/span/SpanConverterFactory.kt
@@ -1,6 +1,7 @@
 package com.jeanbarrossilva.orca.platform.ui.html.span
 
 import com.jeanbarrossilva.orca.platform.ui.html.span.converter.StyleSpanConverter
+import com.jeanbarrossilva.orca.platform.ui.html.span.converter.URLSpanConverter
 import com.jeanbarrossilva.orca.platform.ui.html.span.converter.UnderlineSpanConverter
 
 /** Factory that creates a [SpanConverter] through [create]. **/
@@ -8,6 +9,7 @@ internal object SpanConverterFactory {
     /** Creates a [SpanConverter]. **/
     fun create(): SpanConverter {
         val styleSpanConverter = StyleSpanConverter(next = null)
-        return UnderlineSpanConverter(next = styleSpanConverter)
+        val urlSpanConverter = URLSpanConverter(next = styleSpanConverter)
+        return UnderlineSpanConverter(next = urlSpanConverter)
     }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/html/span/converter/URLSpanConverter.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/html/span/converter/URLSpanConverter.kt
@@ -1,0 +1,18 @@
+package com.jeanbarrossilva.orca.platform.ui.html.span.converter
+
+import android.text.style.URLSpan
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.style.TextDecoration
+import com.jeanbarrossilva.orca.platform.ui.html.span.SpanConverter
+
+/** [SpanConverter] that converts an [URLSpan] into a [SpanStyle]. **/
+internal class URLSpanConverter(override val next: SpanConverter?) : SpanConverter() {
+    override fun onConvert(span: Any): SpanStyle? {
+        return if (span is URLSpan) {
+            SpanStyle(Color.Blue, textDecoration = TextDecoration.Underline)
+        } else {
+            null
+        }
+    }
+}


### PR DESCRIPTION
The issue was a combination of the following factors:

- Some structures weren't annotated with [`@Serializable`](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization/-serializable/index.html);
- Profile toots were being fetched with the feed's URL;
- Link headers weren't being properly read, which impeded the previous and next toots to be loaded.