### PR TITLE
Fix typo in `:core-http`'s test package

### DIFF
--- a/core-http/src/test/java/com/jeanbarrossilva/orca/core/http/CoreHttpClientTests.kt
+++ b/core-http/src/test/java/com/jeanbarrossilva/orca/core/http/CoreHttpClientTests.kt
@@ -1,15 +1,11 @@
-package com.jeanbarrosilva.orca.core.http
+package com.jeanbarrossilva.orca.core.http
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isTrue
-import com.jeanbarrosilva.orca.core.http.test.assertThatRequestAuthorizationHeaderOf
-import com.jeanbarrosilva.orca.core.http.test.runAuthenticatedTest
-import com.jeanbarrosilva.orca.core.http.test.runUnauthenticatedTest
-import com.jeanbarrossilva.orca.core.http.authenticateAndGet
-import com.jeanbarrossilva.orca.core.http.authenticateAndPost
-import com.jeanbarrossilva.orca.core.http.authenticateAndSubmitForm
-import com.jeanbarrossilva.orca.core.http.authenticateAndSubmitFormWithBinaryData
+import com.jeanbarrossilva.orca.core.http.test.assertThatRequestAuthorizationHeaderOf
+import com.jeanbarrossilva.orca.core.http.test.runAuthenticatedTest
+import com.jeanbarrossilva.orca.core.http.test.runUnauthenticatedTest
 import io.ktor.http.parametersOf
 import kotlin.test.Test
 

--- a/core-http/src/test/java/com/jeanbarrossilva/orca/core/http/test/Assert.extensions.kt
+++ b/core-http/src/test/java/com/jeanbarrossilva/orca/core/http/test/Assert.extensions.kt
@@ -1,4 +1,4 @@
-package com.jeanbarrosilva.orca.core.http.test
+package com.jeanbarrossilva.orca.core.http.test
 
 import assertk.Assert
 import assertk.assertThat

--- a/core-http/src/test/java/com/jeanbarrossilva/orca/core/http/test/FixedActorProvider.kt
+++ b/core-http/src/test/java/com/jeanbarrossilva/orca/core/http/test/FixedActorProvider.kt
@@ -1,4 +1,4 @@
-package com.jeanbarrosilva.orca.core.http.test
+package com.jeanbarrossilva.orca.core.http.test
 
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.auth.actor.ActorProvider

--- a/core-http/src/test/java/com/jeanbarrossilva/orca/core/http/test/TestLogger.kt
+++ b/core-http/src/test/java/com/jeanbarrossilva/orca/core/http/test/TestLogger.kt
@@ -1,4 +1,4 @@
-package com.jeanbarrosilva.orca.core.http.test
+package com.jeanbarrossilva.orca.core.http.test
 
 import com.jeanbarrossilva.orca.core.http.Logger
 

--- a/core-http/src/test/java/com/jeanbarrossilva/orca/core/http/test/TestScope.extensions.kt
+++ b/core-http/src/test/java/com/jeanbarrossilva/orca/core/http/test/TestScope.extensions.kt
@@ -1,4 +1,4 @@
-package com.jeanbarrosilva.orca.core.http.test
+package com.jeanbarrossilva.orca.core.http.test
 
 import com.jeanbarrossilva.orca.core.auth.AuthenticationLock
 import com.jeanbarrossilva.orca.core.auth.actor.Actor


### PR DESCRIPTION
Was missing an "s" in "jeanbarrossilva". 🫠