### PR TITLE
Turn `Toot.content` into a `Content`

### DIFF
--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/Context.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/Context.kt
@@ -1,5 +1,6 @@
 package com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot
 
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.Status
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/MastodonToot.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/MastodonToot.kt
@@ -2,10 +2,10 @@ package com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot
 
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Author
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
 import com.jeanbarrossilva.orca.core.mastodon.client.MastodonHttpClient
 import com.jeanbarrossilva.orca.core.mastodon.client.authenticateAndGet
 import com.jeanbarrossilva.orca.core.mastodon.client.authenticateAndPost
-import com.jeanbarrossilva.orca.std.styledstring.StyledString
 import io.ktor.client.call.body
 import java.net.URL
 import java.time.ZonedDateTime
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.flow
 data class MastodonToot(
     override val id: String,
     override val author: Author,
-    override val content: StyledString,
+    override val content: Content,
     override val publicationDateTime: ZonedDateTime,
     override val commentCount: Int,
     override val isFavorite: Boolean,

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/cache/MastodonTootFetcher.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/cache/MastodonTootFetcher.kt
@@ -3,7 +3,7 @@ package com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.cache
 import com.jeanbarrossilva.orca.core.mastodon.client.MastodonHttpClient
 import com.jeanbarrossilva.orca.core.mastodon.client.authenticateAndGet
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.MastodonToot
-import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.Status
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.Status
 import com.jeanbarrossilva.orca.platform.cache.Fetcher
 import io.ktor.client.call.body
 

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/cache/storage/MastodonTootStorage.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/cache/storage/MastodonTootStorage.kt
@@ -14,7 +14,7 @@ class MastodonTootStorage(
 ) : Storage<MastodonToot>() {
     override suspend fun onStore(key: String, value: MastodonToot) {
         val tootEntity = MastodonTootEntity.from(value)
-        val styleEntities = value.content.styles.map { it.toMentionEntity(value.id) }
+        val styleEntities = value.content.text.styles.map { it.toMentionEntity(value.id) }
         tootEntityDao.insert(tootEntity)
         styleEntityDao.insert(styleEntities)
     }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/pagination/TootPaginateSource.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/pagination/TootPaginateSource.kt
@@ -7,7 +7,7 @@ import com.chrynan.paginate.core.PagedResult
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
 import com.jeanbarrossilva.orca.core.mastodon.client.MastodonHttpClient
 import com.jeanbarrossilva.orca.core.mastodon.client.authenticateAndGet
-import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.Status
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status.Status
 import io.ktor.client.call.body
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.Url

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/Card.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/Card.kt
@@ -1,0 +1,19 @@
+package com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status
+
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Headline
+import java.net.URL
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class Card(
+    val url: String,
+    val title: String,
+    val description: String,
+    val image: String?
+) {
+    fun toHeadline(): Headline? {
+        return image?.let {
+            Headline(title, subtitle = description.ifEmpty { null }, coverURL = URL(image))
+        }
+    }
+}

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/Status.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/Status.kt
@@ -1,6 +1,8 @@
-package com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot
+package com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status
 
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.account.MastodonAccount
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.MastodonToot
 import com.jeanbarrossilva.orca.platform.ui.core.style.fromHtml
 import com.jeanbarrossilva.orca.std.styledstring.StyledString
 import java.net.URL
@@ -16,6 +18,7 @@ data class Status internal constructor(
     internal val favouritesCount: Int,
     internal val repliesCount: Int,
     internal val url: String,
+    internal val card: Card?,
     internal val content: String,
     @Suppress("SpellCheckingInspection") internal val favourited: Boolean?,
     internal val reblogged: Boolean?
@@ -23,7 +26,8 @@ data class Status internal constructor(
 
     internal fun toToot(): MastodonToot {
         val author = this.account.toAuthor()
-        val content = StyledString.fromHtml(content)
+        val text = StyledString.fromHtml(content)
+        val content = Content.from(text) { card?.toHeadline() }
         val publicationDateTime = ZonedDateTime.parse(createdAt)
         val url = URL(url)
         return MastodonToot(

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/SampleToot.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/SampleToot.kt
@@ -2,7 +2,7 @@ package com.jeanbarrossilva.orca.core.sample.feed.profile.toot
 
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Author
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
-import com.jeanbarrossilva.orca.std.styledstring.StyledString
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
 import java.net.URL
 import java.time.ZonedDateTime
 import kotlinx.coroutines.flow.Flow
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.flowOf
 internal data class SampleToot(
     override val id: String,
     override val author: Author,
-    override val content: StyledString,
+    override val content: Content,
     override val publicationDateTime: ZonedDateTime,
     override val commentCount: Int,
     override val isFavorite: Boolean,

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/Toot.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/Toot.extensions.kt
@@ -2,7 +2,8 @@ package com.jeanbarrossilva.orca.core.sample.feed.profile.toot
 
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Author
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
-import com.jeanbarrossilva.orca.std.styledstring.StyledString
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
+import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.content.sample
 import java.net.URL
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -29,10 +30,7 @@ private fun createSample(): Toot {
     return SampleToot(
         "${UUID.randomUUID()}",
         Author.sample,
-        content = StyledString(
-            "<p>This is a <b>sample</b> <i>toot</i> that has the sole purpose of allowing one to " +
-                "see how it would look like in <u>Orca</u>.</p>"
-        ),
+        Content.sample,
         publicationDateTime = ZonedDateTime.of(2_003, 10, 8, 8, 0, 0, 0, ZoneId.of("GMT-3")),
         commentCount = 1_024,
         isFavorite = false,

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/Content.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/Content.extensions.kt
@@ -1,0 +1,25 @@
+package com.jeanbarrossilva.orca.core.sample.feed.profile.toot.content
+
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Headline
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Highlight
+import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.content.highlight.sample
+import com.jeanbarrossilva.orca.std.styledstring.buildStyledString
+
+/** [Content] that's returned by [sample]'s getter. **/
+private val sampleContent = Content.from(
+    buildStyledString {
+        +"This is a "
+        bold { +"sample" }
+        italic { +"toot" }
+        +"that has the sole purpose of allowing one to see how it would look like in Orca."
+        +"\n".repeat(2)
+        +Highlight.sample.url.toString()
+    }
+) {
+    Headline.sample
+}
+
+/** Sample [Content]. **/
+val Content.Companion.sample
+    get() = sampleContent

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/highlight/Headline.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/highlight/Headline.extensions.kt
@@ -1,0 +1,17 @@
+package com.jeanbarrossilva.orca.core.sample.feed.profile.toot.content.highlight
+
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Headline
+import java.net.URL
+
+/** [Headline] that's returned by [sample]'s getter. **/
+private val sampleHeadline = Headline(
+    title = "Mastodon",
+    subtitle = "The original server operated by the Mastodon gGmbH non-profit.",
+    coverURL = URL(
+        "https://files.mastodon.social/site_uploads/files/000/000/001/@1x/57c12f441d083cde.png"
+    )
+)
+
+/** Sample [Headline]. **/
+val Headline.Companion.sample
+    get() = sampleHeadline

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/highlight/Highlight.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/highlight/Highlight.extensions.kt
@@ -1,0 +1,12 @@
+package com.jeanbarrossilva.orca.core.sample.feed.profile.toot.content.highlight
+
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Headline
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Highlight
+import java.net.URL
+
+/** [Highlight] that's returned by [sample]'s getter. **/
+private val sampleHighlight = Highlight(Headline.sample, URL("https://mastodon.social"))
+
+/** Sample [Highlight]. **/
+val Highlight.Companion.sample
+    get() = sampleHighlight

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/Toot.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/Toot.kt
@@ -1,6 +1,6 @@
 package com.jeanbarrossilva.orca.core.feed.profile.toot
 
-import com.jeanbarrossilva.orca.std.styledstring.StyledString
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
 import java.io.Serializable
 import java.net.URL
 import java.time.ZonedDateTime
@@ -14,8 +14,8 @@ abstract class Toot : Serializable {
     /** [Author] that has authored this [Toot]. **/
     abstract val author: Author
 
-    /** What's actually been written. **/
-    abstract val content: StyledString
+    /** [Content] that's been composed by the [author]. **/
+    abstract val content: Content
 
     /** Zoned moment in time in which this [Toot] was published. **/
     abstract val publicationDateTime: ZonedDateTime

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Content.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Content.kt
@@ -1,0 +1,81 @@
+package com.jeanbarrossilva.orca.core.feed.profile.toot.content
+
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Headline
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.HeadlineProvider
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Highlight
+import com.jeanbarrossilva.orca.std.styledstring.StyledString
+import com.jeanbarrossilva.orca.std.styledstring.toStyledString
+import com.jeanbarrossilva.orca.std.styledstring.type.Link
+import java.net.URL
+import java.util.Objects
+
+/**
+ * Part that's been composed by the user.
+ *
+ * @param text Written content.
+ * @param highlight [Highlight] from the [text].
+ **/
+class Content private constructor(val text: StyledString, val highlight: Highlight? = null) {
+    /**
+     * [IllegalArgumentException] thrown if the text has a [Highlight] while a [Headline] hasn't
+     * been provided.
+     **/
+    class UnprovidedHeadlineException :
+        IllegalArgumentException("Text has a highlight but no headline was provided.")
+
+    override fun equals(other: Any?): Boolean {
+        return other is Content && text == other.text && highlight == other.highlight
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(text, highlight)
+    }
+
+    override fun toString(): String {
+        return "Content(text=$text, highlight=$highlight)"
+    }
+
+    companion object {
+        /**
+         * Creates [Content] from the given [text].
+         *
+         * @param text [String] from which [Content] will be created.
+         * @param headlineProvider [HeadlineProvider] that provides the [Headline].
+         * @throws UnprovidedHeadlineException If the text has a [Highlight] while a
+         * [HeadlineProvider] hasn't been specified.
+         **/
+        @Throws(UnprovidedHeadlineException::class)
+        fun from(text: StyledString, headlineProvider: HeadlineProvider): Content {
+            val links = text.styles.filterIsInstance<Link>()
+            val link = links.firstOrNull()
+            val url = link?.indices?.let(text::substring)?.let(::URL)
+            val headline = url?.let { headlineProvider.provide(it) }
+            ensureParity(link, headline)
+            val highlight = headline?.let { Highlight(it, url) }
+            val formattedText = if (links.size == 1 && text.trim().endsWith("$url")) {
+                "${text.replaceRange(link?.indices ?: IntRange.EMPTY, "")}"
+                    .trimEnd()
+                    .toStyledString()
+            } else {
+                text
+            }
+            return Content(formattedText, highlight)
+        }
+
+        /**
+         * Ensures the parity of an operation involving the [link] and the [headline], throwing if
+         * the [link] is not `null` and the [headline] is `null`.
+         *
+         * @param link [Link] found in a [StyledString].
+         * @param headline [Headline] with main information about a [Highlight].
+         * @throws UnprovidedHeadlineException If the text has a [Highlight] while the [headline]
+         * hasn't been specified.
+         **/
+        @Throws(UnprovidedHeadlineException::class)
+        private fun ensureParity(link: Link?, headline: Headline?) {
+            if (link != null && headline == null) {
+                throw UnprovidedHeadlineException()
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/highlight/Headline.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/highlight/Headline.kt
@@ -1,0 +1,14 @@
+package com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight
+
+import java.net.URL
+
+/**
+ * Main information of a [Highlight].
+ *
+ * @param title Title of the external site.
+ * @param subtitle Brief description of the content in the external site.
+ * @param coverURL [URL] that leads to the image that represents the content.
+ **/
+data class Headline(val title: String, val subtitle: String?, val coverURL: URL) {
+    companion object
+}

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/highlight/HeadlineProvider.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/highlight/HeadlineProvider.kt
@@ -1,0 +1,13 @@
+package com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight
+
+import java.net.URL
+
+/** Provides a [Headline] through [provide]. **/
+fun interface HeadlineProvider {
+    /**
+     * Provides a [Headline] based on the [url].
+     *
+     * @param url [URL] for which the [Headline] will be provided.
+     **/
+    fun provide(url: URL): Headline?
+}

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/highlight/Highlight.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/highlight/Highlight.kt
@@ -1,0 +1,14 @@
+package com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight
+
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
+import java.net.URL
+
+/**
+ * Main portion of a [Content] that redirects the user to another site.
+ *
+ * @param headline [Headline] with the main information.
+ * @param url [URL] that leads to the external site.
+ **/
+data class Highlight(val headline: Headline, val url: URL) {
+    companion object
+}

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/ContentTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/ContentTests.kt
@@ -1,0 +1,43 @@
+package com.jeanbarrossilva.orca.core.feed.profile.toot.content
+
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Headline
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Highlight
+import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.content.highlight.sample
+import com.jeanbarrossilva.orca.std.styledstring.StyledString
+import com.jeanbarrossilva.orca.std.styledstring.buildStyledString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal class ContentTests {
+    @Test
+    fun `GIVEN a text with a URL without providing a headline WHEN creating content from it THEN it throws`() { // ktlint-disable max-line-length
+        assertFailsWith<Content.UnprovidedHeadlineException> {
+            Content.from(buildStyledString { +Highlight.sample.url.toString() }) {
+                null
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN a text with a single trailing URL WHEN creating content from it THEN it's removed`() { // ktlint-disable max-line-length
+        assertEquals(
+            StyledString("🥸"),
+            Content
+                .from(buildStyledString { +"🥸 ${Highlight.sample.url}" }) { Headline.sample }
+                .text
+        )
+    }
+
+    @Test
+    fun `GIVEN a text with two trailing URLs WHEN creating content from it THEN they're kept`() {
+        assertEquals(
+            buildStyledString { +"🫨 ${Highlight.sample.url} ${Highlight.sample.url}" },
+            Content
+                .from(buildStyledString { +"🫨 ${Highlight.sample.url} ${Highlight.sample.url}" }) {
+                    Headline.sample
+                }
+                .text
+        )
+    }
+}

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/test/TestToot.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/test/TestToot.kt
@@ -2,8 +2,8 @@ package com.jeanbarrossilva.orca.core.feed.profile.toot.test
 
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Author
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
 import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.sample
-import com.jeanbarrossilva.orca.std.styledstring.StyledString
 import java.net.URL
 import java.time.ZonedDateTime
 import kotlinx.coroutines.flow.Flow
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.Flow
 internal class TestToot(
     override val id: String = Toot.sample.id,
     override val author: Author = Toot.sample.author,
-    override val content: StyledString = Toot.sample.content,
+    override val content: Content = Toot.sample.content,
     override val publicationDateTime: ZonedDateTime = Toot.sample.publicationDateTime,
     override val commentCount: Int = Toot.sample.commentCount,
     isLiked: Boolean = Toot.sample.isFavorite,

--- a/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/Composer.kt
+++ b/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/Composer.kt
@@ -238,7 +238,7 @@ private fun EmptyWithToolbarComposerPreview() {
 private fun PopulatedWithoutToolbarComposerPreview() {
     OrcaTheme {
         Composer(
-            TextFieldValue(Toot.sample.content.toAnnotatedString()),
+            TextFieldValue(Toot.sample.content.text.toAnnotatedString()),
             isInitiallyFocused = false
         )
     }
@@ -250,7 +250,7 @@ private fun PopulatedWithoutToolbarComposerPreview() {
 private fun PopulatedWithToolbarComposerPreview() {
     OrcaTheme {
         Composer(
-            TextFieldValue(Toot.sample.content.toAnnotatedString()),
+            TextFieldValue(Toot.sample.content.text.toAnnotatedString()),
             isInitiallyFocused = true
         )
     }

--- a/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/Toot.extensions.kt
+++ b/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/Toot.extensions.kt
@@ -15,7 +15,7 @@ internal fun Toot.toTootDetails(colors: Colors): TootDetails {
         author.avatarURL,
         author.name,
         author.account,
-        body = content.toAnnotatedString(colors),
+        body = content.text.toAnnotatedString(colors),
         publicationDateTime,
         commentCount,
         isFavorite,

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/Toot.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/Toot.extensions.kt
@@ -18,7 +18,7 @@ fun Toot.toTootPreview(): TootPreview {
  * @param colors [Colors] by which the resulting [TootPreview]'s [TootPreview.body] can be colored.
  **/
 fun Toot.toTootPreview(colors: Colors): TootPreview {
-    val body = content.toAnnotatedString(colors)
+    val body = content.text.toAnnotatedString(colors)
     return TootPreview(
         id,
         author.avatarURL,

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/style/Style.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/style/Style.extensions.kt
@@ -1,12 +1,14 @@
 package com.jeanbarrossilva.orca.platform.ui.core.style
 
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import com.jeanbarrossilva.orca.platform.theme.configuration.colors.Colors
 import com.jeanbarrossilva.orca.std.styledstring.Style
 import com.jeanbarrossilva.orca.std.styledstring.type.Bold
 import com.jeanbarrossilva.orca.std.styledstring.type.Email
 import com.jeanbarrossilva.orca.std.styledstring.type.Hashtag
+import com.jeanbarrossilva.orca.std.styledstring.type.Italic
 import com.jeanbarrossilva.orca.std.styledstring.type.Link
 import com.jeanbarrossilva.orca.std.styledstring.type.Mention
 
@@ -21,6 +23,7 @@ internal fun Style.toSpanStyle(colors: Colors): SpanStyle {
     return when (this) {
         is Bold -> SpanStyle(fontWeight = FontWeight.Bold)
         is Email, is Hashtag, is Link, is Mention -> SpanStyle(colors.brand.container)
+        is Italic -> SpanStyle(fontStyle = FontStyle.Italic)
         else -> throw IllegalArgumentException("Cannot convert an unknown $this style.")
     }
 }


### PR DESCRIPTION
[`Content`](https://github.com/jeanbarrossilva/Orca/blob/ed46061bffd913ac20dbcaa6a40c89fe7772cec9/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Content.kt) holds both the text and the highlight contained in it.