### PR TITLE
Remove unused deps from `:core:http:mastodon-social`

### DIFF
--- a/core/http/mastodon-social/build.gradle.kts
+++ b/core/http/mastodon-social/build.gradle.kts
@@ -2,10 +2,7 @@ import com.jeanbarrossilva.orca.namespaceFor
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.android.maps.secrets)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.kotlin.symbolProcessor)
 
     id("build-src")
 }
@@ -13,35 +10,8 @@ plugins {
 android {
     composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
     namespace = namespaceFor("core.http.mastodon.social")
-
-    buildFeatures {
-        buildConfig = true
-        compose = true
-    }
-
-    secrets {
-        defaultPropertiesFileName = "public.properties"
-        ignoreList += "^(?!mastodon\\.clientSecret).*$"
-    }
 }
 
 dependencies {
     api(project(":core:http"))
-    api(project(":platform:cache"))
-    api(libs.paginate)
-    api(libs.android.room.ktx)
-
-    implementation(project(":platform:theme"))
-    implementation(libs.android.lifecycle.viewmodel)
-    implementation(libs.koin.android)
-    implementation(libs.loadable.list)
-
-    ksp(libs.android.room.compiler)
-
-    releaseImplementation(libs.slf4j) {
-        because("Ktor references \"StaticLoggerBinder\" and it is missing on minification.")
-    }
-
-    testImplementation(project(":core:sample"))
-    testImplementation(libs.junit)
 }


### PR DESCRIPTION
Remainings from the migration of base core HTTP structures to [`:core:http`](https://github.com/jeanbarrossilva/Orca/tree/f599bb6538d7e7ad527ebcdae4732463bb6a1e56/core/http) (#102).