### PR TITLE
Add attachments to toot content

### DIFF
--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/MastodonAttachment.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/MastodonAttachment.kt
@@ -1,0 +1,16 @@
+package com.jeanbarrossilva.orca.core.mastodon.feed.profile.toot.status
+
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Attachment
+import java.net.URL
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class MastodonAttachment(val previewUrl: String, val description: String) {
+    private val coreAttachment by lazy {
+        Attachment(description.ifBlank { null }, URL(previewUrl))
+    }
+
+    fun toAttachment(): Attachment {
+        return coreAttachment
+    }
+}

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/Status.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/toot/status/Status.kt
@@ -20,6 +20,7 @@ data class Status internal constructor(
     internal val url: String,
     internal val card: Card?,
     internal val content: String,
+    internal val mediaAttachments: List<MastodonAttachment>,
     @Suppress("SpellCheckingInspection") internal val favourited: Boolean?,
     internal val reblogged: Boolean?
 ) {
@@ -27,7 +28,8 @@ data class Status internal constructor(
     internal fun toToot(): MastodonToot {
         val author = this.account.toAuthor()
         val text = StyledString.fromHtml(content)
-        val content = Content.from(text) { card?.toHeadline() }
+        val attachments = mediaAttachments.map(MastodonAttachment::toAttachment)
+        val content = Content.from(text, attachments) { card?.toHeadline() }
         val publicationDateTime = ZonedDateTime.parse(createdAt)
         val url = URL(url)
         return MastodonToot(

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/Content.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/Content.extensions.kt
@@ -1,10 +1,12 @@
 package com.jeanbarrossilva.orca.core.sample.feed.profile.toot.content
 
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Attachment
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Headline
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Highlight
 import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.content.highlight.sample
 import com.jeanbarrossilva.orca.std.styledstring.buildStyledString
+import java.net.URL
 
 /** [Content] that's returned by [sample]'s getter. **/
 private val sampleContent = Content.from(
@@ -15,7 +17,13 @@ private val sampleContent = Content.from(
         +"that has the sole purpose of allowing one to see how it would look like in Orca."
         +"\n".repeat(2)
         +Highlight.sample.url.toString()
-    }
+    },
+    attachments = listOf(
+        Attachment(
+            description = "Abstract art",
+            URL("https://images.unsplash.com/photo-1692890846581-da1a95435f34")
+        )
+    )
 ) {
     Headline.sample
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Attachment.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Attachment.kt
@@ -1,0 +1,11 @@
+package com.jeanbarrossilva.orca.core.feed.profile.toot.content
+
+import java.net.URL
+
+/**
+ * Media that has been attached to [Content].
+ *
+ * @param description Description of what's displayed.
+ * @param url [URL] that leads to the media.
+ **/
+data class Attachment(val description: String?, val url: URL)

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Content.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Content.kt
@@ -13,9 +13,14 @@ import java.util.Objects
  * Part that's been composed by the user.
  *
  * @param text Written content.
+ * @param attachments [Attachment]s containing the attached media.
  * @param highlight [Highlight] from the [text].
  **/
-class Content private constructor(val text: StyledString, val highlight: Highlight? = null) {
+class Content private constructor(
+    val text: StyledString,
+    val attachments: List<Attachment>,
+    val highlight: Highlight? = null
+) {
     /**
      * [IllegalArgumentException] thrown if the text has a [Highlight] while a [Headline] hasn't
      * been provided.
@@ -40,12 +45,17 @@ class Content private constructor(val text: StyledString, val highlight: Highlig
          * Creates [Content] from the given [text].
          *
          * @param text [String] from which [Content] will be created.
+         * @param attachments [Attachment]s containing the attached media.
          * @param headlineProvider [HeadlineProvider] that provides the [Headline].
          * @throws UnprovidedHeadlineException If the text has a [Highlight] while a
          * [HeadlineProvider] hasn't been specified.
          **/
         @Throws(UnprovidedHeadlineException::class)
-        fun from(text: StyledString, headlineProvider: HeadlineProvider): Content {
+        fun from(
+            text: StyledString,
+            attachments: List<Attachment> = emptyList(),
+            headlineProvider: HeadlineProvider
+        ): Content {
             val links = text.styles.filterIsInstance<Link>()
             val link = links.firstOrNull()
             val url = link?.indices?.let(text::substring)?.let(::URL)
@@ -58,7 +68,7 @@ class Content private constructor(val text: StyledString, val highlight: Highlig
             } else {
                 text
             }
-            return Content(formattedText, highlight)
+            return Content(formattedText, attachments, highlight)
         }
 
         /**


### PR DESCRIPTION
Adds the [`attachments`](https://github.com/jeanbarrossilva/Orca/blob/6ab0feb41175c802f4077cd043906ad337cdb3ac/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Content.kt#L21) property to [`Content`](https://github.com/jeanbarrossilva/Orca/blob/6ab0feb41175c802f4077cd043906ad337cdb3ac/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Content.kt#L21).