### PR TITLE
Add `Domain` value class for integrity insurance

### DIFF
--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/AuthenticationTestRule.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/AuthenticationTestRule.kt
@@ -15,7 +15,9 @@ internal class AuthenticationTestRule(private val composeRule: ComposeTestRule) 
     ExternalResource() {
     override fun before() {
         composeRule.onNodeWithTag(AUTH_USERNAME_FIELD_TAG).performTextInput(Account.sample.username)
-        composeRule.onNodeWithTag(AUTH_INSTANCE_FIELD_TAG).performTextInput(Account.sample.instance)
+        composeRule.onNodeWithTag(AUTH_INSTANCE_FIELD_TAG).performTextInput(
+            "${Account.sample.domain}"
+        )
         composeRule.onNodeWithTag(AUTH_SIGN_IN_BUTTON_TAG).performClick()
     }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/account/HttpAccount.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/account/HttpAccount.kt
@@ -74,7 +74,7 @@ internal data class HttpAccount(
 
     /** Converts this [HttpAccount] into an [Account]. **/
     private fun toAccount(): Account {
-        return Account.of(acct, fallbackInstance = "mastodon.social")
+        return Account.of(acct, fallbackDomain = "mastodon.social")
     }
 
     /**

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/storage/HttpProfileSearchResultEntity.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/storage/HttpProfileSearchResultEntity.kt
@@ -29,7 +29,7 @@ data class HttpProfileSearchResultEntity(
 ) {
     /** Converts this [HttpProfileSearchResultEntity] into a [ProfileSearchResult]. **/
     internal fun toProfileSearchResult(): ProfileSearchResult {
-        val account = Account.of(account, fallbackInstance = "mastodon.social")
+        val account = Account.of(account, fallbackDomain = "mastodon.social")
         val avatarURL = URL(avatarURL)
         val url = URL(url)
         return ProfileSearchResult(id, account, avatarURL, name, url)

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/Account.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/Account.kt
@@ -1,60 +1,43 @@
 package com.jeanbarrossilva.orca.core.feed.profile.account
 
+import com.jeanbarrossilva.orca.core.feed.profile.account.Account.BlankUsernameException
+import com.jeanbarrossilva.orca.core.feed.profile.account.Account.Companion.of
+import com.jeanbarrossilva.orca.core.feed.profile.account.Account.IllegalUsernameException
+import com.jeanbarrossilva.orca.core.instance.domain.Domain
+import com.jeanbarrossilva.orca.core.instance.domain.isLegal
 import java.io.Serializable
 
 /**
- * Identifies the user within an [instance].
+ * Identifies the user within the [domain].
  *
  * An [Account] can be instantiated either through the [at] extension function or by parsing a given
  * [String] with [of].
  *
  * @param username Unique name that can be modified.
- * @param instance Mastodon instance from which the user is.
+ * @param domain [Domain] of the server in which this [Account] is.
  * @throws BlankUsernameException If the [username] is blank.
- * @throws IllegalUsernameException If the [username] contains any of the [illegalCharacters].
- * @throws BlankInstanceException If the [instance] is blank.
- * @throws IllegalInstanceException If the [instance] contains any of the [illegalCharacters].
- * @throws InstanceWithoutDomainException If the [instance] doesn't have a domain.
+ * @throws IllegalUsernameException If the [username] contains any illegal characters.
  **/
-data class Account internal constructor(val username: String, val instance: String) : Serializable {
+data class Account internal constructor(val username: String, val domain: Domain) : Serializable {
     /** [IllegalArgumentException] thrown if the [username] is blank. **/
     class BlankUsernameException internal constructor() :
         IllegalArgumentException("An account cannot have a blank username.")
 
     /**
-     * [IllegalArgumentException] thrown if the [username] contains any of the [illegalCharacters].
+     * [IllegalArgumentException] thrown if the [username] contains any illegal characters.
      *
      * @param illegalCharacters [Char]s that make the [username] illegal.
      **/
     class IllegalUsernameException internal constructor(illegalCharacters: List<Char>) :
         IllegalArgumentException("Username cannot contain: $illegalCharacters")
 
-    /** [IllegalArgumentException] thrown if the [instance] is blank. **/
-    class BlankInstanceException internal constructor() :
-        IllegalArgumentException("An account cannot have a blank instance.")
-
-    /**
-     * [IllegalArgumentException] thrown if the [instance] contains any of the [illegalCharacters].
-     *
-     * @param illegalCharacters [Char]s that make the [instance] illegal.
-     **/
-    class IllegalInstanceException internal constructor(illegalCharacters: List<Char>) :
-        IllegalArgumentException("Instance cannot contain: $illegalCharacters")
-
-    /** [IllegalArgumentException] thrown if the [instance] doesn't have a domain. **/
-    inner class InstanceWithoutDomainException internal constructor() :
-        IllegalArgumentException("The instance \"$instance\" doesn't have a domain.")
-
     init {
         ensureUsernameNonBlankness()
         ensureUsernameLegality()
-        ensureInstanceNonBlankness()
-        ensureInstanceLegality()
-        ensureInstanceDomainPresence()
     }
 
     override fun toString(): String {
-        return username + SEPARATOR + instance
+        return username + SEPARATOR + domain
     }
 
     /**
@@ -74,58 +57,14 @@ data class Account internal constructor(val username: String, val instance: Stri
      * @throws IllegalUsernameException If the [username] is illegal.
      **/
     private fun ensureUsernameLegality() {
-        ensureLegalityOf(username) {
+        Domain.doOnIllegality(username) {
             throw IllegalUsernameException(it)
         }
     }
 
-    /**
-     * Ensures that the instance is not blank.
-     *
-     * @throws BlankInstanceException If the [instance] is blank.
-     **/
-    private fun ensureInstanceNonBlankness() {
-        if (instance.isBlank()) {
-            throw BlankInstanceException()
-        }
-    }
-
-    /**
-     * Ensures that the [instance] is legal.
-     *
-     * @throws IllegalInstanceException If the [instance] is illegal.
-     **/
-    private fun ensureInstanceLegality() {
-        ensureLegalityOf(instance) {
-            throw IllegalInstanceException(it)
-        }
-    }
-
-    /**
-     * Ensures that the [instance] has a domain.
-     *
-     * @throws InstanceWithoutDomainException If the [instance] doesn't have a domain.
-     **/
-    private fun ensureInstanceDomainPresence() {
-        if (!instance.containsDomain) {
-            throw InstanceWithoutDomainException()
-        }
-    }
-
     companion object {
-        /** [Char] that separates the [username] from the [instance]. **/
+        /** [Char] that separates the [username] from the [domain]. **/
         private const val SEPARATOR = '@'
-
-        /** [Char]s that neither the [username] nor the [instance] should contain. **/
-        private val illegalCharacters = arrayOf(' ', SEPARATOR)
-
-        /** Whether the [String] contains a domain. **/
-        private val String.containsDomain
-            get() = split('.').getOrNull(1)?.isNotBlank() ?: false
-
-        /** Whether this [String] contains none of the [illegalCharacters]. **/
-        private val String.isLegal
-            get() = illegalCharacters.none { it in this }
 
         /**
          * [IllegalArgumentException] thrown if a blank [String] is given when parsing it into an
@@ -139,33 +78,34 @@ data class Account internal constructor(val username: String, val instance: Stri
         /**
          * Parses the [string] into an [Account].
          *
-         * It should be formatted as `"{username}@{instance}"`, with "{username}" and "{instance}"
+         * It should be formatted as `"{username}@{domain}"`, with "{username}" and "{domain}"
          * replaced by the actual data they represent; it can also be given as `"{username}"`,
-         * without the instance, if a [fallbackInstance] is specified.
+         * without the domain, if a [fallbackDomain] is specified.
          *
-         * Any leading or trailing whitespace in both the [string] and the [fallbackInstance] will
-         * be ignored.
+         * Any leading or trailing whitespace in both the [string] and the [fallbackDomain] will be
+         * ignored.
          *
          * @param string [String] to be parsed.
-         * @param fallbackInstance Instance to fallback to if the [string] only has a username.
+         * @param fallbackDomain [Domain] to fallback to if the [string] only has a username.
          * @throws BlankStringException If the [string] is blank.
          * @throws BlankUsernameException If the username is blank.
-         * @throws IllegalUsernameException If the username contains any of the
-         * [illegalCharacters].
-         * @throws BlankInstanceException If the instance is not specified in the [string] and the
-         * [fallbackInstance] is `null`.
-         * @throws IllegalInstanceException If the instance contains any of the
-         * [illegalCharacters].
-         * @throws InstanceWithoutDomainException If the instance doesn't have a domain.
+         * @throws IllegalUsernameException If the username contains any illegal characters.
+         * @throws Domain.BlankValueException If the domain is not specified in the [string] and the
+         * [fallbackDomain] is `null`.
+         * @throws Domain.IllegalValueException If the domain contains any of the
+         * [Domain.illegalCharacters].
+         * @throws Domain.ValueWithoutTopLevelDomainException If the domain doesn't have a top-level
+         * domain.
          **/
-        fun of(string: String, fallbackInstance: String? = null): Account {
+        fun of(string: String, fallbackDomain: String? = null): Account {
             val formattedString = string.trim().ifEmpty { throw BlankStringException() }
-            val split = formattedString.split(SEPARATOR)
-            val username = split.first()
-            val containsInstance = split.size > 1
-            val formattedFallbackInstance = fallbackInstance?.trim().orEmpty()
-            val instance = if (containsInstance) split[1].trim() else formattedFallbackInstance
-            return Account(username, instance)
+            val parts = formattedString.split(SEPARATOR)
+            val username = parts.first()
+            val containsDomain = parts.size > 1
+            val domainValue =
+                if (containsDomain) parts[1].trim() else fallbackDomain?.trim().orEmpty()
+            val domain = Domain(domainValue)
+            return Account(username, domain)
         }
 
         /**
@@ -175,32 +115,6 @@ data class Account internal constructor(val username: String, val instance: Stri
          **/
         fun isUsernameValid(username: String): Boolean {
             return username.isNotBlank() && username.isLegal
-        }
-
-        /**
-         * Verifies whether the instance is valid.
-         *
-         * @param instance Instance whose validity will be verified.
-         **/
-        fun isInstanceValid(instance: String): Boolean {
-            return instance.isNotBlank() && instance.isLegal && instance.containsDomain
-        }
-
-        /**
-         * Ensures that the [string] doesn't contain any of the [illegalCharacters].
-         *
-         * @param string [String] to check against.
-         * @param onIllegality Callback called if the [string] is considered to be illegal.
-         **/
-        private fun ensureLegalityOf(
-            string: String,
-            onIllegality: (illegal: List<Char>) -> Unit
-        ) {
-            val illegal = illegalCharacters.filter { it in string }
-            val isIllegal = illegal.any { it in string }
-            if (isIllegal) {
-                onIllegality(illegal)
-            }
         }
     }
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/String.extensions.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/String.extensions.kt
@@ -1,11 +1,13 @@
 package com.jeanbarrossilva.orca.core.feed.profile.account
 
+import com.jeanbarrossilva.orca.core.instance.domain.Domain
+
 /**
  * Creates an [Account] with the receiver [String] as the [username][Account.username] and
- * [instance] as the [Account.instance].
+ * [domain] as the [Account.domain].
  *
- * @param instance Mastodon instance from which the user is.
+ * @param domain Mastodon instance from which the user is.
  **/
-infix fun String.at(instance: String): Account {
-    return Account(username = this, instance)
+infix fun String.at(domain: String): Account {
+    return Account(username = this, Domain(domain))
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/instance/domain/Domain.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/instance/domain/Domain.kt
@@ -1,0 +1,110 @@
+package com.jeanbarrossilva.orca.core.instance.domain
+
+/**
+ * An instance's unique identifier.
+ *
+ * @param value [String] that represents this [Domain].
+ **/
+@JvmInline
+value class Domain internal constructor(private val value: String) {
+    /** [IllegalArgumentException] thrown if the [value] is blank. **/
+    class BlankValueException internal constructor() :
+        IllegalArgumentException("Domain cannot be empty.")
+
+    /**
+     * [IllegalArgumentException] thrown if the [value] contains any of the
+     * [illegalCharacters].
+     *
+     * @param illegalCharacters [Char]s that make the [value] illegal.
+     **/
+    class IllegalValueException internal constructor(illegalCharacters: List<Char>) :
+        IllegalArgumentException("Value cannot contain: $illegalCharacters.")
+
+    /**
+     * [IllegalArgumentException] thrown if the [value] doesn't have a top-level domain.
+     *
+     * @param value Domain that lacks a top-level domain.
+     **/
+    class ValueWithoutTopLevelDomainException internal constructor(value: String) :
+        IllegalArgumentException("\"$value\" doesn't have a top-level domain.")
+
+    init {
+        ensureNonBlankness()
+        ensureLegality()
+        ensureTopLevelDomainPresence()
+    }
+
+    override fun toString(): String {
+        return value
+    }
+
+    /**
+     * Ensures that the [value] is not blank.
+     *
+     * @throws BlankValueException If the [value] is blank.
+     **/
+    private fun ensureNonBlankness() {
+        if (value.isBlank()) {
+            throw BlankValueException()
+        }
+    }
+
+    /**
+     * Ensures that the [value] is legal.
+     *
+     * @throws IllegalValueException If the [value] is illegal.
+     **/
+    private fun ensureLegality() {
+        doOnIllegality(value) {
+            throw IllegalValueException(it)
+        }
+    }
+
+    /**
+     * Ensures that the [value] has a top-level domain.
+     *
+     * @throws ValueWithoutTopLevelDomainException If the [value] doesn't have a top-level domain.
+     **/
+    private fun ensureTopLevelDomainPresence() {
+        if (!containsTopLevelDomain(value)) {
+            throw ValueWithoutTopLevelDomainException(value)
+        }
+    }
+
+    companion object {
+        /** [Char]s that the [value] shouldn't contain. **/
+        internal val illegalCharacters = arrayOf(' ', '@')
+
+        /**
+         * Verifies whether the [value] is valid.
+         *
+         * @param value [String] whose validity will be verified.
+         **/
+        fun isValid(value: String): Boolean {
+            return value.isNotBlank() && value.isLegal && containsTopLevelDomain(value)
+        }
+
+        /**
+         * Runs the [action] if the [value] contains any of the [illegalCharacters].
+         *
+         * @param value [String] to check against.
+         * @param action Callback called if the [value] is considered to be illegal.
+         **/
+        internal fun doOnIllegality(value: String, action: (illegal: List<Char>) -> Unit) {
+            val illegal = illegalCharacters.filter { it in value }
+            val isIllegal = illegal.any { it in value }
+            if (isIllegal) {
+                action(illegal)
+            }
+        }
+
+        /**
+         * Whether the [value] contains a top-level domain.
+         *
+         * @param value [String] whose top-level domain's presence will be checked.
+         **/
+        private fun containsTopLevelDomain(value: String): Boolean {
+            return value.split('.').getOrNull(1)?.isNotBlank() ?: false
+        }
+    }
+}

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/instance/domain/String.extensions.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/instance/domain/String.extensions.kt
@@ -1,0 +1,5 @@
+package com.jeanbarrossilva.orca.core.instance.domain
+
+/** Whether this [String] contains no illegal characters. **/
+internal val String.isLegal
+    get() = Domain.illegalCharacters.none { it in this }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/AccountTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/AccountTests.kt
@@ -1,5 +1,6 @@
 package com.jeanbarrossilva.orca.core.feed.profile.account
 
+import com.jeanbarrossilva.orca.core.instance.domain.Domain
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -14,7 +15,7 @@ internal class AccountTests {
     }
 
     @Test
-    fun `GIVEN a blank string with a fallback instance WHEN parsing it THEN it throws`() {
+    fun `GIVEN a blank string with a fallback domain WHEN parsing it THEN it throws`() {
         assertFailsWith<Account.Companion.BlankStringException> {
             Account.of(" ", "appleseed.com")
         }
@@ -28,43 +29,43 @@ internal class AccountTests {
     }
 
     @Test
-    fun `GIVEN a string containing only a username without the separator without a fallback instance WHEN parsing it THEN it throws`() { // ktlint-disable max-line-length
-        assertFailsWith<Account.BlankInstanceException> {
+    fun `GIVEN a string containing only a username without the separator without a fallback domain WHEN parsing it THEN it throws`() { // ktlint-disable max-line-length
+        assertFailsWith<Domain.BlankValueException> {
             Account.of("john")
         }
     }
 
     @Test
-    fun `GIVEN a string containing only a username with the separator without a fallback instance WHEN parsing it THEN it throws`() { // ktlint-disable max-line-length
-        assertFailsWith<Account.BlankInstanceException> {
+    fun `GIVEN a string containing only a username with the separator without a fallback domain WHEN parsing it THEN it throws`() { // ktlint-disable max-line-length
+        assertFailsWith<Domain.BlankValueException> {
             Account.of("john@")
         }
     }
 
     @Test
-    fun `GIVEN a string containing a valid username and an instance with illegal characters WHEN parsing it THEN it throws`() { // ktlint-disable max-line-length
-        assertFailsWith<Account.IllegalInstanceException> {
+    fun `GIVEN a string containing a valid username and an domain with illegal characters WHEN parsing it THEN it throws`() { // ktlint-disable max-line-length
+        assertFailsWith<Domain.IllegalValueException> {
             Account.of("john@apple seed.com")
         }
     }
 
     @Test
-    fun `GIVEN a string containing a valid username without an instance with a fallback one with illegal characters WHEN parsing it THEN it throws`() { // ktlint-disable max-line-length
-        assertFailsWith<Account.IllegalInstanceException> {
-            Account.of("john", fallbackInstance = "apple seed.com")
+    fun `GIVEN a string containing a valid username without an domain with a fallback one with illegal characters WHEN parsing it THEN it throws`() { // ktlint-disable max-line-length
+        assertFailsWith<Domain.IllegalValueException> {
+            Account.of("john", fallbackDomain = "apple seed.com")
         }
     }
 
     @Test
-    fun `GIVEN a string containing a valid username and a valid instance WHEN parsing it THEN it creates an account`() { // ktlint-disable max-line-length
+    fun `GIVEN a string containing a valid username and a valid domain WHEN parsing it THEN it creates an account`() { // ktlint-disable max-line-length
         assertEquals("john" at "appleseed.com", Account.of("john@appleseed.com"))
     }
 
     @Test
-    fun `GIVEN a string containing only a username with a valid fallback instance WHEN parsing it THEN it creates an account`() { // ktlint-disable max-line-length
+    fun `GIVEN a string containing only a username with a valid fallback domain WHEN parsing it THEN it creates an account`() { // ktlint-disable max-line-length
         assertEquals(
             "john" at "appleseed.com",
-            Account.of("john", fallbackInstance = "appleseed.com")
+            Account.of("john", fallbackDomain = "appleseed.com")
         )
     }
 
@@ -76,15 +77,5 @@ internal class AccountTests {
     @Test
     fun `GIVEN a username with an illegal character WHEN verifying if it's valid THEN it isn't`() {
         assertFalse(Account.isUsernameValid("john@"))
-    }
-
-    @Test
-    fun `GIVEN a blank instance WHEN verifying if it's valid THEN it isn't`() {
-        assertFalse(Account.isInstanceValid(" "))
-    }
-
-    @Test
-    fun `GIVEN an instance with an illegal character WHEN verifying if it's valid THEN it isn't`() {
-        assertFalse(Account.isInstanceValid("@appleseed.com"))
     }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/DomainTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/DomainTests.kt
@@ -1,0 +1,28 @@
+package com.jeanbarrossilva.orca.core.feed.profile.account
+
+import com.jeanbarrossilva.orca.core.instance.domain.Domain
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+internal class DomainTests {
+    @Test
+    fun `GIVEN a blank domain WHEN ensuring its integrity THEN it throws`() {
+        assertFailsWith<Domain.BlankValueException> {
+            Domain(" ")
+        }
+    }
+
+    @Test
+    fun `GIVEN an domain with an illegal character WHEN ensuring its integrity THEN it throws`() {
+        assertFailsWith<Domain.IllegalValueException> {
+            Domain("@appleseed.com")
+        }
+    }
+
+    @Test
+    fun `GIVEN an domain without a TLD WHEN ensuring its integrity THEN it throws`() {
+        assertFailsWith<Domain.ValueWithoutTopLevelDomainException> {
+            Domain("appleseed.")
+        }
+    }
+}

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/StringExtensionsTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/StringExtensionsTests.kt
@@ -1,5 +1,6 @@
 package com.jeanbarrossilva.orca.core.feed.profile.account
 
+import com.jeanbarrossilva.orca.core.instance.domain.Domain
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -19,28 +20,28 @@ internal class StringExtensionsTests {
     }
 
     @Test
-    fun `GIVEN a blank instance WHEN creating an account with it THEN it throws`() {
-        assertFailsWith<Account.BlankInstanceException> {
+    fun `GIVEN a blank domain WHEN creating an account with it THEN it throws`() {
+        assertFailsWith<Domain.BlankValueException> {
             "john" at " "
         }
     }
 
     @Test
-    fun `GIVEN an instance with an illegal character WHEN creating an account with it THEN it throws`() { // ktlint-disable max-line-length
-        assertFailsWith<Account.IllegalInstanceException> {
+    fun `GIVEN an domain with an illegal character WHEN creating an account with it THEN it throws`() { // ktlint-disable max-line-length
+        assertFailsWith<Domain.IllegalValueException> {
             "john" at "@appleseed.com"
         }
     }
 
     @Test
-    fun `GIVEN an instance without a TLD WHEN creating an account with it THEN it throws`() {
-        assertFailsWith<Account.InstanceWithoutDomainException> {
+    fun `GIVEN an domain without a TLD WHEN creating an account with it THEN it throws`() {
+        assertFailsWith<Domain.ValueWithoutTopLevelDomainException> {
             "john" at "appleseed."
         }
     }
 
     @Test
-    fun `GIVEN a valid username and a valid instance WHEN creating an account with them THEN it's created`() { // ktlint-disable max-line-length
+    fun `GIVEN a valid username and a valid domain WHEN creating an account with them THEN it's created`() { // ktlint-disable max-line-length
         "john" at "appleseed.com"
     }
 }

--- a/feature/auth/src/androidTest/java/com/jeanbarrossilva/orca/feature/auth/AuthActivityTests.kt
+++ b/feature/auth/src/androidTest/java/com/jeanbarrossilva/orca/feature/auth/AuthActivityTests.kt
@@ -26,7 +26,7 @@ internal class AuthActivityTests {
     @Test
     fun signsInWhenAccountIsValidAndSignInButtonIsClicked() {
         composeRule.onUsernameField().performTextInput(Account.sample.username)
-        composeRule.onInstanceField().performTextInput(Account.sample.instance)
+        composeRule.onInstanceField().performTextInput("${Account.sample.domain}")
         composeRule.onSignInButton().performClick()
         assertIsAtLeast(CompleteLifecycleState.PAUSED, composeRule.activity.completeLifecycleState)
     }

--- a/feature/auth/src/androidTest/java/com/jeanbarrossilva/orca/feature/auth/AuthTests.kt
+++ b/feature/auth/src/androidTest/java/com/jeanbarrossilva/orca/feature/auth/AuthTests.kt
@@ -19,19 +19,19 @@ internal class AuthTests {
     val composeRule = createComposeRule()
 
     @Test
-    fun disablesSignInButtonWhenUsernameIsInvalidAndInstanceIsValid() { // ktlint-disable max-line-length
+    fun disablesSignInButtonWhenUsernameIsInvalidAndInstanceIsValid() {
         composeRule.setContent {
             OrcaTheme {
                 TestAuth()
             }
         }
         composeRule.onUsernameField().performTextInput("john@")
-        composeRule.onInstanceField().performTextInput(Account.sample.instance)
+        composeRule.onInstanceField().performTextInput("${Account.sample.domain}")
         composeRule.onSignInButton().assertIsNotEnabled()
     }
 
     @Test
-    fun disabledSignInButtonWhenUsernameIsValidAndInstanceIsInvalid() { // ktlint-disable max-line-length
+    fun disabledSignInButtonWhenUsernameIsValidAndInstanceIsInvalid() {
         composeRule.setContent {
             OrcaTheme {
                 TestAuth()
@@ -50,7 +50,7 @@ internal class AuthTests {
             }
         }
         composeRule.onUsernameField().performTextInput(Account.sample.username)
-        composeRule.onInstanceField().performTextInput(Account.sample.instance)
+        composeRule.onInstanceField().performTextInput("${Account.sample.domain}")
         composeRule.onSignInButton().assertIsEnabled()
     }
 }

--- a/feature/auth/src/androidTest/java/com/jeanbarrossilva/orca/feature/auth/test/TestAuth.kt
+++ b/feature/auth/src/androidTest/java/com/jeanbarrossilva/orca/feature/auth/test/TestAuth.kt
@@ -18,7 +18,7 @@ internal fun TestAuth(modifier: Modifier = Modifier) {
         username,
         onUsernameChange = { username = it },
         instance,
-        onInstanceChange = { instance = it },
+        onDomainChange = { instance = it },
         onSignIn = { },
         modifier
     )

--- a/feature/auth/src/main/java/com/jeanbarrossilva/orca/feature/auth/Auth.kt
+++ b/feature/auth/src/main/java/com/jeanbarrossilva/orca/feature/auth/Auth.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import com.jeanbarrossilva.orca.core.feed.profile.account.Account
+import com.jeanbarrossilva.orca.core.instance.domain.Domain
 import com.jeanbarrossilva.orca.core.sample.feed.profile.account.sample
 import com.jeanbarrossilva.orca.platform.theme.MultiThemePreview
 import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
@@ -52,7 +53,7 @@ internal fun Auth(viewModel: AuthViewModel, modifier: Modifier = Modifier) {
         username,
         onUsernameChange = viewModel::setUsername,
         instance,
-        onInstanceChange = viewModel::setInstance,
+        onDomainChange = viewModel::setInstance,
         onSignIn = viewModel::signIn,
         modifier
     )
@@ -62,8 +63,8 @@ internal fun Auth(viewModel: AuthViewModel, modifier: Modifier = Modifier) {
 internal fun Auth(
     username: String,
     onUsernameChange: (username: String) -> Unit,
-    instance: String,
-    onInstanceChange: (instance: String) -> Unit,
+    domain: String,
+    onDomainChange: (domain: String) -> Unit,
     onSignIn: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -128,8 +129,8 @@ internal fun Auth(
                     Text("@")
 
                     TextField(
-                        instance,
-                        onInstanceChange,
+                        domain,
+                        onDomainChange,
                         Modifier
                             .fillMaxWidth()
                             .testTag(AUTH_INSTANCE_FIELD_TAG),
@@ -149,7 +150,7 @@ internal fun Auth(
                 .align(Alignment.BottomStart)
                 .fillMaxWidth()
                 .testTag(AUTH_SIGN_IN_BUTTON_TAG),
-            isEnabled = Account.isUsernameValid(username) && Account.isInstanceValid(instance)
+            isEnabled = Account.isUsernameValid(username) && Domain.isValid(domain)
         ) {
             Text("Sign in")
         }
@@ -168,7 +169,7 @@ private fun InvalidAuthPreview() {
 @MultiThemePreview
 private fun ValidAuthPreview() {
     OrcaTheme {
-        Auth(Account.sample.username, Account.sample.instance)
+        Auth(Account.sample.username, "${Account.sample.domain}")
     }
 }
 
@@ -178,7 +179,7 @@ private fun Auth(username: String, instance: String, modifier: Modifier = Modifi
         username,
         onUsernameChange = { },
         instance,
-        onInstanceChange = { },
+        onDomainChange = { },
         onSignIn = { },
         modifier
     )

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetails.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetails.kt
@@ -77,7 +77,7 @@ internal sealed class ProfileDetails : Serializable {
     abstract val url: URL
 
     val formattedAccount
-        get() = "${account.username}@${account.instance}"
+        get() = "${account.username}@${account.domain}"
     val username
         get() = "@${account.username}"
 


### PR DESCRIPTION
Ensures that each domain is valid by replacing its [`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string) representations by [`Domain`](https://github.com/jeanbarrossilva/Orca/blob/06e7047d2eb33c35e43090a29a629666910f752b/core/src/main/java/com/jeanbarrossilva/orca/core/instance/domain/Domain.kt) instances.