### PR TITLE
Add `Option` and `Options` components

### DIFF
--- a/platform/theme/build.gradle.kts
+++ b/platform/theme/build.gradle.kts
@@ -6,9 +6,15 @@ plugins {
 android {
     buildFeatures.compose = true
     composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 }
 
 dependencies {
+    androidTestImplementation(libs.android.compose.ui.test.junit)
+    androidTestImplementation(libs.android.compose.ui.test.manifest)
+    androidTestImplementation(libs.android.test.core)
+    androidTestImplementation(libs.android.test.runner)
+
     api(libs.android.compose.material)
     api(libs.android.compose.ui.tooling)
 
@@ -16,4 +22,5 @@ dependencies {
     implementation(libs.accompanist.adapter)
     implementation(libs.android.material)
     implementation(libs.kotlin.reflect)
+    implementation(libs.loadable.placeholder)
 }

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/OptionTests.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/OptionTests.kt
@@ -1,0 +1,67 @@
+package com.jeanbarrossilva.orca.platform.theme.kit.input.option
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
+import com.jeanbarrossilva.orca.platform.theme.kit.input.option.test.onOption
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+internal class OptionTests {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun isSemanticallySelectedWhenSelected() {
+        composeRule.setContent {
+            OrcaTheme {
+                Option(isSelected = true)
+            }
+        }
+        composeRule.onOption().assertIsSelected()
+    }
+
+    @Test
+    fun showsSelectionIconWhenSelected() {
+        composeRule.setContent {
+            OrcaTheme {
+                Option(isSelected = true)
+            }
+        }
+        composeRule
+            .onNodeWithTag(OPTION_SELECTION_ICON_TAG, useUnmergedTree = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun runsCallbackWhenSelected() {
+        var isSelected by mutableStateOf(false)
+        composeRule.setContent {
+            OrcaTheme {
+                Option(isSelected, onSelectionToggle = { isSelected = it })
+            }
+        }
+        composeRule.onOption().performClick()
+        assertTrue(isSelected)
+    }
+
+    @Test
+    fun runsCallbackWhenUnselected() {
+        var isSelected by mutableStateOf(true)
+        composeRule.setContent {
+            OrcaTheme {
+                Option(isSelected, onSelectionToggle = { isSelected = it })
+            }
+        }
+        composeRule.onOption().performClick()
+        assertFalse(isSelected)
+    }
+}

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/OptionsTests.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/OptionsTests.kt
@@ -1,0 +1,152 @@
+package com.jeanbarrossilva.orca.platform.theme.kit.input.option.list
+
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.material3.Surface
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.filter
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onSiblings
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
+import com.jeanbarrossilva.orca.platform.theme.configuration.Shapes
+import com.jeanbarrossilva.orca.platform.theme.extensions.bottom
+import com.jeanbarrossilva.orca.platform.theme.extensions.top
+import com.jeanbarrossilva.orca.platform.theme.kit.input.option.OptionDefaults
+import com.jeanbarrossilva.orca.platform.theme.kit.input.option.list.test.assertIsShapedBy
+import com.jeanbarrossilva.orca.platform.theme.kit.input.option.test.onOption
+import com.jeanbarrossilva.orca.platform.theme.kit.input.option.test.onOptions
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+internal class OptionsTests {
+    private val defaultOptionShape: CornerBasedShape
+        get() {
+            val context = InstrumentationRegistry.getInstrumentation().context
+            val shapes = Shapes.getDefault(context)
+            return OptionDefaults.getShape(shapes)
+        }
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun shapesSingleOptionWithDefaultShape() {
+        composeRule.setContent {
+            OrcaTheme {
+                SampleOptions(count = 1)
+            }
+        }
+        composeRule.onOption().assertIsShapedBy(defaultOptionShape)
+    }
+
+    @Test
+    fun shapesFirstOptionWithZeroedBottomCornerSizes() {
+        composeRule.setContent {
+            OrcaTheme {
+                Surface(color = Color.Transparent) {
+                    SampleOptions()
+                }
+            }
+        }
+        composeRule.onOptions().onFirst().assertIsShapedBy(defaultOptionShape.top)
+    }
+
+    @Test
+    fun shapesIntermediateOptionWithZeroedCornerSizes() {
+        composeRule.setContent {
+            OrcaTheme {
+                SampleOptions()
+            }
+        }
+        composeRule.onOptions()[1].assertIsShapedBy(RectangleShape)
+    }
+
+    @Test
+    fun shapesLastOptionWithZeroedTopCornerSizes() {
+        composeRule.setContent {
+            OrcaTheme {
+                Surface(color = Color.Transparent) {
+                    SampleOptions()
+                }
+            }
+        }
+        composeRule.onOptions().onLast().assertIsShapedBy(defaultOptionShape.bottom)
+    }
+
+    @Test
+    fun surroundsIntermediateOptionWithDividers() {
+        composeRule.setContent {
+            OrcaTheme {
+                SampleOptions()
+            }
+        }
+        composeRule
+            .onOptions()[1]
+            .onSiblings()
+            .filter(hasTestTag(OPTIONS_DIVIDER_TAG))
+            .assertCountEquals(2)
+    }
+
+    @Test
+    fun selectsFirstOptionByDefault() {
+        composeRule.setContent {
+            OrcaTheme {
+                SampleOptions()
+            }
+        }
+        composeRule.onOptions().onFirst().assertIsSelected()
+    }
+
+    @Test
+    fun runsCallbackWhenOptionIsSelectedByDefault() {
+        var selection = IndexedValue<Boolean?>(index = -1, null)
+        composeRule.setContent {
+            OrcaTheme {
+                SampleOptions(
+                    onSelectionToggle = { index, isSelected ->
+                        selection = IndexedValue(index, isSelected)
+                    }
+                )
+            }
+        }
+        assertEquals(IndexedValue(index = 0, true), selection)
+    }
+
+    @Test
+    fun runsCallbackOnceWhenOptionIsSelectedMultipleTimes() {
+        var count = 0
+        composeRule.setContent {
+            OrcaTheme {
+                SampleOptions(
+                    onSelectionToggle =  { index, _ ->
+                        if (index == 0) {
+                            count++
+                        }
+                    }
+                )
+            }
+        }
+        composeRule.onOptions().onFirst().performClick()
+        assertEquals(1, count)
+    }
+
+    @Test
+    fun unselectsPreviouslySelectedOptionWhenAnotherOneIsSelected() {
+        composeRule.setContent {
+            OrcaTheme {
+                SampleOptions()
+            }
+        }
+        composeRule.onOptions().onLast().performClick()
+        composeRule.onOptions().onFirst().assertIsNotSelected()
+    }
+}

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/OptionsTests.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/OptionsTests.kt
@@ -127,7 +127,7 @@ internal class OptionsTests {
         composeRule.setContent {
             OrcaTheme {
                 SampleOptions(
-                    onSelectionToggle =  { index, _ ->
+                    onSelectionToggle = { index, _ ->
                         if (index == 0) {
                             count++
                         }

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/test/SemanticsMatcher.extensions.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/test/SemanticsMatcher.extensions.kt
@@ -1,0 +1,26 @@
+package com.jeanbarrossilva.orca.platform.theme.kit.input.option.list.test
+
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.ModifierInfo
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.test.SemanticsMatcher
+
+/**
+ * [SemanticsMatcher] that indicates whether the [Shape] by which the [SemanticsNode] has been
+ * clipped is the given one.
+ *
+ * @param shape [Shape] to assert that it's the one by which the [SemanticsNode] is shaped.
+ **/
+internal fun isShapedBy(shape: Shape): SemanticsMatcher {
+    return SemanticsMatcher("Shape = '$shape'") { node ->
+        shape == node
+            .layoutInfo
+            .getModifierInfo()
+            .map(ModifierInfo::modifier)
+            .filterIsInstance<ModifierNodeElement<*>>()
+            .flatMap(ModifierNodeElement<*>::inspectableElements)
+            .find { element -> element.name == "shape" }
+            ?.value
+    }
+}

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/test/SemanticsNodeInteraction.extensions.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/test/SemanticsNodeInteraction.extensions.kt
@@ -1,0 +1,15 @@
+package com.jeanbarrossilva.orca.platform.theme.kit.input.option.list.test
+
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+
+/**
+ * Asserts that the [SemanticsNode] has been clipped by the given [shape].
+ *
+ * @param shape [Shape] to assert that it's the one by which the [SemanticsNode] is shaped.
+ **/
+internal fun SemanticsNodeInteraction.assertIsShapedBy(shape: Shape): SemanticsNodeInteraction {
+    return assert(isShapedBy(shape))
+}

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/test/ComposeTestRule.extensions.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/test/ComposeTestRule.extensions.kt
@@ -1,0 +1,19 @@
+package com.jeanbarrossilva.orca.platform.theme.kit.input.option.test
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionCollection
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import com.jeanbarrossilva.orca.platform.theme.kit.input.option.OPTION_TAG
+import com.jeanbarrossilva.orca.platform.theme.kit.input.option.Option
+
+/** [SemanticsNodeInteraction] of an [Option]. **/
+internal fun ComposeTestRule.onOption(): SemanticsNodeInteraction {
+    return onNodeWithTag(OPTION_TAG)
+}
+
+/** [SemanticsNodeInteractionCollection] of [Option]s. **/
+internal fun ComposeTestRule.onOptions(): SemanticsNodeInteractionCollection {
+    return onAllNodesWithTag(OPTION_TAG)
+}

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/Shapes.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/Shapes.kt
@@ -1,14 +1,15 @@
 package com.jeanbarrossilva.orca.platform.theme.configuration
 
+import android.content.Context
 import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocal
 import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import com.jeanbarrossilva.orca.platform.theme.R
-import com.jeanbarrossilva.orca.platform.theme.extensions.fractionResource
+import com.jeanbarrossilva.orca.platform.theme.extensions.getFraction
 
 /** [CompositionLocal] that provides [Shapes]. **/
 internal val LocalShapes = compositionLocalOf {
@@ -37,10 +38,21 @@ data class Shapes internal constructor(
 
         /** [Shapes] that are provided by default. **/
         internal val default
-            @Composable get() = Shapes(
-                RoundedCornerShape(dimensionResource(R.dimen.largeShapeCornerSize)),
-                RoundedCornerShape(dimensionResource(R.dimen.mediumShapeCornerSize)),
-                RoundedCornerShape((fractionResource(R.fraction.smallShapeCornerSize) ?: 0f) * 100)
+            @Composable get() = getDefault(LocalContext.current)
+
+        /**
+         * Gets the [Shapes] that are provided by default.
+         *
+         * @param context [Context] from which the [Shapes] will be obtained.
+         **/
+        internal fun getDefault(context: Context): Shapes {
+            return Shapes(
+                RoundedCornerShape(context.resources.getDimension(R.dimen.largeShapeCornerSize)),
+                RoundedCornerShape(context.resources.getDimension(R.dimen.mediumShapeCornerSize)),
+                RoundedCornerShape(
+                    (context.resources.getFraction(R.fraction.smallShapeCornerSize) ?: 0f) * 100f
+                )
             )
+        }
     }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/iconography/Iconography.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/iconography/Iconography.kt
@@ -31,6 +31,7 @@ internal val LocalIconography = compositionLocalOf {
  * @param reblog [ImageVector] for a single or various reposts.
  * @param search [ImageVector] that indicates the ability to search or the performance of such
  * operation for elements in a given context.
+ * @param selected [ImageVector] for selected states.
  * @param send [ImageVector] that denotes a send operation.
  * @param share [Icon] for sharing.
  * @param unavailable [Icon] for unavailable resources.
@@ -50,6 +51,7 @@ data class Iconography internal constructor(
     val profile: Icon,
     val reblog: ImageVector,
     val search: ImageVector,
+    val selected: ImageVector,
     val send: ImageVector,
     val share: Icon,
     val unavailable: Icon
@@ -71,6 +73,7 @@ data class Iconography internal constructor(
             profile = Icon.Empty,
             reblog = ImageVector.Empty,
             search = ImageVector.Empty,
+            selected = ImageVector.Empty,
             send = ImageVector.Empty,
             share = Icon.Empty,
             unavailable = Icon.Empty
@@ -111,6 +114,7 @@ data class Iconography internal constructor(
                 ),
                 ImageVector.vectorResource(R.drawable.icon_reblog),
                 ImageVector.vectorResource(R.drawable.icon_search),
+                ImageVector.vectorResource(R.drawable.icon_selected),
                 ImageVector.vectorResource(R.drawable.icon_send),
                 Icon(
                     ImageVector.vectorResource(R.drawable.icon_share_outlined),

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/CornerBasedShape.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/CornerBasedShape.extensions.kt
@@ -3,6 +3,11 @@ package com.jeanbarrossilva.orca.platform.theme.extensions
 import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.ZeroCornerSize
+
+/** Version of this [CornerBasedShape] with zeroed top [CornerSize]s. **/
+internal val CornerBasedShape.bottom
+    get() = copy(topStart = ZeroCornerSize, topEnd = ZeroCornerSize)
 
 /** Reversed version of this [CornerBasedShape], with its top and bottom [CornerSize]s switched. **/
 internal val CornerBasedShape.reversed: CornerBasedShape
@@ -12,3 +17,7 @@ internal val CornerBasedShape.reversed: CornerBasedShape
         bottomEnd = topStart,
         bottomStart = topStart
     )
+
+/** Version of this [CornerBasedShape] with zeroed bottom [CornerSize]s. **/
+internal val CornerBasedShape.top
+    get() = copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize)

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Resources.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Resources.extensions.kt
@@ -3,20 +3,16 @@ package com.jeanbarrossilva.orca.platform.theme.extensions
 import android.content.res.Resources
 import androidx.annotation.FloatRange
 import androidx.annotation.FractionRes
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 
 /**
  * Loads the fraction associated with the given resource [id].
  *
  * @param id ID of the fraction resource.
  **/
-@Composable
 @FloatRange(from = 0.0, to = 1.0)
-internal fun fractionResource(@FractionRes id: Int): Float? {
-    val context = LocalContext.current
+internal fun Resources.getFraction(@FractionRes id: Int): Float? {
     return try {
-        context.resources.getFraction(id, 1, 1)
+        getFraction(id, 1, 1)
     } catch (_: Resources.NotFoundException) {
         null
     }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/Option.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/Option.kt
@@ -1,0 +1,214 @@
+package com.jeanbarrossilva.orca.platform.theme.kit.input.option
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.jeanbarrossilva.loadable.placeholder.MediumTextualPlaceholder
+import com.jeanbarrossilva.orca.platform.theme.MultiThemePreview
+import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
+import com.jeanbarrossilva.orca.platform.theme.configuration.Shapes
+import com.jeanbarrossilva.orca.platform.theme.extensions.border
+import com.jeanbarrossilva.orca.platform.theme.kit.input.option.list.Options
+
+/** Tag that identifies an [Option] for testing purposes. **/
+internal const val OPTION_TAG = "option"
+
+/**
+ * Tag that identifies the [Icon] of an [Option] that indicates that it's selected for testing
+ * purposes.
+ **/
+internal const val OPTION_SELECTION_ICON_TAG = "option-selection-icon"
+
+/** Default values of an [Option]. **/
+internal object OptionDefaults {
+    /** [Modifier] that's applied to an [Option] by default. **/
+    val modifier
+        @Composable get() = Modifier.border(shape)
+
+    /** [CornerBasedShape] that clips an [Option] by default. **/
+    val shape
+        @Composable get() = getShape(OrcaTheme.shapes)
+
+    /**
+     * Gets the [CornerBasedShape] that clips an [Option] by default.
+     *
+     * @param shapes [Shapes] from which the [CornerBasedShape] will be obtained.
+     **/
+    fun getShape(shapes: Shapes): CornerBasedShape {
+        return shapes.medium
+    }
+}
+
+/**
+ * A loading selectable configuration.
+ *
+ * @param modifier [Modifier] to be applied to the underlying [Row].
+ **/
+@Composable
+fun Option(modifier: Modifier = Modifier) {
+    CoreOption(OptionDefaults.modifier then modifier)
+}
+
+/**
+ * A selectable configuration.
+ *
+ * @param isSelected Whether it is selected.
+ * @param onSelectionToggle Callback run whenever it is toggled.
+ * @param modifier [Modifier] to be applied to the underlying [Row].
+ * @param content [Text] that's the label.
+ **/
+@Composable
+fun Option(
+    isSelected: Boolean,
+    onSelectionToggle: (isSelected: Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    CoreOption(
+        isSelected,
+        onSelectionToggle,
+        OptionDefaults.modifier then modifier,
+        content = content
+    )
+}
+
+/**
+ * A selectable configuration.
+ *
+ * @param isSelected Whether it is selected.
+ * @param modifier [Modifier] to be applied to the underlying [Row].
+ * @param onSelectionToggle Callback run whenever it is toggled.
+ **/
+@Composable
+internal fun Option(
+    isSelected: Boolean,
+    modifier: Modifier = Modifier,
+    onSelectionToggle: (isSelected: Boolean) -> Unit = { }
+) {
+    Option(isSelected, onSelectionToggle, modifier) {
+        Text("Label")
+    }
+}
+
+/**
+ * A loading selectable configuration. This is the [Composable] used by [Option], given that it
+ * allows for more customization in terms of its appearance, which, for example, makes it suitable
+ * to be composed alongside other options within [Options].
+ *
+ * @param modifier [Modifier] to be applied to the underlying [Row].
+ * @param shape [Shape] by which it will be clipped.
+ **/
+@Composable
+internal fun CoreOption(modifier: Modifier = Modifier, shape: Shape = OptionDefaults.shape) {
+    CoreOption(isSelected = false, onSelectionToggle = { }, modifier, shape) {
+        MediumTextualPlaceholder()
+    }
+}
+
+/**
+ * A selectable configuration. This is the [Composable] used by [Option], given that it allows for
+ * more customization in terms of its appearance, which, for example, makes it suitable to be
+ * composed alongside other options within [Options].
+ *
+ * @param isSelected Whether it is selected.
+ * @param onSelectionToggle Callback run whenever it is toggled.
+ * @param modifier [Modifier] to be applied to the underlying [Row].
+ * @param shape [Shape] by which it will be clipped.
+ * @param content [Text] that's the label.
+ **/
+@Composable
+internal fun CoreOption(
+    isSelected: Boolean,
+    onSelectionToggle: (isSelected: Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    shape: Shape = OptionDefaults.shape,
+    content: @Composable () -> Unit
+) {
+    val spacing = OrcaTheme.spacings.large
+    val selectedContainerColor = OrcaTheme.colors.primary.container
+    val containerColor =
+        if (isSelected) selectedContainerColor else OrcaTheme.colors.surface.container
+    val contentColor = contentColorFor(containerColor)
+
+    Row(
+        modifier
+            .clip(shape)
+            .clickable(role = Role.Checkbox) { onSelectionToggle(!isSelected) }
+            .background(containerColor)
+            .padding(spacing)
+            .fillMaxWidth()
+            .testTag(OPTION_TAG)
+            .semantics { selected = isSelected },
+        Arrangement.SpaceBetween,
+        Alignment.CenterVertically
+    ) {
+        CompositionLocalProvider(
+            LocalContentColor provides contentColor,
+            LocalTextStyle provides OrcaTheme.typography.labelLarge.copy(color = contentColor)
+        ) {
+            content()
+            Spacer(Modifier.width(spacing))
+
+            Box(Modifier.size(24.dp)) {
+                if (isSelected) {
+                    Icon(
+                        OrcaTheme.iconography.selected,
+                        contentDescription = "Selected",
+                        Modifier.testTag(OPTION_SELECTION_ICON_TAG)
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Preview of a loading [Option]. **/
+@Composable
+@MultiThemePreview
+private fun LoadingOptionPreview() {
+    OrcaTheme {
+        Option()
+    }
+}
+
+/** Preview of an unselected [Option]. **/
+@Composable
+@MultiThemePreview
+private fun UnselectedOptionPreview() {
+    OrcaTheme {
+        Option(isSelected = false)
+    }
+}
+
+/** Preview of a selected [Option]. **/
+@Composable
+@MultiThemePreview
+private fun SelectedOptionPreview() {
+    OrcaTheme {
+        Option(isSelected = true)
+    }
+}

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/Options.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/Options.kt
@@ -1,0 +1,106 @@
+package com.jeanbarrossilva.orca.platform.theme.kit.input.option.list
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.testTag
+import com.jeanbarrossilva.orca.platform.theme.MultiThemePreview
+import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
+import com.jeanbarrossilva.orca.platform.theme.extensions.border
+import com.jeanbarrossilva.orca.platform.theme.extensions.bottom
+import com.jeanbarrossilva.orca.platform.theme.extensions.top
+import com.jeanbarrossilva.orca.platform.theme.kit.input.option.Option
+import com.jeanbarrossilva.orca.platform.theme.kit.input.option.OptionDefaults
+
+/** Tag that identifies [Options]' [Divider]s for testing purposes. **/
+internal const val OPTIONS_DIVIDER_TAG = "options-divider"
+
+/**
+ * [Column] of loading [Option]s that are shaped according to their position.
+ *
+ * @param modifier [Modifier] to be applied to the underlying [Column].
+ **/
+@Composable
+fun Options(modifier: Modifier = Modifier) {
+    Options(onSelectionToggle = { _, _ -> }, modifier) {
+        repeat(128) {
+            option()
+        }
+    }
+}
+
+/**
+ * [Column] of [Option]s that are shaped according to their position and can be singly selected.
+ *
+ * @param onSelectionToggle Callback run whenever any of the [Option]s is toggled.
+ * @param modifier [Modifier] to be applied to the underlying [Column].
+ * @param content Actions to be run on the given [OptionsScope].
+ **/
+@Composable
+fun Options(
+    onSelectionToggle: (index: Int, isSelected: Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    content: OptionsScope.() -> Unit
+) {
+    val defaultOptionShape = OptionDefaults.shape
+    val scope =
+        remember(onSelectionToggle, content) { OptionsScope(onSelectionToggle).apply(content) }
+
+    Column(modifier.border(defaultOptionShape)) {
+        scope.options.forEachIndexed { index, option ->
+            when {
+                scope.options.size == 1 -> option(defaultOptionShape)
+                index == 0 -> option(defaultOptionShape.top)
+                index == scope.options.lastIndex -> {
+                    option(defaultOptionShape.bottom)
+                    return@forEachIndexed
+                }
+                else -> option(RectangleShape)
+            }
+
+            Divider(Modifier.testTag(OPTIONS_DIVIDER_TAG))
+        }
+    }
+}
+
+/**
+ * [Column] of [Option]s that are shaped according to their position.
+ *
+ * @param count Amount of sample [Option]s to be added.
+ * @param onSelectionToggle Callback run whenever any of the [Option]s is toggled.
+ * @param modifier [Modifier] to be applied to the underlying [Column].
+ **/
+@Composable
+internal fun SampleOptions(
+    modifier: Modifier = Modifier,
+    count: Int = 3,
+    onSelectionToggle: (index: Int, isSelected: Boolean) -> Unit = { _, _ -> }
+) {
+    Options(onSelectionToggle, modifier) {
+        repeat(count) {
+            option {
+                Text("Label #$it")
+            }
+        }
+    }
+}
+
+@Composable
+@MultiThemePreview
+private fun LoadingOptionsPreview() {
+    OrcaTheme {
+        Options()
+    }
+}
+
+@Composable
+@MultiThemePreview
+private fun LoadedOptionsPreview() {
+    OrcaTheme {
+        SampleOptions()
+    }
+}

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/OptionsScope.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/OptionsScope.kt
@@ -1,0 +1,67 @@
+package com.jeanbarrossilva.orca.platform.theme.kit.input.option.list
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import com.jeanbarrossilva.orca.platform.theme.kit.input.option.CoreOption
+import com.jeanbarrossilva.orca.platform.theme.kit.input.option.Option
+
+/**
+ * Scope through which [Option]s can be added.
+ *
+ * @param onSelectionToggle Callback run whenever any of the [Option]s is toggled.
+ **/
+class OptionsScope internal constructor(
+    private val onSelectionToggle: (index: Int, isSelected: Boolean) -> Unit
+) {
+    /** Index of the [Option] that's currently selected. **/
+    private var selectedOptionIndex by mutableIntStateOf(-1)
+
+    /** [Option]s that have been added. **/
+    internal val options = mutableStateListOf<@Composable (Shape) -> Unit>()
+
+    /**
+     * Adds an [Option].
+     *
+     * @param modifier [Modifier] to be applied to the [Option].
+     * @param content [Text] that's the label.
+     **/
+    fun option(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+        with(options.size) index@{
+            options.add { shape ->
+                CoreOption(
+                    isSelected = this@index == selectedOptionIndex,
+                    onSelectionToggle = { isSelected ->
+                        if (selectedOptionIndex != this@index) {
+                            selectedOptionIndex = this@index
+                            onSelectionToggle(selectedOptionIndex, isSelected)
+                        }
+                    },
+                    modifier,
+                    shape,
+                    content
+                )
+            }
+            if (this@index == 0) {
+                selectedOptionIndex = 0
+                onSelectionToggle(selectedOptionIndex, true)
+            }
+        }
+    }
+
+    /**
+     * Adds a loading [Option].
+     *
+     * @param modifier [Modifier] to be applied to the [Option].
+     **/
+    internal fun option(modifier: Modifier = Modifier) {
+        options.add {
+            CoreOption(modifier, shape = it)
+        }
+    }
+}

--- a/platform/theme/src/main/res/drawable/icon_selected.xml
+++ b/platform/theme/src/main/res/drawable/icon_selected.xml
@@ -1,0 +1,12 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?colorControlNormal"
+    android:autoMirrored="true"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M9.86,18a1,1 0,0 1,-0.73 -0.32l-4.86,-5.17a1,1 0,1 1,1.46 -1.37l4.12,4.39l8.41,-9.2a1,1 0,1 1,1.48 1.34l-9.14,10a1,1 0,0 1,-0.73 0.33Z" />
+</vector>

--- a/platform/theme/src/main/res/values/themes.xml
+++ b/platform/theme/src/main/res/values/themes.xml
@@ -29,13 +29,14 @@
         <item name="colorErrorContainer">@color/errorContainer</item>
         <item name="colorOnBackground">@color/backgroundContent</item>
         <item name="colorOnErrorContainer">@color/errorContent</item>
+        <item name="colorOnPrimary">@color/primaryContent</item>
         <item name="colorOnPrimaryContainer">@color/primaryContent</item>
         <item name="colorOnSecondaryContainer">@color/secondary</item>
         <item name="colorOnSurface">@color/surfaceContent</item>
         <item name="colorOnSurfaceVariant">@color/tertiary</item>
         <item name="colorOutline">@color/tertiary</item>
         <item name="colorOutlineVariant">@color/placeholder</item>
-        <item name="colorPrimary">@color/primaryContent</item>
+        <item name="colorPrimary">@color/primaryContainer</item>
         <item name="colorPrimaryContainer">@color/primaryContainer</item>
         <item name="colorSurface">@color/surfaceContainer</item>
         <item name="colorSurfaceVariant">@color/placeholder</item>


### PR DESCRIPTION
Adds a component for selectable configurations to the theme.

<img width="256" src="https://github.com/jeanbarrossilva/Orca/assets/38408390/4f4d4ae3-779c-4be1-92fa-cdc265d6544d" />
<img width="256" src="https://github.com/jeanbarrossilva/Orca/assets/38408390/3c60fca6-6ce3-44bd-bcff-d388133bfa0d" />
