### PR TITLE
Fix unselectable `Option`s

### DIFF
--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/Options.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/Options.kt
@@ -51,7 +51,7 @@ fun Options(
     content: OptionsScope.() -> Unit
 ) {
     val defaultOptionShape = OptionDefaults.shape
-    var selectedOptionIndex by remember(content) { mutableIntStateOf(0) }
+    var selectedOptionIndex by remember { mutableIntStateOf(0) }
     val scope = remember(onSelection, content) {
         OptionsScope { selectedOptionIndex = it }.apply(content)
     }


### PR DESCRIPTION
[`Option`](https://github.com/jeanbarrossilva/Orca/blob/302524797e3e4a296bd1e9093109d3ee0053a0ef/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/Option.kt)s added to an [`Options`](https://github.com/jeanbarrossilva/Orca/blob/302524797e3e4a296bd1e9093109d3ee0053a0ef/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/Options.kt) [`Composable`](https://developer.android.com/reference/kotlin/androidx/compose/runtime/Composable) were unselectable, as it kept selecting the first one again.