### PR TITLE
Fix empty primary button

### DIFF
--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/button/PrimaryButton.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/button/PrimaryButton.kt
@@ -38,14 +38,16 @@ fun PrimaryButton(
 ) {
     val enabledContentColor = OrcaTheme.colors.primary.content
     val disabledContentColor = OrcaTheme.colors.disabled.content
-    val contentColor =
-        remember(isEnabled) { if (isEnabled) enabledContentColor else disabledContentColor }
+    val contentColor = remember(isEnabled, enabledContentColor, disabledContentColor) {
+        if (isEnabled) enabledContentColor else disabledContentColor
+    }
     var isLoading by remember { mutableStateOf(false) }
 
     ElevatedButton(
         onClick = {
             isLoading = true
             onClick()
+            isLoading = false
         },
         modifier,
         isEnabled,
@@ -58,12 +60,14 @@ fun PrimaryButton(
         ),
         contentPadding = PaddingValues(OrcaTheme.spacings.large)
     ) {
-        ProvideTextStyle(LocalTextStyle.current.copy(color = contentColor)) {
-            if (isLoading) {
-                CircularProgressIndicator(Modifier.size(17.4.dp), strokeCap = StrokeCap.Round)
-            } else {
-                content()
-            }
+        if (isLoading) {
+            CircularProgressIndicator(
+                Modifier.size(17.4.dp),
+                contentColor,
+                strokeCap = StrokeCap.Round
+            )
+        } else {
+            ProvideTextStyle(LocalTextStyle.current.copy(color = contentColor), content)
         }
     }
 }


### PR DESCRIPTION
Fixes a bug that made [`PrimaryButton`](https://github.com/jeanbarrossilva/Orca/blob/a7b75f128e952052bba610f4930ccb0db365274c/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/button/PrimaryButton.kt)s empty after they were clicked.

<img width="256" src="https://github.com/jeanbarrossilva/Orca/assets/38408390/585470d8-4395-4840-9eac-a1018f4e4d29" />