### PR TITLE
Fix blank feed on multiple navigation

### DIFF
--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/pagination/TootPaginateSource.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/pagination/TootPaginateSource.kt
@@ -14,6 +14,7 @@ import io.ktor.http.Url
 
 abstract class TootPaginateSource internal constructor() : BasePaginateSource<Url, Toot>() {
     private var index = 0
+        set(index) { field = minOf(0, index) }
 
     protected abstract val route: String
 


### PR DESCRIPTION
An error was occurring when navigating to the feed after the first time it's been navigated to because of a negative toot pagination index. Since there is no error screen yet, the feed would be blank.