### PR TITLE
Fix crash on auth

### DIFF
--- a/core/http/mastodon-social/src/main/java/com/jeanbarrossilva/orca/core/mastodon/social/instance/MastodonSocialInstance.kt
+++ b/core/http/mastodon-social/src/main/java/com/jeanbarrossilva/orca/core/mastodon/social/instance/MastodonSocialInstance.kt
@@ -13,7 +13,7 @@ class MastodonSocialInstance(context: Context, actorProvider: ActorProvider) :
     override val url = Url("https://mastodon.social")
     override val client = CoreHttpClient {
         defaultRequest {
-            url.takeFrom(url)
+            url.takeFrom(this@MastodonSocialInstance.url)
         }
     }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationViewModel.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationViewModel.kt
@@ -8,11 +8,10 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
+import com.jeanbarrossilva.orca.core.http.HttpBridge
 import com.jeanbarrossilva.orca.core.http.R
 import com.jeanbarrossilva.orca.core.http.auth.Mastodon
-import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.request.HttpRequest
 import io.ktor.client.request.forms.submitForm
 import io.ktor.http.Parameters
 import kotlinx.coroutines.launch
@@ -21,13 +20,10 @@ import kotlinx.coroutines.launch
  * [AndroidViewModel] that requests an [Actor] through [request].
  *
  * @param application [Application] that allows [Context]-specific behavior.
- * @param client [HttpClient] by which the [HttpRequest] to authenticate the current user will be
- * performed.
  * @param authorizationCode Code provided by the API when authorization was granted to the user.
  **/
 internal class HttpAuthenticationViewModel private constructor(
     application: Application,
-    private val client: HttpClient,
     private val authorizationCode: String
 ) : AndroidViewModel(application) {
     /**
@@ -41,8 +37,8 @@ internal class HttpAuthenticationViewModel private constructor(
         val scheme = application.getString(R.string.scheme)
         val redirectUri = application.getString(R.string.redirect_uri, scheme)
         viewModelScope.launch {
-            client
-                .submitForm(
+            with(HttpBridge.instance.client) {
+                submitForm(
                     "/oauth/token",
                     Parameters.build {
                         set("grant_type", "authorization_code")
@@ -53,9 +49,10 @@ internal class HttpAuthenticationViewModel private constructor(
                         set("scope", Mastodon.SCOPES)
                     }
                 )
-                .body<HttpAuthenticationToken>()
-                .toActor(client)
-                .run(onAuthentication)
+                    .body<HttpAuthenticationToken>()
+                    .toActor(this)
+                    .run(onAuthentication)
+            }
         }
     }
 
@@ -64,16 +61,14 @@ internal class HttpAuthenticationViewModel private constructor(
          * Creates a [ViewModelProvider.Factory] that provides an [HttpAuthenticationViewModel].
          *
          * @param application [Application] that allows [Context]-specific behavior.
-         * @param client [HttpClient] by which the [HttpRequest] to authenticate the current user
-         * will be performed.
          * @param authorizationCode Code provided by the API when authorization was granted to the
          * user.
          **/
-        fun createFactory(application: Application, client: HttpClient, authorizationCode: String):
+        fun createFactory(application: Application, authorizationCode: String):
             ViewModelProvider.Factory {
             return viewModelFactory {
                 initializer {
-                    HttpAuthenticationViewModel(application, client, authorizationCode)
+                    HttpAuthenticationViewModel(application, authorizationCode)
                 }
             }
         }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationViewModel.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationViewModel.kt
@@ -64,8 +64,10 @@ internal class HttpAuthenticationViewModel private constructor(
          * @param authorizationCode Code provided by the API when authorization was granted to the
          * user.
          **/
-        fun createFactory(application: Application, authorizationCode: String):
-            ViewModelProvider.Factory {
+        fun createFactory(
+            application: Application,
+            authorizationCode: String
+        ): ViewModelProvider.Factory {
             return viewModelFactory {
                 initializer {
                     HttpAuthenticationViewModel(application, authorizationCode)

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/activity/HttpAuthenticationActivity.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/activity/HttpAuthenticationActivity.kt
@@ -5,22 +5,18 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
+import com.jeanbarrossilva.orca.core.http.HttpBridge
 import com.jeanbarrossilva.orca.core.http.auth.authentication.HttpAuthentication
 import com.jeanbarrossilva.orca.core.http.auth.authentication.HttpAuthenticationViewModel
-import com.jeanbarrossilva.orca.core.http.auth.authentication.HttpAuthenticator
+import com.jeanbarrossilva.orca.core.http.instance.ContextualHttpInstance
 import com.jeanbarrossilva.orca.platform.ui.core.composable.ComposableActivity
 import com.jeanbarrossilva.orca.platform.ui.core.on
-import org.koin.android.ext.android.get
-import org.koin.android.ext.android.inject
 
 /**
  * [ComposableActivity] that visually notifies the user of the background authentication process
  * that takes place when this is created and automatically finishes itself when it's done.
  **/
 class HttpAuthenticationActivity : ComposableActivity() {
-    /** [HttpAuthenticator] through which authentication will be performed. **/
-    private val authenticator by inject<HttpAuthenticator>()
-
     /** Code provided by the API when the user was authorized. **/
     private val authorizationCode by extra<String>(AUTHORIZATION_CODE_KEY)
 
@@ -29,7 +25,7 @@ class HttpAuthenticationActivity : ComposableActivity() {
      * be requested.
      **/
     private val viewModel by viewModels<HttpAuthenticationViewModel> {
-        HttpAuthenticationViewModel.createFactory(application, client = get(), authorizationCode)
+        HttpAuthenticationViewModel.createFactory(application, authorizationCode)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -48,7 +44,7 @@ class HttpAuthenticationActivity : ComposableActivity() {
      **/
     private fun authenticate() {
         viewModel.request {
-            authenticator.receive(it)
+            (HttpBridge.instance as ContextualHttpInstance).authenticator.receive(it)
             finish()
         }
     }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpAuthorizationActivity.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpAuthorizationActivity.kt
@@ -5,18 +5,16 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.runtime.Composable
+import com.jeanbarrossilva.orca.core.http.HttpBridge
+import com.jeanbarrossilva.orca.core.http.instance.ContextualHttpInstance
 import com.jeanbarrossilva.orca.platform.ui.core.composable.ComposableActivity
 import io.ktor.http.Url
-import org.koin.android.ext.android.inject
 
 /**
  * [ComposableActivity] that visually notifies the user of the background authorization process that
  * takes place when this is created and automatically finishes itself when it's done.
  **/
 class HttpAuthorizationActivity internal constructor() : ComposableActivity() {
-    /** [HttpAuthorizer] through which authorization will be performed. **/
-    private val authorizer by inject<HttpAuthorizer>()
-
     /**
      * [HttpAuthorizationViewModel] from which the [Url] to the authorization webpage will be
      * obtained.
@@ -43,8 +41,8 @@ class HttpAuthorizationActivity internal constructor() : ComposableActivity() {
 
     /**
      * Sends the access token that's been successfully retrieved from the deep link through which
-     * this [HttpAuthorizationActivity] was started to the [authorizer] or requests the access token
-     * if it's been started directly by Orca.
+     * this [HttpAuthorizationActivity] was started to the [HttpAuthorizer] or requests the access
+     * token if it's been started directly by Orca.
      *
      * @throws UnprovidedAccessTokenException If this [HttpAuthorizationActivity] has been started
      * from a deep link and an access token hasn't been provided.
@@ -55,7 +53,7 @@ class HttpAuthorizationActivity internal constructor() : ComposableActivity() {
     }
 
     /**
-     * Sends the access token that might be in the [deepLink] to the [authorizer].
+     * Sends the access token that might be in the [deepLink] to the [HttpAuthorizer].
      *
      * @param deepLink [Uri] from which this [HttpAuthorizationActivity] was started after
      * requesting for the user to be authorized.
@@ -65,7 +63,7 @@ class HttpAuthorizationActivity internal constructor() : ComposableActivity() {
     private fun sendAccessTokenToAuthorizer(deepLink: Uri) {
         val accessToken =
             deepLink.getQueryParameter("code") ?: throw UnprovidedAccessTokenException()
-        authorizer.receive(accessToken)
+        (HttpBridge.instance as ContextualHttpInstance).authorizer.receive(accessToken)
         finish()
     }
 

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpAuthorizer.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpAuthorizer.kt
@@ -14,7 +14,7 @@ import kotlin.coroutines.suspendCoroutine
  * @param context [Context] through which the [HttpAuthorizationActivity] will be started.
  * @see receive
  **/
-internal class HttpAuthorizer(private val context: Context) : Authorizer() {
+class HttpAuthorizer internal constructor(private val context: Context) : Authorizer() {
     /** [Continuation] of the coroutine that's suspended on authorization. **/
     private var continuation: Continuation<String>? = null
 

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/ContextualHttpInstance.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/ContextualHttpInstance.kt
@@ -32,10 +32,7 @@ import com.jeanbarrossilva.orca.platform.cache.Cache
  * the [authenticationLock].
  **/
 abstract class ContextualHttpInstance(context: Context, actorProvider: ActorProvider) :
-    HttpInstance<HttpAuthenticator> {
-    /** [HttpAuthorizer] that authorizes the user when the [authenticator] authenticates them. **/
-    private val authorizer = HttpAuthorizer(context)
-
+    HttpInstance<HttpAuthorizer, HttpAuthenticator> {
     /** [MastodonDatabase] in which cached structures will be persisted.  **/
     private val database = MastodonDatabase.getInstance(context)
 
@@ -83,6 +80,7 @@ abstract class ContextualHttpInstance(context: Context, actorProvider: ActorProv
     /** [Cache] that decides how to obtain [HttpToot]s. **/
     private val tootCache = Cache.of(context, name = "toot-cache", HttpTootFetcher, tootStorage)
 
+    final override val authorizer = HttpAuthorizer(context)
     final override val authenticator = HttpAuthenticator(context, authorizer, actorProvider)
     final override val authenticationLock = AuthenticationLock(authenticator, actorProvider)
     final override val feedProvider = HttpFeedProvider(actorProvider)

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/HttpInstance.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/HttpInstance.kt
@@ -1,20 +1,25 @@
 package com.jeanbarrossilva.orca.core.http.instance
 
 import com.jeanbarrossilva.orca.core.auth.Authenticator
+import com.jeanbarrossilva.orca.core.auth.Authorizer
 import com.jeanbarrossilva.orca.core.instance.Instance
 import io.ktor.client.HttpClient
 import io.ktor.client.request.HttpRequest
 import io.ktor.http.Url
 
-/** An [HttpInstance] with a generic [Authenticator]. **/
-internal typealias SomeHttpInstance = HttpInstance<*>
+/** An [HttpInstance] with a generic [Authorizer] and an [Authenticator]. **/
+internal typealias SomeHttpInstance = HttpInstance<*, *>
 
 /**
  * [Instance] that performs all of its underlying operations by sending [HttpRequest]s to the API.
  *
- * @param T [Authenticator] to authenticate the user with.
+ * @param F [Authorizer] with which authorization will be performed.
+ * @param S [Authenticator] to authenticate the user with.
  **/
-interface HttpInstance<T : Authenticator> : Instance<T> {
+interface HttpInstance<F : Authorizer, S : Authenticator> : Instance<S> {
+    /** [Authorizer] by which the user will be authorized. **/
+    val authorizer: F
+
     /** [Url] to which routes will be appended when [HttpRequest]s are sent. **/
     val url: Url
 

--- a/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/TestHttpInstance.kt
+++ b/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/TestHttpInstance.kt
@@ -7,6 +7,7 @@ import com.jeanbarrossilva.orca.core.http.client.Logger
 import com.jeanbarrossilva.orca.core.http.instance.HttpInstance
 import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.core.sample.instance.sample
+import com.jeanbarrossilva.orca.core.test.TestAuthorizer
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.engine.mock.MockEngine
@@ -15,11 +16,15 @@ import io.ktor.client.engine.mock.respondOk
 import io.ktor.client.request.HttpRequest
 import io.ktor.http.Url
 
-/** [HttpInstance] whose [client] responds OK to each sent [HttpRequest]. **/
+/**
+ * [HttpInstance] whose [client] responds OK to each sent [HttpRequest].
+ *
+ * @param T [Authenticator] to authenticate the user with.
+ **/
 internal class TestHttpInstance<T : Authenticator>(
     override val authenticator: T,
     override val authenticationLock: AuthenticationLock<T>
-) : HttpInstance<T> {
+) : HttpInstance<TestAuthorizer, T> {
     /**
      * [HttpClientEngineFactory] that creates a [MockEngine] that sends an OK response to each
      * [HttpRequest].
@@ -32,6 +37,7 @@ internal class TestHttpInstance<T : Authenticator>(
         }
     }
 
+    override val authorizer = TestAuthorizer()
     override val feedProvider = Instance.sample.feedProvider
     override val profileProvider = Instance.sample.profileProvider
     override val profileSearcher = Instance.sample.profileSearcher


### PR DESCRIPTION
Fixes a crash that happens when authenticating with [`:core:http`](https://github.com/jeanbarrossilva/Orca/tree/0215ba7a5b9c0c1c47c0408856d82f7689db651a/core/http) because the [`HttpAuthorizer`](https://github.com/jeanbarrossilva/Orca/blob/0215ba7a5b9c0c1c47c0408856d82f7689db651a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpAuthorizer.kt) and the [`HttpAuthenticator`](https://github.com/jeanbarrossilva/Orca/blob/0215ba7a5b9c0c1c47c0408856d82f7689db651a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticator.kt) were being retrieved as if they had been injected as such (which wasn't the case).