### PR TITLE
Turn `:platform:cache` `Access` into a data class

### DIFF
--- a/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/Cache.kt
+++ b/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/Cache.kt
@@ -148,7 +148,7 @@ abstract class Cache<T> internal constructor(context: Context, name: String) {
      * @see timeToLive
      **/
     private suspend fun markAsAlive(key: String) {
-        val access = Access.of(key, Access.Type.ALIVE, elapsedTime.inWholeMilliseconds)
+        val access = Access(key, Access.Type.ALIVE, elapsedTime.inWholeMilliseconds)
         accessDao.insert(access)
     }
 
@@ -159,7 +159,7 @@ abstract class Cache<T> internal constructor(context: Context, name: String) {
      * @see timeToIdle
      **/
     private suspend fun markAsIdle(key: String) {
-        val access = Access.of(key, Access.Type.IDLE, elapsedTime.inWholeMilliseconds)
+        val access = Access(key, Access.Type.IDLE, elapsedTime.inWholeMilliseconds)
         accessDao.insert(access)
     }
 
@@ -169,6 +169,7 @@ abstract class Cache<T> internal constructor(context: Context, name: String) {
          *
          * @param context [Context] through which an instance of the underlying [CacheDatabase] will
          * be obtained.
+         * @param name Identifier of the [Cache] to be created.
          * @param fetcher [Fetcher] through which values will be obtained from their source
          * (normally the network).
          * @param storage [Storage] for fetched values to be stored in and retrieved from.

--- a/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/database/Access.kt
+++ b/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/database/Access.kt
@@ -8,15 +8,18 @@ import androidx.room.PrimaryKey
  * Holds the [key] to which a value has been associated and the moment in which it was last
  * accessed.
  *
- * @param id Unique identifier of this [Access].
  * @param key Unique identifier of the stored value.
  * @param type [Type] that indicates how the value was accessed.
  * @param time Time that's been elapsed when the access occurred.
  **/
 @Entity(tableName = "accesses")
-internal class Access
-@Discouraged(message = "Use `Access.Companion.of` to create an Access instance.")
-constructor(@PrimaryKey val id: String, val key: String, val type: Type, val time: Long) {
+internal data class Access(val key: String, val type: Type, val time: Long) {
+    /** Unique identifier composed by the [key] and the [type]. **/
+    @PrimaryKey
+    var id = "$type:$key"
+        @Discouraged(message = "ID should not be changed manually.")
+        set
+
     /** Indicates how a value was accessed. **/
     enum class Type {
         /** Indicates that a value was written and read. **/
@@ -24,33 +27,5 @@ constructor(@PrimaryKey val id: String, val key: String, val type: Type, val tim
 
         /** Indicates that a value was written (created or updated). **/
         ALIVE
-    }
-
-    override fun equals(other: Any?): Boolean {
-        return other is Access && id == other.id
-    }
-
-    override fun hashCode(): Int {
-        return id.hashCode()
-    }
-
-    override fun toString(): String {
-        return "Access(id=$id, key=$key, type=$type, time=$time)"
-    }
-
-    companion object {
-        /**
-         * Creates an [Access] instance.
-         *
-         * @param key Unique identifier of the stored value.
-         * @param type [Type] that indicates how the value was accessed.
-         * @param time Time that's been elapsed when the access occurred.
-         **/
-        fun of(key: String, type: Type, time: Long): Access {
-            val id = "$type:$key"
-
-            @Suppress("DiscouragedApi")
-            return Access(id, key, type, time)
-        }
     }
 }


### PR DESCRIPTION
Consequently removes [`Access.Companion#of`](https://github.com/jeanbarrossilva/Orca/blob/7ffc8d5f134fd77eaff74f4aad35c4879994cc76/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/database/Access.kt#L49).