### PR TITLE
Format Kotlin files with ktfmt

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,20 +1,25 @@
-name: Lint
+name: Format check
 on:
-  pull_request:
-    branches: [ "main" ]
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+permissions:
+  contents: read
 jobs:
-  ktlint:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
+  build:
+    runs-on: macos-latest
     steps:
-      - uses: actions/checkout@master
-      - name: ktlint
-        uses: ScaCap/action-ktlint@master
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          android: true
-          github_token: ${{ secrets.github_token }}
-          ktlint_version: "0.49.1"
-          reporter: github-check
+          java-version: '17'
+          distribution: 'corretto'
+      - name: Check format with Spotless
+        env:
+          GITHUB_USERNAME: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: spotlessCheck

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 android {
     compileSdk = libs.versions.android.sdk.target.get().toInt()
-    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.get()
     flavorDimensions += Dimensions.VERSION
     namespace = namespaceFor("app")
 

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/BottomNavigationTests.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/BottomNavigationTests.kt
@@ -10,24 +10,23 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class BottomNavigationTests {
-    @get:Rule
-    val composeRule = createAndroidComposeRule<DemoOrcaActivity>()
+  @get:Rule val composeRule = createAndroidComposeRule<DemoOrcaActivity>()
 
-    @Test
-    fun navigatesOnceWhenClickingFeedItemMultipleTimes() {
-        repeat(2) { onView(withId(R.id.feed)).perform(click()) }
-        assertEquals(1, composeRule.activity.supportFragmentManager.fragments.size)
-    }
+  @Test
+  fun navigatesOnceWhenClickingFeedItemMultipleTimes() {
+    repeat(2) { onView(withId(R.id.feed)).perform(click()) }
+    assertEquals(1, composeRule.activity.supportFragmentManager.fragments.size)
+  }
 
-    @Test
-    fun navigatesOnceWhenClickingProfileDetailsItemMultipleTimes() {
-        repeat(2) { onView(withId(R.id.profile_details)).perform(click()) }
+  @Test
+  fun navigatesOnceWhenClickingProfileDetailsItemMultipleTimes() {
+    repeat(2) { onView(withId(R.id.profile_details)).perform(click()) }
 
-        /*
-         * We expect it to have two Fragment instances because we start with a FeedFragment,
-         * and then comes the single ProfileDetailsFragment one after the navigation is
-         * performed once.
-         */
-        assertEquals(2, composeRule.activity.supportFragmentManager.fragments.size)
-    }
+    /*
+     * We expect it to have two Fragment instances because we start with a FeedFragment,
+     * and then comes the single ProfileDetailsFragment one after the navigation is
+     * performed once.
+     */
+    assertEquals(2, composeRule.activity.supportFragmentManager.fragments.size)
+  }
 }

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/FeedTests.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/FeedTests.kt
@@ -20,23 +20,21 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class FeedTests {
-    @get:Rule
-    val intentsRule = IntentsRule()
+  @get:Rule val intentsRule = IntentsRule()
 
-    @get:Rule
-    val composeRule = createAndroidComposeRule<DemoOrcaActivity>()
+  @get:Rule val composeRule = createAndroidComposeRule<DemoOrcaActivity>()
 
-    @Test
-    fun navigatesToTootHighlight() {
-        var hasNavigated = false
-        intending(browsesTo("${Highlight.sample.url}")).ok { hasNavigated = true }
-        composeRule.onHeadlineCards().onFirst().performClick()
-        assertTrue(hasNavigated)
-    }
+  @Test
+  fun navigatesToTootHighlight() {
+    var hasNavigated = false
+    intending(browsesTo("${Highlight.sample.url}")).ok { hasNavigated = true }
+    composeRule.onHeadlineCards().onFirst().performClick()
+    assertTrue(hasNavigated)
+  }
 
-    @Test
-    fun navigatesToComposerOnFabClick() {
-        composeRule.onNodeWithTag(FEED_FLOATING_ACTION_BUTTON_TAG).performClick()
-        intended(hasComponent(ComposerActivity::class.qualifiedName))
-    }
+  @Test
+  fun navigatesToComposerOnFabClick() {
+    composeRule.onNodeWithTag(FEED_FLOATING_ACTION_BUTTON_TAG).performClick()
+    intended(hasComponent(ComposerActivity::class.qualifiedName))
+  }
 }

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/ProfileDetailsTests.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/ProfileDetailsTests.kt
@@ -25,24 +25,22 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class ProfileDetailsTests {
-    @get:Rule
-    val intentsRule = IntentsRule()
+  @get:Rule val intentsRule = IntentsRule()
 
-    @get:Rule
-    val composeRule = createAndroidComposeRule<DemoOrcaActivity>()
+  @get:Rule val composeRule = createAndroidComposeRule<DemoOrcaActivity>()
 
-    @Test
-    fun navigatesToTootHighlight() {
-        var hasNavigated = false
-        intending(browsesTo("${Highlight.sample.url}")).ok { hasNavigated = true }
-        composeRule.onHeadlineCards().onFirst().performClick()
-        assertTrue(hasNavigated)
-    }
+  @Test
+  fun navigatesToTootHighlight() {
+    var hasNavigated = false
+    intending(browsesTo("${Highlight.sample.url}")).ok { hasNavigated = true }
+    composeRule.onHeadlineCards().onFirst().performClick()
+    assertTrue(hasNavigated)
+  }
 
-    @Test
-    fun navigatesToTootDetailsOnTootPreviewClick() {
-        onView(withId(R.id.profile_details)).perform(click())
-        composeRule.onTootPreviews().onFirst().performStartClick()
-        assertIsAtFragment(composeRule.activity, TootDetailsFragment.getRoute(Toot.sample.id))
-    }
+  @Test
+  fun navigatesToTootDetailsOnTootPreviewClick() {
+    onView(withId(R.id.profile_details)).perform(click())
+    composeRule.onTootPreviews().onFirst().performStartClick()
+    assertIsAtFragment(composeRule.activity, TootDetailsFragment.getRoute(Toot.sample.id))
+  }
 }

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/TootDetailsTests.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/TootDetailsTests.kt
@@ -15,17 +15,15 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class TootDetailsTests {
-    @get:Rule
-    val intentsRule = IntentsRule()
+  @get:Rule val intentsRule = IntentsRule()
 
-    @get:Rule
-    val composeRule = createAndroidComposeRule<DemoOrcaActivity>()
+  @get:Rule val composeRule = createAndroidComposeRule<DemoOrcaActivity>()
 
-    @Test
-    fun navigatesToTootHighlight() {
-        var hasNavigated = false
-        intending(browsesTo("${Highlight.sample.url}")).ok { hasNavigated = true }
-        composeRule.onHeadlineCards().onFirst().performClick()
-        assertTrue(hasNavigated)
-    }
+  @Test
+  fun navigatesToTootHighlight() {
+    var hasNavigated = false
+    intending(browsesTo("${Highlight.sample.url}")).ok { hasNavigated = true }
+    composeRule.onHeadlineCards().onFirst().performClick()
+    assertTrue(hasNavigated)
+  }
 }

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/ComposeTestRule.extensions.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/ComposeTestRule.extensions.kt
@@ -6,9 +6,7 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.performTouchInput
 
-/** Performs a click on the portion located at [Offset.Zero] of this [SemanticsNode]. **/
+/** Performs a click on the portion located at [Offset.Zero] of this [SemanticsNode]. */
 internal fun SemanticsNodeInteraction.performStartClick() {
-    performTouchInput {
-        click(Offset.Zero)
-    }
+  performTouchInput { click(Offset.Zero) }
 }

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/Matcher.extensions.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/Matcher.extensions.kt
@@ -11,7 +11,7 @@ import org.hamcrest.Matcher
  * Creates a [Matcher] that matches an [Intent] that browses to the given [uri].
  *
  * @param uri [String] form of the [URI] to which the [Intent] browses to.
- **/
+ */
 internal fun browsesTo(uri: String): Matcher<Intent> {
-    return both(hasAction(Intent.ACTION_VIEW)).and(hasData(uri))
+  return both(hasAction(Intent.ACTION_VIEW)).and(hasData(uri))
 }

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/OngoingStubbing.extensions.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/OngoingStubbing.extensions.kt
@@ -9,10 +9,10 @@ import androidx.test.espresso.intent.OngoingStubbing
  *
  * @param action Operation to be performed before the response.
  * @see Activity.RESULT_OK
- **/
+ */
 internal fun OngoingStubbing.ok(action: () -> Unit) {
-    respondWithFunction {
-        action()
-        Instrumentation.ActivityResult(Activity.RESULT_OK, null)
-    }
+  respondWithFunction {
+    action()
+    Instrumentation.ActivityResult(Activity.RESULT_OK, null)
+  }
 }

--- a/app/src/demo/java/com/jeanbarrossilva/orca/app/demo/DemoOrcaActivity.kt
+++ b/app/src/demo/java/com/jeanbarrossilva/orca/app/demo/DemoOrcaActivity.kt
@@ -4,5 +4,5 @@ import com.jeanbarrossilva.orca.app.OrcaActivity
 import com.jeanbarrossilva.orca.app.demo.module.core.DemoHttpModule
 
 internal class DemoOrcaActivity : OrcaActivity() {
-    override val httpModule = DemoHttpModule
+  override val httpModule = DemoHttpModule
 }

--- a/app/src/demo/java/com/jeanbarrossilva/orca/app/demo/module/core/DemoHttpModule.kt
+++ b/app/src/demo/java/com/jeanbarrossilva/orca/app/demo/module/core/DemoHttpModule.kt
@@ -10,11 +10,12 @@ import com.jeanbarrossilva.orca.core.sample.auth.sample
 import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.muting.SampleTermMuter
 import com.jeanbarrossilva.orca.core.sample.instance.sample
 
-internal object DemoHttpModule : HttpModule(
+internal object DemoHttpModule :
+  HttpModule(
     { Authorizer.sample },
     { Instance.sample.authenticator },
     { ActorProvider.sample },
     { Instance.sample.authenticationLock },
     { SampleTermMuter() },
     { InstanceProvider.sample }
-)
+  )

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/OrcaApplication.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/OrcaApplication.kt
@@ -8,30 +8,27 @@ import com.jeanbarrossilva.orca.platform.launchable.Launchable
 import net.time4j.android.ApplicationStarter
 
 internal open class OrcaApplication : Application(), Launchable {
-    private val preferences
-        get() = getSharedPreferences("orca", Context.MODE_PRIVATE)
+  private val preferences
+    get() = getSharedPreferences("orca", Context.MODE_PRIVATE)
 
-    override fun onCreate() {
-        super.onCreate()
+  override fun onCreate() {
+    super.onCreate()
 
-        @Suppress("DiscouragedApi")
-        markAsLaunched()
+    @Suppress("DiscouragedApi") markAsLaunched()
 
-        ApplicationStarter.initialize(this, true)
-    }
+    ApplicationStarter.initialize(this, true)
+  }
 
-    override fun count(): Int {
-        return preferences.getInt(LAUNCH_COUNT_PREFERENCE_KEY, 0)
-    }
+  override fun count(): Int {
+    return preferences.getInt(LAUNCH_COUNT_PREFERENCE_KEY, 0)
+  }
 
-    @Discouraged("Should only be called by OrcaApplication internally.")
-    override fun markAsLaunched() {
-        preferences.edit {
-            putInt(LAUNCH_COUNT_PREFERENCE_KEY, count() + 1)
-        }
-    }
+  @Discouraged("Should only be called by OrcaApplication internally.")
+  override fun markAsLaunched() {
+    preferences.edit { putInt(LAUNCH_COUNT_PREFERENCE_KEY, count() + 1) }
+  }
 
-    companion object {
-        private const val LAUNCH_COUNT_PREFERENCE_KEY = "launch_count"
-    }
+  companion object {
+    private const val LAUNCH_COUNT_PREFERENCE_KEY = "launch_count"
+  }
 }

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/core/MainHttpModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/core/MainHttpModule.kt
@@ -9,11 +9,12 @@ import com.jeanbarrossilva.orca.core.sharedpreferences.actor.SharedPreferencesAc
 import com.jeanbarrossilva.orca.core.sharedpreferences.feed.profile.toot.muting.SharedPreferencesTermMuter
 import com.jeanbarrossilva.orca.std.injector.Injector
 
-internal class MainHttpModule : HttpModule(
+internal class MainHttpModule :
+  HttpModule(
     { HttpAuthorizer(context = Injector.get()) },
     { HttpAuthenticator(context = Injector.get(), authorizer = get(), actorProvider = get()) },
     { SharedPreferencesActorProvider(context = Injector.get()) },
     { AuthenticationLock(authenticator = get(), actorProvider = get()) },
     { SharedPreferencesTermMuter(context = Injector.get()) },
     { HttpInstanceProvider(context = Injector.get()) }
-)
+  )

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/feed/MainFeedModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/feed/MainFeedModule.kt
@@ -6,9 +6,10 @@ import com.jeanbarrossilva.orca.core.http.instanceProvider
 import com.jeanbarrossilva.orca.feature.feed.FeedModule
 import com.jeanbarrossilva.orca.std.injector.Injector
 
-internal class MainFeedModule(activity: OrcaActivity) : FeedModule(
+internal class MainFeedModule(activity: OrcaActivity) :
+  FeedModule(
     { Injector.from<HttpModule>().instanceProvider().provide().feedProvider },
     { Injector.from<HttpModule>().instanceProvider().provide().tootProvider },
     { NavigatorFeedBoundary(activity, activity.navigator) },
     onBottomAreaAvailabilityChangeListener = { activity }
-)
+  )

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/feed/NavigatorFeedBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/feed/NavigatorFeedBoundary.kt
@@ -10,22 +10,22 @@ import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 import java.net.URL
 
 internal class NavigatorFeedBoundary(
-    private val context: Context,
-    private val navigator: Navigator
+  private val context: Context,
+  private val navigator: Navigator
 ) : FeedBoundary {
-    override fun navigateToSearch() {
-        SearchFragment.navigate(navigator)
-    }
+  override fun navigateToSearch() {
+    SearchFragment.navigate(navigator)
+  }
 
-    override fun navigateTo(url: URL) {
-        context.browseTo(url)
-    }
+  override fun navigateTo(url: URL) {
+    context.browseTo(url)
+  }
 
-    override fun navigateToTootDetails(id: String) {
-        TootDetailsFragment.navigate(navigator, id)
-    }
+  override fun navigateToTootDetails(id: String) {
+    TootDetailsFragment.navigate(navigator, id)
+  }
 
-    override fun navigateToComposer() {
-        ComposerActivity.start(context)
-    }
+  override fun navigateToComposer() {
+    ComposerActivity.start(context)
+  }
 }

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/profiledetails/MainProfileDetailsModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/profiledetails/MainProfileDetailsModule.kt
@@ -6,9 +6,10 @@ import com.jeanbarrossilva.orca.core.http.instanceProvider
 import com.jeanbarrossilva.orca.feature.ProfileDetailsModule
 import com.jeanbarrossilva.orca.std.injector.Injector
 
-internal class MainProfileDetailsModule(activity: OrcaActivity) : ProfileDetailsModule(
+internal class MainProfileDetailsModule(activity: OrcaActivity) :
+  ProfileDetailsModule(
     { Injector.from<HttpModule>().instanceProvider().provide().profileProvider },
     { Injector.from<HttpModule>().instanceProvider().provide().tootProvider },
     { NavigatorProfileDetailsBoundary(activity, activity.navigator) },
     onBottomAreaAvailabilityChangeListener = { activity }
-)
+  )

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/profiledetails/NavigatorProfileDetailsBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/profiledetails/NavigatorProfileDetailsBoundary.kt
@@ -8,14 +8,14 @@ import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 import java.net.URL
 
 internal class NavigatorProfileDetailsBoundary(
-    private val context: Context,
-    private val navigator: Navigator
+  private val context: Context,
+  private val navigator: Navigator
 ) : ProfileDetailsBoundary {
-    override fun navigateTo(url: URL) {
-        context.browseTo(url)
-    }
+  override fun navigateTo(url: URL) {
+    context.browseTo(url)
+  }
 
-    override fun navigateToTootDetails(id: String) {
-        TootDetailsFragment.navigate(navigator, id)
-    }
+  override fun navigateToTootDetails(id: String) {
+    TootDetailsFragment.navigate(navigator, id)
+  }
 }

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/search/MainSearchModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/search/MainSearchModule.kt
@@ -6,7 +6,8 @@ import com.jeanbarrossilva.orca.feature.search.SearchModule
 import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 import com.jeanbarrossilva.orca.std.injector.Injector
 
-internal class MainSearchModule(navigator: Navigator) : SearchModule(
+internal class MainSearchModule(navigator: Navigator) :
+  SearchModule(
     { Injector.from<HttpModule>().instanceProvider().provide().profileSearcher },
     { NavigatorSearchBoundary(navigator) }
-)
+  )

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/search/NavigatorSearchBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/search/NavigatorSearchBoundary.kt
@@ -5,11 +5,11 @@ import com.jeanbarrossilva.orca.feature.search.SearchBoundary
 import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 
 internal class NavigatorSearchBoundary(private val navigator: Navigator) : SearchBoundary {
-    override fun navigateToProfileDetails(id: String) {
-        ProfileDetailsFragment.navigate(navigator, id)
-    }
+  override fun navigateToProfileDetails(id: String) {
+    ProfileDetailsFragment.navigate(navigator, id)
+  }
 
-    override fun pop() {
-        navigator.pop()
-    }
+  override fun pop() {
+    navigator.pop()
+  }
 }

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/settings/MainSettingsModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/settings/MainSettingsModule.kt
@@ -6,7 +6,8 @@ import com.jeanbarrossilva.orca.feature.settings.SettingsModule
 import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 import com.jeanbarrossilva.orca.std.injector.Injector
 
-internal class MainSettingsModule(private val navigator: Navigator) : SettingsModule(
+internal class MainSettingsModule(private val navigator: Navigator) :
+  SettingsModule(
     { Injector.from<HttpModule>().termMuter() },
     { NavigatorSettingsBoundary(navigator) }
-)
+  )

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/settings/NavigatorSettingsBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/settings/NavigatorSettingsBoundary.kt
@@ -5,7 +5,7 @@ import com.jeanbarrossilva.orca.feature.settings.termmuting.TermMutingFragment
 import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 
 internal class NavigatorSettingsBoundary(private val navigator: Navigator) : SettingsBoundary {
-    override fun navigateToTermMuting() {
-        TermMutingFragment.navigate(navigator)
-    }
+  override fun navigateToTermMuting() {
+    TermMutingFragment.navigate(navigator)
+  }
 }

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/settings/termmuting/MainTermMutingModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/settings/termmuting/MainTermMutingModule.kt
@@ -6,7 +6,8 @@ import com.jeanbarrossilva.orca.feature.settings.termmuting.TermMutingModule
 import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 import com.jeanbarrossilva.orca.std.injector.Injector
 
-internal class MainTermMutingModule(private val navigator: Navigator) : TermMutingModule(
+internal class MainTermMutingModule(private val navigator: Navigator) :
+  TermMutingModule(
     { Injector.from<HttpModule>().termMuter() },
     { NavigatorTermMutingBoundary(navigator) }
-)
+  )

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/settings/termmuting/NavigatorTermMutingBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/settings/termmuting/NavigatorTermMutingBoundary.kt
@@ -4,7 +4,7 @@ import com.jeanbarrossilva.orca.feature.settings.termmuting.TermMutingBoundary
 import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 
 internal class NavigatorTermMutingBoundary(private val navigator: Navigator) : TermMutingBoundary {
-    override fun pop() {
-        navigator.pop()
-    }
+  override fun pop() {
+    navigator.pop()
+  }
 }

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/tootdetails/MainTootDetailsModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/tootdetails/MainTootDetailsModule.kt
@@ -6,8 +6,9 @@ import com.jeanbarrossilva.orca.core.http.instanceProvider
 import com.jeanbarrossilva.orca.feature.tootdetails.TootDetailsModule
 import com.jeanbarrossilva.orca.std.injector.Injector
 
-internal class MainTootDetailsModule(activity: OrcaActivity) : TootDetailsModule(
+internal class MainTootDetailsModule(activity: OrcaActivity) :
+  TootDetailsModule(
     { Injector.from<HttpModule>().instanceProvider().provide().tootProvider },
     { NavigatorTootDetailsBoundary(activity, activity.navigator) },
     onBottomAreaAvailabilityChangeListener = { activity }
-)
+  )

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/tootdetails/NavigatorTootDetailsBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/tootdetails/NavigatorTootDetailsBoundary.kt
@@ -8,18 +8,18 @@ import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 import java.net.URL
 
 internal class NavigatorTootDetailsBoundary(
-    private val context: Context,
-    private val navigator: Navigator
+  private val context: Context,
+  private val navigator: Navigator
 ) : TootDetailsBoundary {
-    override fun navigateTo(url: URL) {
-        context.browseTo(url)
-    }
+  override fun navigateTo(url: URL) {
+    context.browseTo(url)
+  }
 
-    override fun navigateToTootDetails(id: String) {
-        TootDetailsFragment.navigate(navigator, id)
-    }
+  override fun navigateToTootDetails(id: String) {
+    TootDetailsFragment.navigate(navigator, id)
+  }
 
-    override fun pop() {
-        navigator.pop()
-    }
+  override fun pop() {
+    navigator.pop()
+  }
 }

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/navigation/BottomNavigation.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/navigation/BottomNavigation.kt
@@ -14,48 +14,45 @@ import com.jeanbarrossilva.orca.platform.ui.core.navigation.transition.suddenly
 import com.jeanbarrossilva.orca.std.injector.Injector
 
 internal enum class BottomNavigation {
-    FEED {
-        override val id = R.id.feed
+  FEED {
+    override val id = R.id.feed
 
-        override suspend fun getDestination(): Navigator.Navigation.Destination<*> {
-            return Injector.from<HttpModule>().authenticationLock().requestUnlock {
-                Navigator.Navigation.Destination("feed") {
-                    FeedFragment(it.id)
-                }
-            }
-        }
-    },
-    PROFILE_DETAILS {
-        override val id = R.id.profile_details
-
-        override suspend fun getDestination(): Navigator.Navigation.Destination<*> {
-            return Injector.from<HttpModule>().authenticationLock().requestUnlock {
-                Navigator.Navigation.Destination(ProfileDetailsFragment.createRoute(it.id)) {
-                    ProfileDetailsFragment(BackwardsNavigationState.Unavailable, it.id)
-                }
-            }
-        }
-    },
-    SETTINGS {
-        override val id = R.id.settings
-
-        override suspend fun getDestination(): Navigator.Navigation.Destination<*> {
-            return Navigator.Navigation.Destination("settings", ::SettingsFragment)
-        }
-    };
-
-    @get:IdRes
-    protected abstract val id: Int
-
-    protected abstract suspend fun getDestination(): Navigator.Navigation.Destination<*>
-
-    companion object {
-        suspend fun navigate(navigator: Navigator, @IdRes id: Int) {
-            val value = values().find { it.id == id } ?: throw NoSuchElementException("$id")
-            val destination = value.getDestination()
-            navigator.navigate(suddenly(), disallowingDuplication()) {
-                to(destination.route, destination.target)
-            }
-        }
+    override suspend fun getDestination(): Navigator.Navigation.Destination<*> {
+      return Injector.from<HttpModule>().authenticationLock().requestUnlock {
+        Navigator.Navigation.Destination("feed") { FeedFragment(it.id) }
+      }
     }
+  },
+  PROFILE_DETAILS {
+    override val id = R.id.profile_details
+
+    override suspend fun getDestination(): Navigator.Navigation.Destination<*> {
+      return Injector.from<HttpModule>().authenticationLock().requestUnlock {
+        Navigator.Navigation.Destination(ProfileDetailsFragment.createRoute(it.id)) {
+          ProfileDetailsFragment(BackwardsNavigationState.Unavailable, it.id)
+        }
+      }
+    }
+  },
+  SETTINGS {
+    override val id = R.id.settings
+
+    override suspend fun getDestination(): Navigator.Navigation.Destination<*> {
+      return Navigator.Navigation.Destination("settings", ::SettingsFragment)
+    }
+  };
+
+  @get:IdRes protected abstract val id: Int
+
+  protected abstract suspend fun getDestination(): Navigator.Navigation.Destination<*>
+
+  companion object {
+    suspend fun navigate(navigator: Navigator, @IdRes id: Int) {
+      val value = values().find { it.id == id } ?: throw NoSuchElementException("$id")
+      val destination = value.getDestination()
+      navigator.navigate(suddenly(), disallowingDuplication()) {
+        to(destination.route, destination.target)
+      }
+    }
+  }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,101 +3,94 @@ import com.jeanbarrossilva.orca.chrynan
 import com.jeanbarrossilva.orca.loadable
 import com.jeanbarrossilva.orca.namespace
 import com.jeanbarrossilva.orca.parentNamespaceCandidate
-import com.ncorti.ktfmt.gradle.KtfmtExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.android.maps.secrets) apply false
-    alias(libs.plugins.kotlin.android) apply false
-    alias(libs.plugins.kotlin.jvm) apply false
-    alias(libs.plugins.kotlin.serialization) apply false
-    alias(libs.plugins.kotlin.symbolProcessor) apply false
-    alias(libs.plugins.ktfmtGradle) apply false
-    alias(libs.plugins.moduleDependencyGraph)
+  alias(libs.plugins.android.application) apply false
+  alias(libs.plugins.android.library) apply false
+  alias(libs.plugins.android.maps.secrets) apply false
+  alias(libs.plugins.kotlin.android) apply false
+  alias(libs.plugins.kotlin.jvm) apply false
+  alias(libs.plugins.kotlin.serialization) apply false
+  alias(libs.plugins.kotlin.symbolProcessor) apply false
+  alias(libs.plugins.spotless)
+  alias(libs.plugins.moduleDependencyGraph)
 
-    id("build-src")
+  id("build-src")
+}
+
+allprojects { repositories.mavenCentral() }
+
+spotless.kotlin {
+  target("*.kt", "*.kts")
+  ktfmt().googleStyle()
 }
 
 subprojects subproject@{
-    tasks.withType<KotlinCompile> {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.fromTarget(libs.versions.java.get()))
-            freeCompilerArgs.addAll("-Xcontext-receivers", "-Xstring-concat=inline")
+  tasks.withType<KotlinCompile> {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.fromTarget(libs.versions.java.get()))
+      freeCompilerArgs.addAll("-Xcontext-receivers", "-Xstring-concat=inline")
+    }
+  }
+
+  repositories {
+    chrynan()
+    google()
+    gradlePluginPortal()
+    loadable(project)
+  }
+
+  afterEvaluate {
+    with(JavaVersion.toVersion(libs.versions.java.get())) java@{
+      extensions.findByType<JavaPluginExtension>()?.apply {
+        sourceCompatibility = this@java
+        targetCompatibility = this@java
+      }
+
+      extensions.findByType<LibraryExtension>()?.apply {
+        compileSdk = libs.versions.android.sdk.target.get().toInt()
+        defaultConfig.minSdk = libs.versions.android.sdk.min.get().toInt()
+        setDefaultNamespaceIfUnsetAndEligible(this@subproject)
+
+        buildTypes { release { isMinifyEnabled = true } }
+
+        compileOptions {
+          sourceCompatibility = this@java
+          targetCompatibility = this@java
         }
+      }
     }
-
-    repositories {
-        chrynan()
-        google()
-        gradlePluginPortal()
-        loadable(project)
-        mavenCentral()
-    }
-
-    afterEvaluate {
-        apply(plugin = libs.plugins.ktfmtGradle.get().pluginId)
-
-        with(JavaVersion.toVersion(libs.versions.java.get())) java@{
-            extensions.findByType<JavaPluginExtension>()?.apply {
-                sourceCompatibility = this@java
-                targetCompatibility = this@java
-            }
-
-            extensions.findByType<LibraryExtension>()?.apply {
-                compileSdk = libs.versions.android.sdk.target.get().toInt()
-                defaultConfig.minSdk = libs.versions.android.sdk.min.get().toInt()
-                setDefaultNamespaceIfUnsetAndEligible(this@subproject)
-
-                buildTypes {
-                    release {
-                        isMinifyEnabled = true
-                    }
-                }
-
-                compileOptions {
-                    sourceCompatibility = this@java
-                    targetCompatibility = this@java
-                }
-            }
-        }
-
-        extensions.findByType<KtfmtExtension>()?.googleStyle()
-    }
+  }
 }
 
-tasks.register<Delete>("clean") {
-    delete(rootProject.buildDir)
-}
+tasks.named("clean") { delete(rootProject.buildDir) }
 
 /**
- * Sets a default [namespace] to the [project] if it doesn't have one and the [project]'s
- * coordinate candidates are eligible to be part of the one to be set.
+ * Sets a default [namespace] to the [project] if it doesn't have one and the [project]'s coordinate
+ * candidates are eligible to be part of the one to be set.
  *
  * @param project [Project] whose [namespace] will be set if unset.
  * @see isEligibleForNamespace
- **/
+ */
 fun LibraryExtension.setDefaultNamespaceIfUnsetAndEligible(project: Project) {
-    if (
-        namespace == null &&
-        isEligibleForNamespace(project.name) &&
-        isEligibleForNamespace(project.parentNamespaceCandidate)
-    ) {
-        namespace = createDefaultNamespace(project)
-    }
+  if (
+    namespace == null &&
+      isEligibleForNamespace(project.name) &&
+      isEligibleForNamespace(project.parentNamespaceCandidate)
+  ) {
+    namespace = createDefaultNamespace(project)
+  }
 }
 
 /**
  * Whether the [coordinates] are valid namespace coordinates.
  *
  * @param coordinates Dot-separated coordinates whose eligibility will be checked.
- **/
+ */
 fun isEligibleForNamespace(coordinates: String): Boolean {
-    return coordinates.all {
-        it.isLetterOrDigit() || it == '.'
-    }
+  return coordinates.all { it.isLetterOrDigit() || it == '.' }
 }
 
 /**
@@ -105,7 +98,7 @@ fun isEligibleForNamespace(coordinates: String): Boolean {
  *
  * @param project [Project] for which the default [namespace] will be created.
  * @return Created [namespace].
- **/
+ */
 fun createDefaultNamespace(project: Project): String {
-    return "${rootProject.namespace}." + project.parentNamespaceCandidate + ".${project.name}"
+  return "${rootProject.namespace}." + project.parentNamespaceCandidate + ".${project.name}"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import com.jeanbarrossilva.orca.chrynan
 import com.jeanbarrossilva.orca.loadable
 import com.jeanbarrossilva.orca.namespace
 import com.jeanbarrossilva.orca.parentNamespaceCandidate
+import com.ncorti.ktfmt.gradle.KtfmtExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -14,6 +15,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kotlin.symbolProcessor) apply false
+    alias(libs.plugins.ktfmtGradle) apply false
     alias(libs.plugins.moduleDependencyGraph)
 
     id("build-src")
@@ -36,6 +38,8 @@ subprojects subproject@{
     }
 
     afterEvaluate {
+        apply(plugin = libs.plugins.ktfmtGradle.get().pluginId)
+
         with(JavaVersion.toVersion(libs.versions.java.get())) java@{
             extensions.findByType<JavaPluginExtension>()?.apply {
                 sourceCompatibility = this@java
@@ -59,6 +63,8 @@ subprojects subproject@{
                 }
             }
         }
+
+        extensions.findByType<KtfmtExtension>()?.googleStyle()
     }
 }
 

--- a/core-test/src/main/java/com/jeanbarrossilva/orca/core/test/TestActorProvider.kt
+++ b/core-test/src/main/java/com/jeanbarrossilva/orca/core/test/TestActorProvider.kt
@@ -3,20 +3,20 @@ package com.jeanbarrossilva.orca.core.test
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.auth.actor.ActorProvider
 
-/** [ActorProvider] that remembers and retrieves [Actor]s locally. **/
+/** [ActorProvider] that remembers and retrieves [Actor]s locally. */
 open class TestActorProvider : ActorProvider() {
-    /**
-     * [Actor] that's been remembered.
-     *
-     * @see remember
-     **/
-    private var rememberedActor: Actor = Actor.Unauthenticated
+  /**
+   * [Actor] that's been remembered.
+   *
+   * @see remember
+   */
+  private var rememberedActor: Actor = Actor.Unauthenticated
 
-    override suspend fun remember(actor: Actor) {
-        rememberedActor = actor
-    }
+  override suspend fun remember(actor: Actor) {
+    rememberedActor = actor
+  }
 
-    override suspend fun retrieve(): Actor {
-        return rememberedActor
-    }
+  override suspend fun retrieve(): Actor {
+    return rememberedActor
+  }
 }

--- a/core-test/src/main/java/com/jeanbarrossilva/orca/core/test/TestAuthenticationLock.kt
+++ b/core-test/src/main/java/com/jeanbarrossilva/orca/core/test/TestAuthenticationLock.kt
@@ -7,14 +7,14 @@ import com.jeanbarrossilva.orca.core.auth.actor.Actor
  * [AuthenticationLock] with test-specific default structures.
  *
  * @param authenticator [TestAuthenticator] through which the [Actor] will be authenticated if it
- * isn't and [requestUnlock][AuthenticationLock.requestUnlock] is called.
+ *   isn't and [requestUnlock][AuthenticationLock.requestUnlock] is called.
  * @param actorProvider [TestActorProvider] whose provided [Actor] will be ensured to be either
- * [unauthenticated][Actor.Unauthenticated] or [authenticated][Actor.Authenticated].
- **/
+ *   [unauthenticated][Actor.Unauthenticated] or [authenticated][Actor.Authenticated].
+ */
 @Suppress("FunctionName")
 fun TestAuthenticationLock(
-    actorProvider: TestActorProvider = TestActorProvider(),
-    authenticator: TestAuthenticator = TestAuthenticator(actorProvider = actorProvider)
+  actorProvider: TestActorProvider = TestActorProvider(),
+  authenticator: TestAuthenticator = TestAuthenticator(actorProvider = actorProvider)
 ): AuthenticationLock<TestAuthenticator> {
-    return AuthenticationLock(authenticator, actorProvider)
+  return AuthenticationLock(authenticator, actorProvider)
 }

--- a/core-test/src/main/java/com/jeanbarrossilva/orca/core/test/TestAuthenticator.kt
+++ b/core-test/src/main/java/com/jeanbarrossilva/orca/core/test/TestAuthenticator.kt
@@ -8,43 +8,44 @@ import com.jeanbarrossilva.orca.core.auth.actor.Actor
  *
  * @param authorizer [TestAuthorizer] with which the user will be authorized.
  * @param actorProvider [TestActorProvider] to which the [authenticated][Actor.Authenticated]
- * [Actor] will be sent to be remembered when authentication occurs.
+ *   [Actor] will be sent to be remembered when authentication occurs.
  * @param onOnAuthenticate Operation to be performed when [onAuthenticate] is called.
  * @see currentActor
  * @see switchCurrentActor
- **/
+ */
 class TestAuthenticator(
-    override val authorizer: TestAuthorizer = TestAuthorizer(),
-    override val actorProvider: TestActorProvider = TestActorProvider(),
-    private val onOnAuthenticate: suspend (authorizationCode: String) -> Unit = { }
+  override val authorizer: TestAuthorizer = TestAuthorizer(),
+  override val actorProvider: TestActorProvider = TestActorProvider(),
+  private val onOnAuthenticate: suspend (authorizationCode: String) -> Unit = {}
 ) : Authenticator() {
-    /**
-     * [Actor] to be switched on [onAuthenticate].
-     *
-     * @see switchCurrentActor
-     **/
-    private var currentActor: Actor = Actor.Unauthenticated
+  /**
+   * [Actor] to be switched on [onAuthenticate].
+   *
+   * @see switchCurrentActor
+   */
+  private var currentActor: Actor = Actor.Unauthenticated
 
-    /**
-     * [Authenticated][Actor.Authenticated] [Actor] to switch to when the [currentActor] is
-     * [unauthenticated][Actor.Unauthenticated].
-     **/
-    private val authenticatedActor = Actor.Authenticated("test-id", "test-access-token")
+  /**
+   * [Authenticated][Actor.Authenticated] [Actor] to switch to when the [currentActor] is
+   * [unauthenticated][Actor.Unauthenticated].
+   */
+  private val authenticatedActor = Actor.Authenticated("test-id", "test-access-token")
 
-    override suspend fun onAuthenticate(authorizationCode: String): Actor {
-        onOnAuthenticate(authorizationCode)
-        switchCurrentActor()
-        return currentActor
-    }
+  override suspend fun onAuthenticate(authorizationCode: String): Actor {
+    onOnAuthenticate(authorizationCode)
+    switchCurrentActor()
+    return currentActor
+  }
 
-    /**
-     * Switches the [currentActor] to an [authenticated][Actor.Authenticated] one if it's
-     * [unauthenticated][Actor.Unauthenticated] or vice-versa.
-     **/
-    private fun switchCurrentActor() {
-        currentActor = when (currentActor) {
-            is Actor.Unauthenticated -> authenticatedActor
-            is Actor.Authenticated -> Actor.Unauthenticated
-        }
-    }
+  /**
+   * Switches the [currentActor] to an [authenticated][Actor.Authenticated] one if it's
+   * [unauthenticated][Actor.Unauthenticated] or vice-versa.
+   */
+  private fun switchCurrentActor() {
+    currentActor =
+      when (currentActor) {
+        is Actor.Unauthenticated -> authenticatedActor
+        is Actor.Authenticated -> Actor.Unauthenticated
+      }
+  }
 }

--- a/core-test/src/main/java/com/jeanbarrossilva/orca/core/test/TestAuthorizer.kt
+++ b/core-test/src/main/java/com/jeanbarrossilva/orca/core/test/TestAuthorizer.kt
@@ -7,15 +7,15 @@ import com.jeanbarrossilva.orca.core.auth.Authorizer
  *
  * @param onAuthorize Operation to be performed when [authorize] is called.
  * @see AUTHORIZATION_CODE
- **/
-class TestAuthorizer(private val onAuthorize: () -> Unit = { }) : Authorizer() {
-    override suspend fun authorize(): String {
-        onAuthorize()
-        return AUTHORIZATION_CODE
-    }
+ */
+class TestAuthorizer(private val onAuthorize: () -> Unit = {}) : Authorizer() {
+  override suspend fun authorize(): String {
+    onAuthorize()
+    return AUTHORIZATION_CODE
+  }
 
-    companion object {
-        /** Authorization code provided by [authorize]. **/
-        const val AUTHORIZATION_CODE = "authorization-code"
-    }
+  companion object {
+    /** Authorization code provided by [authorize]. */
+    const val AUTHORIZATION_CODE = "authorization-code"
+  }
 }

--- a/core/http/build.gradle.kts
+++ b/core/http/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 android {
     buildFeatures.compose = true
-    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.get()
     defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
     buildFeatures {

--- a/core/http/src/androidTest/java/com/jeanbarrossilva/orca/core/http/client/AndroidLoggerTests.kt
+++ b/core/http/src/androidTest/java/com/jeanbarrossilva/orca/core/http/client/AndroidLoggerTests.kt
@@ -6,19 +6,19 @@ import io.mockk.verify
 import org.junit.Test
 
 internal class AndroidLoggerTests {
-    @Test
-    fun infoCallsAndroidLogI() {
-        mockkStatic(Log::class) {
-            Logger.android.info("😮")
-            verify { Log.i(Logger.ANDROID_LOGGER_TAG, "😮") }
-        }
+  @Test
+  fun infoCallsAndroidLogI() {
+    mockkStatic(Log::class) {
+      Logger.android.info("😮")
+      verify { Log.i(Logger.ANDROID_LOGGER_TAG, "😮") }
     }
+  }
 
-    @Test
-    fun errorCallsAndroidLogE() {
-        mockkStatic(Log::class) {
-            Logger.android.error("😵")
-            verify { Log.e(Logger.ANDROID_LOGGER_TAG, "😵") }
-        }
+  @Test
+  fun errorCallsAndroidLogE() {
+    mockkStatic(Log::class) {
+      Logger.android.error("😵")
+      verify { Log.e(Logger.ANDROID_LOGGER_TAG, "😵") }
     }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/HttpDatabase.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/HttpDatabase.kt
@@ -13,55 +13,54 @@ import com.jeanbarrossilva.orca.core.http.feed.profile.toot.cache.storage.HttpTo
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.cache.storage.style.HttpStyleEntity
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.cache.storage.style.HttpStyleEntityDao
 
-/** [RoomDatabase] in which core-HTTP-related persistence operations will take place. **/
+/** [RoomDatabase] in which core-HTTP-related persistence operations will take place. */
 @Database(
-    entities = [
-        HttpStyleEntity::class,
-        HttpProfileEntity::class,
-        HttpProfileSearchResultEntity::class,
-        HttpTootEntity::class
+  entities =
+    [
+      HttpStyleEntity::class,
+      HttpProfileEntity::class,
+      HttpProfileSearchResultEntity::class,
+      HttpTootEntity::class
     ],
-    version = 1
+  version = 1
 )
 internal abstract class HttpDatabase : RoomDatabase() {
-    /** DAO for operating on [HTTP style entities][HttpStyleEntity]. **/
-    abstract val styleEntityDao: HttpStyleEntityDao
+  /** DAO for operating on [HTTP style entities][HttpStyleEntity]. */
+  abstract val styleEntityDao: HttpStyleEntityDao
 
-    /** DAO for operating on [HTTP profile entities][HttpProfileEntity]. **/
-    abstract val profileEntityDao: HttpProfileEntityDao
+  /** DAO for operating on [HTTP profile entities][HttpProfileEntity]. */
+  abstract val profileEntityDao: HttpProfileEntityDao
+
+  /** DAO for operating on [HTTP profile search result entities][HttpProfileSearchResultEntity]. */
+  abstract val profileSearchResultEntityDao: HttpProfileSearchResultEntityDao
+
+  /** DAO for operating on [HTTP toot entities][HttpTootEntity]. */
+  abstract val tootEntityDao: HttpTootEntityDao
+
+  companion object {
+    private lateinit var instance: HttpDatabase
 
     /**
-     * DAO for operating on [HTTP profile search result entities][HttpProfileSearchResultEntity].
-     **/
-    abstract val profileSearchResultEntityDao: HttpProfileSearchResultEntityDao
-
-    /** DAO for operating on [HTTP toot entities][HttpTootEntity]. **/
-    abstract val tootEntityDao: HttpTootEntityDao
-
-    companion object {
-        private lateinit var instance: HttpDatabase
-
-        /**
-         * Builds or retrieves the previously instantiated [HttpDatabase].
-         *
-         * @param context [Context] to be used for building it.
-         **/
-        fun getInstance(context: Context): HttpDatabase {
-            return if (Companion::instance.isInitialized) {
-                instance
-            } else {
-                instance = build(context)
-                instance
-            }
-        }
-
-        /**
-         * Builds a [HttpDatabase].
-         *
-         * @param context [Context] from which it will be built.
-         **/
-        private fun build(context: Context): HttpDatabase {
-            return Room.databaseBuilder(context, HttpDatabase::class.java, "http-database").build()
-        }
+     * Builds or retrieves the previously instantiated [HttpDatabase].
+     *
+     * @param context [Context] to be used for building it.
+     */
+    fun getInstance(context: Context): HttpDatabase {
+      return if (Companion::instance.isInitialized) {
+        instance
+      } else {
+        instance = build(context)
+        instance
+      }
     }
+
+    /**
+     * Builds a [HttpDatabase].
+     *
+     * @param context [Context] from which it will be built.
+     */
+    private fun build(context: Context): HttpDatabase {
+      return Room.databaseBuilder(context, HttpDatabase::class.java, "http-database").build()
+    }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/HttpModule.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/HttpModule.kt
@@ -10,10 +10,10 @@ import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
 
 open class HttpModule(
-    @Inject internal val authorizer: Module.() -> Authorizer,
-    @Inject internal val authenticator: Module.() -> Authenticator,
-    @Inject internal val actorProvider: Module.() -> ActorProvider,
-    @Inject internal val authenticationLock: Module.() -> SomeAuthenticationLock,
-    @Inject internal val termMuter: Module.() -> TermMuter,
-    @Inject internal val instanceProvider: Module.() -> InstanceProvider
+  @Inject internal val authorizer: Module.() -> Authorizer,
+  @Inject internal val authenticator: Module.() -> Authenticator,
+  @Inject internal val actorProvider: Module.() -> ActorProvider,
+  @Inject internal val authenticationLock: Module.() -> SomeAuthenticationLock,
+  @Inject internal val termMuter: Module.() -> TermMuter,
+  @Inject internal val instanceProvider: Module.() -> InstanceProvider
 ) : Module()

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/Mastodon.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/Mastodon.kt
@@ -2,15 +2,15 @@ package com.jeanbarrossilva.orca.core.http.auth
 
 import com.jeanbarrossilva.orca.core.http.BuildConfig
 
-/** API configuration for authorization and authentication. **/
+/** API configuration for authorization and authentication. */
 internal object Mastodon {
-    /** Identifies Orca amongst all Mastodon clients. **/
-    @Suppress("SpellCheckingInspection")
-    const val CLIENT_ID = "F2Rx9d7C3x45KRVJ9rU4IjIJgrsjzaq74bSLo__VUG0"
+  /** Identifies Orca amongst all Mastodon clients. */
+  @Suppress("SpellCheckingInspection")
+  const val CLIENT_ID = "F2Rx9d7C3x45KRVJ9rU4IjIJgrsjzaq74bSLo__VUG0"
 
-    /** Private code. **/
-    const val CLIENT_SECRET = BuildConfig.mastodonclientSecret
+  /** Private code. */
+  const val CLIENT_SECRET = BuildConfig.mastodonclientSecret
 
-    /** Scopes required by Orca for its functionalities to work properly. **/
-    const val SCOPES = "read write follow"
+  /** Scopes required by Orca for its functionalities to work properly. */
+  const val SCOPES = "read write follow"
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthentication.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthentication.kt
@@ -24,28 +24,26 @@ import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
  */
 @Composable
 internal fun HttpAuthentication(modifier: Modifier = Modifier) {
-    Surface(modifier, color = OrcaTheme.colors.background.container) {
-        Column(
-            Modifier.fillMaxSize(),
-            Arrangement.spacedBy(OrcaTheme.spacings.medium, Alignment.CenterVertically),
-            Alignment.CenterHorizontally
-        ) {
-            Icon(OrcaTheme.iconography.login, contentDescription = "Link", Modifier.size(64.dp))
+  Surface(modifier, color = OrcaTheme.colors.background.container) {
+    Column(
+      Modifier.fillMaxSize(),
+      Arrangement.spacedBy(OrcaTheme.spacings.medium, Alignment.CenterVertically),
+      Alignment.CenterHorizontally
+    ) {
+      Icon(OrcaTheme.iconography.login, contentDescription = "Link", Modifier.size(64.dp))
 
-            Text(
-                stringResource(R.string.core_http_authentication_authenticating),
-                textAlign = TextAlign.Center,
-                style = OrcaTheme.typography.headlineLarge
-            )
-        }
+      Text(
+        stringResource(R.string.core_http_authentication_authenticating),
+        textAlign = TextAlign.Center,
+        style = OrcaTheme.typography.headlineLarge
+      )
     }
+  }
 }
 
-/** Preview of an [HttpAuthentication]. **/
+/** Preview of an [HttpAuthentication]. */
 @Composable
 @MultiThemePreview
 private fun HttpAuthenticationPreview() {
-    OrcaTheme {
-        HttpAuthentication()
-    }
+  OrcaTheme { HttpAuthentication() }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationToken.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationToken.kt
@@ -15,18 +15,19 @@ import kotlinx.serialization.Serializable
  * authorization was successfully granted to the user.
  *
  * @param accessToken Token that gives Orca user-level access to the API resources.
- **/
+ */
 @Serializable
 internal data class HttpAuthenticationToken(val accessToken: String) {
-    /**
-     * Converts this [HttpAuthenticationToken] into an [authenticated][Actor.Authenticated] [Actor].
-     **/
-    suspend fun toActor(): Actor.Authenticated {
-        val id = (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
-            .client
-            .get("/api/v1/accounts/verify_credentials") { bearerAuth(accessToken) }
-            .body<HttpAuthenticationVerification>()
-            .id
-        return Actor.Authenticated(id, accessToken)
-    }
+  /**
+   * Converts this [HttpAuthenticationToken] into an [authenticated][Actor.Authenticated] [Actor].
+   */
+  suspend fun toActor(): Actor.Authenticated {
+    val id =
+      (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+        .client
+        .get("/api/v1/accounts/verify_credentials") { bearerAuth(accessToken) }
+        .body<HttpAuthenticationVerification>()
+        .id
+    return Actor.Authenticated(id, accessToken)
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationVerification.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationVerification.kt
@@ -6,6 +6,5 @@ import kotlinx.serialization.Serializable
  * Structure returned by the API when the user's credentials are verified.
  *
  * @param id Unique identifier of the user.
- **/
-@Serializable
-internal data class HttpAuthenticationVerification(val id: String)
+ */
+@Serializable internal data class HttpAuthenticationVerification(val id: String)

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationViewModel.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationViewModel.kt
@@ -24,58 +24,54 @@ import kotlinx.coroutines.launch
  *
  * @param application [Application] that allows [Context]-specific behavior.
  * @param authorizationCode Code provided by the API when authorization was granted to the user.
- **/
-internal class HttpAuthenticationViewModel private constructor(
-    application: Application,
-    private val authorizationCode: String
-) : AndroidViewModel(application) {
-    /**
-     * Requests the API to authenticate the user and runs [onAuthentication] with the resulting
-     * [Actor].
-     *
-     * @param onAuthentication Callback run when the user has been successfully authenticated.
-     **/
-    internal fun request(onAuthentication: (Actor.Authenticated) -> Unit) {
-        val application = getApplication<Application>()
-        val scheme = application.getString(R.string.scheme)
-        val redirectUri = application.getString(R.string.redirect_uri, scheme)
-        viewModelScope.launch {
-            (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
-                .client
-                .submitForm(
-                    "/oauth/token",
-                    Parameters.build {
-                        set("grant_type", "authorization_code")
-                        set("code", authorizationCode)
-                        set("client_id", Mastodon.CLIENT_ID)
-                        set("client_secret", Mastodon.CLIENT_SECRET)
-                        set("redirect_uri", redirectUri)
-                        set("scope", Mastodon.SCOPES)
-                    }
-                )
-                .body<HttpAuthenticationToken>()
-                .toActor()
-                .run(onAuthentication)
-        }
+ */
+internal class HttpAuthenticationViewModel
+private constructor(application: Application, private val authorizationCode: String) :
+  AndroidViewModel(application) {
+  /**
+   * Requests the API to authenticate the user and runs [onAuthentication] with the resulting
+   * [Actor].
+   *
+   * @param onAuthentication Callback run when the user has been successfully authenticated.
+   */
+  internal fun request(onAuthentication: (Actor.Authenticated) -> Unit) {
+    val application = getApplication<Application>()
+    val scheme = application.getString(R.string.scheme)
+    val redirectUri = application.getString(R.string.redirect_uri, scheme)
+    viewModelScope.launch {
+      (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+        .client
+        .submitForm(
+          "/oauth/token",
+          Parameters.build {
+            set("grant_type", "authorization_code")
+            set("code", authorizationCode)
+            set("client_id", Mastodon.CLIENT_ID)
+            set("client_secret", Mastodon.CLIENT_SECRET)
+            set("redirect_uri", redirectUri)
+            set("scope", Mastodon.SCOPES)
+          }
+        )
+        .body<HttpAuthenticationToken>()
+        .toActor()
+        .run(onAuthentication)
     }
+  }
 
-    companion object {
-        /**
-         * Creates a [ViewModelProvider.Factory] that provides an [HttpAuthenticationViewModel].
-         *
-         * @param application [Application] that allows [Context]-specific behavior.
-         * @param authorizationCode Code provided by the API when authorization was granted to the
-         * user.
-         **/
-        fun createFactory(
-            application: Application,
-            authorizationCode: String
-        ): ViewModelProvider.Factory {
-            return viewModelFactory {
-                initializer {
-                    HttpAuthenticationViewModel(application, authorizationCode)
-                }
-            }
-        }
+  companion object {
+    /**
+     * Creates a [ViewModelProvider.Factory] that provides an [HttpAuthenticationViewModel].
+     *
+     * @param application [Application] that allows [Context]-specific behavior.
+     * @param authorizationCode Code provided by the API when authorization was granted to the user.
+     */
+    fun createFactory(
+      application: Application,
+      authorizationCode: String
+    ): ViewModelProvider.Factory {
+      return viewModelFactory {
+        initializer { HttpAuthenticationViewModel(application, authorizationCode) }
+      }
     }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticator.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticator.kt
@@ -16,29 +16,29 @@ import kotlin.coroutines.suspendCoroutine
  *
  * @param context [Context] in which the [HttpAuthenticationActivity] will be started.
  * @see receive
- **/
+ */
 class HttpAuthenticator(
-    private val context: Context,
-    override val authorizer: Authorizer,
-    override val actorProvider: ActorProvider
+  private val context: Context,
+  override val authorizer: Authorizer,
+  override val actorProvider: ActorProvider
 ) : Authenticator() {
-    /** [Continuation] of the coroutine that's suspended on authentication. **/
-    private var continuation: Continuation<Actor>? = null
+  /** [Continuation] of the coroutine that's suspended on authentication. */
+  private var continuation: Continuation<Actor>? = null
 
-    override suspend fun onAuthenticate(authorizationCode: String): Actor {
-        return suspendCoroutine {
-            continuation = it
-            HttpAuthenticationActivity.start(context, authorizationCode)
-        }
+  override suspend fun onAuthenticate(authorizationCode: String): Actor {
+    return suspendCoroutine {
+      continuation = it
+      HttpAuthenticationActivity.start(context, authorizationCode)
     }
+  }
 
-    /**
-     * Notifies this [HttpAuthenticator] that the [actor] has been successfully retrieved,
-     * consequently resuming the suspended coroutine.
-     *
-     * @param actor [Actor] to be received.
-     **/
-    internal fun receive(actor: Actor) {
-        continuation?.resume(actor)
-    }
+  /**
+   * Notifies this [HttpAuthenticator] that the [actor] has been successfully retrieved,
+   * consequently resuming the suspended coroutine.
+   *
+   * @param actor [Actor] to be received.
+   */
+  internal fun receive(actor: Actor) {
+    continuation?.resume(actor)
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpInstanceProvider.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpInstanceProvider.kt
@@ -4,21 +4,21 @@ import com.jeanbarrossilva.orca.core.http.instance.HttpInstance
 import com.jeanbarrossilva.orca.core.http.instance.SomeHttpInstance
 import com.jeanbarrossilva.orca.core.instance.domain.Domain
 
-/** Provides an [HttpInstance] through [onProvide]. **/
+/** Provides an [HttpInstance] through [onProvide]. */
 abstract class HttpInstanceProvider {
-    /**
-     * Provides an [HttpInstance].
-     *
-     * @param domain [Domain] to which the user belongs.
-     **/
-    internal fun provide(domain: Domain): SomeHttpInstance {
-        return onProvide(domain)
-    }
+  /**
+   * Provides an [HttpInstance].
+   *
+   * @param domain [Domain] to which the user belongs.
+   */
+  internal fun provide(domain: Domain): SomeHttpInstance {
+    return onProvide(domain)
+  }
 
-    /**
-     * Provides an [HttpInstance].
-     *
-     * @param domain [Domain] to which the user belongs.
-     **/
-    protected abstract fun onProvide(domain: Domain): SomeHttpInstance
+  /**
+   * Provides an [HttpInstance].
+   *
+   * @param domain [Domain] to which the user belongs.
+   */
+  protected abstract fun onProvide(domain: Domain): SomeHttpInstance
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/activity/Activity.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/activity/Activity.extensions.kt
@@ -8,10 +8,10 @@ import android.content.Intent
  *
  * @param key Key to which the extra is associated.
  * @throws ClassCastException If the extra is present but isn't a [T].
- **/
+ */
 internal inline fun <reified T> Activity.extra(key: String): Lazy<T> {
-    return lazy {
-        @Suppress("DEPRECATION")
-        intent?.extras?.get(key) as T
-    }
+  return lazy {
+    @Suppress("DEPRECATION")
+    intent?.extras?.get(key) as T
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/domains/DomainsProvider.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/domains/DomainsProvider.kt
@@ -2,15 +2,15 @@ package com.jeanbarrossilva.orca.feature.auth.domains
 
 import com.jeanbarrossilva.orca.core.instance.domain.Domain
 
-/** Provides [Domain]s through [provide]. **/
+/** Provides [Domain]s through [provide]. */
 interface DomainsProvider {
-    /** Provides the available Mastodon server [Domain]s. **/
-    suspend fun provide(): List<Domain>
+  /** Provides the available Mastodon server [Domain]s. */
+  suspend fun provide(): List<Domain>
 
-    /**
-     * Provides the available Mastodon server [Domain]s matching the given [query].
-     *
-     * @param query Query to provide the [Domain]s with.
-     **/
-    suspend fun provide(query: String): List<Domain>
+  /**
+   * Provides the available Mastodon server [Domain]s matching the given [query].
+   *
+   * @param query Query to provide the [Domain]s with.
+   */
+  suspend fun provide(query: String): List<Domain>
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpAuthorization.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpAuthorization.kt
@@ -44,7 +44,7 @@ import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.button.ButtonBar
 import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.top.TopAppBar
 import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.top.text.AutoSizeText
 
-/** Tag that identifies the sign-in [PrimaryButton] for testing purposes. **/
+/** Tag that identifies the sign-in [PrimaryButton] for testing purposes. */
 const val HTTP_AUTHORIZATION_SIGN_IN_BUTTON_TAG = "http-authorization-sign-in-button"
 
 /**
@@ -52,52 +52,49 @@ const val HTTP_AUTHORIZATION_SIGN_IN_BUTTON_TAG = "http-authorization-sign-in-bu
  * authenticated.
  *
  * @param viewModel [HttpAuthorizationViewModel] by which the [Domain]s will be loaded and to which
- * updates to the search query and the selection will be sent.
+ *   updates to the search query and the selection will be sent.
  * @param modifier [Modifier] to be applied to the underlying [Box].
- **/
+ */
 @Composable
 internal fun HttpAuthorization(
-    viewModel: HttpAuthorizationViewModel,
-    modifier: Modifier = Modifier
+  viewModel: HttpAuthorizationViewModel,
+  modifier: Modifier = Modifier
 ) {
-    val searchQuery by viewModel.searchQueryFlow.collectAsState()
-    val instanceDomainSelectablesLoadable by viewModel
-        .instanceDomainSelectablesLoadableFlow
-        .collectAsState()
+  val searchQuery by viewModel.searchQueryFlow.collectAsState()
+  val instanceDomainSelectablesLoadable by
+    viewModel.instanceDomainSelectablesLoadableFlow.collectAsState()
 
-    when (
-        @Suppress("NAME_SHADOWING")
-        val instanceDomainSelectablesLoadable = instanceDomainSelectablesLoadable
-    ) {
-        is Loadable.Loading ->
-            HttpAuthorization(modifier)
-        is Loadable.Loaded ->
-            HttpAuthorization(
-                searchQuery,
-                onSearch = viewModel::search,
-                instanceDomainSelectablesLoadable.content,
-                onSelection = viewModel::select,
-                onSignIn = viewModel::authorize
-            )
-        is Loadable.Failed ->
-            Unit
-    }
+  when (
+    @Suppress("NAME_SHADOWING")
+    val instanceDomainSelectablesLoadable = instanceDomainSelectablesLoadable
+  ) {
+    is Loadable.Loading -> HttpAuthorization(modifier)
+    is Loadable.Loaded ->
+      HttpAuthorization(
+        searchQuery,
+        onSearch = viewModel::search,
+        instanceDomainSelectablesLoadable.content,
+        onSelection = viewModel::select,
+        onSignIn = viewModel::authorize
+      )
+    is Loadable.Failed -> Unit
+  }
 }
 
 /**
  * Screen that presents loading [Domain]s.
  *
  * @param modifier [Modifier] to be applied to the underlying [Box].
- **/
+ */
 @Composable
 internal fun HttpAuthorization(modifier: Modifier = Modifier) {
-    HttpAuthorization(
-        searchField = { },
-        instanceDomains = { Options() },
-        onSignIn = { },
-        isSignInButtonEnabled = false,
-        modifier
-    )
+  HttpAuthorization(
+    searchField = {},
+    instanceDomains = { Options() },
+    onSignIn = {},
+    isSignInButtonEnabled = false,
+    modifier
+  )
 }
 
 /**
@@ -109,142 +106,126 @@ internal fun HttpAuthorization(modifier: Modifier = Modifier) {
  * @param onSelection Callback run whenever a [Domain] is selected.
  * @param onSignIn Callback run whenever the sign-in [PrimaryButton] is clicked.
  * @param modifier [Modifier] to be applied to the underlying [Box].
- **/
+ */
 @Composable
 internal fun HttpAuthorization(
-    searchQuery: String,
-    onSearch: (query: String) -> Unit,
-    instanceDomains: SelectableList<Domain>,
-    onSelection: (Domain) -> Unit,
-    onSignIn: () -> Unit,
-    modifier: Modifier = Modifier
+  searchQuery: String,
+  onSearch: (query: String) -> Unit,
+  instanceDomains: SelectableList<Domain>,
+  onSelection: (Domain) -> Unit,
+  onSignIn: () -> Unit,
+  modifier: Modifier = Modifier
 ) {
-    HttpAuthorization(
-        searchField = {
-            TextField(
-                searchQuery,
-                onSearch,
-                Modifier.fillMaxWidth(),
-                KeyboardOptions(imeAction = ImeAction.Search),
-                isSingleLined = true
-            ) {
-                Text(stringResource(R.string.core_http_authorization_search))
-            }
-        },
-        instanceDomains = {
-            Options(onSelection = { onSelection(instanceDomains[it].value) }) {
-                instanceDomains.forEach {
-                    option {
-                        Text("${it.value}")
-                    }
-                }
-            }
-        },
-        onSignIn,
-        isSignInButtonEnabled = true,
-        modifier
-    )
+  HttpAuthorization(
+    searchField = {
+      TextField(
+        searchQuery,
+        onSearch,
+        Modifier.fillMaxWidth(),
+        KeyboardOptions(imeAction = ImeAction.Search),
+        isSingleLined = true
+      ) {
+        Text(stringResource(R.string.core_http_authorization_search))
+      }
+    },
+    instanceDomains = {
+      Options(onSelection = { onSelection(instanceDomains[it].value) }) {
+        instanceDomains.forEach { option { Text("${it.value}") } }
+      }
+    },
+    onSignIn,
+    isSignInButtonEnabled = true,
+    modifier
+  )
 }
 
 @Composable
 internal fun HttpAuthorization(
-    searchField: @Composable LazyItemScope.() -> Unit,
-    instanceDomains: @Composable LazyItemScope.() -> Unit,
-    onSignIn: () -> Unit,
-    isSignInButtonEnabled: Boolean,
-    modifier: Modifier = Modifier
+  searchField: @Composable LazyItemScope.() -> Unit,
+  instanceDomains: @Composable LazyItemScope.() -> Unit,
+  onSignIn: () -> Unit,
+  isSignInButtonEnabled: Boolean,
+  modifier: Modifier = Modifier
 ) {
-    val lazyListState = rememberLazyListState()
+  val lazyListState = rememberLazyListState()
 
-    @OptIn(ExperimentalMaterial3Api::class)
-    val topAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+  @OptIn(ExperimentalMaterial3Api::class)
+  val topAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
-    val isHeaderHidden by remember(lazyListState) {
-        derivedStateOf {
-            lazyListState.firstVisibleItemIndex > 0
+  val isHeaderHidden by
+    remember(lazyListState) { derivedStateOf { lazyListState.firstVisibleItemIndex > 0 } }
+  val headerTitle = stringResource(R.string.core_http_authorization_account_origin)
+  val spacing = OrcaTheme.spacings.extraLarge
+
+  Box(modifier) {
+    Scaffold(
+      buttonBar = {
+        ButtonBar(lazyListState) {
+          PrimaryButton(onClick = onSignIn, isEnabled = isSignInButtonEnabled) {
+            Text(stringResource(R.string.core_http_authorization_sign_in))
+          }
         }
+      }
+    ) {
+      LazyColumn(
+        state = lazyListState,
+        verticalArrangement = Arrangement.spacedBy(spacing),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        contentPadding = it + PaddingValues(spacing)
+      ) {
+        item {
+          Column(
+            verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.small),
+            horizontalAlignment = Alignment.CenterHorizontally
+          ) {
+            Text(
+              stringResource(R.string.core_http_authorization_welcome),
+              textAlign = TextAlign.Center,
+              style = OrcaTheme.typography.headlineLarge
+            )
+
+            Text(headerTitle, textAlign = TextAlign.Center, style = OrcaTheme.typography.titleSmall)
+          }
+        }
+
+        item(content = searchField)
+        item(content = instanceDomains)
+      }
     }
-    val headerTitle = stringResource(R.string.core_http_authorization_account_origin)
-    val spacing = OrcaTheme.spacings.extraLarge
 
-    Box(modifier) {
-        Scaffold(
-            buttonBar = {
-                ButtonBar(lazyListState) {
-                    PrimaryButton(onClick = onSignIn, isEnabled = isSignInButtonEnabled) {
-                        Text(stringResource(R.string.core_http_authorization_sign_in))
-                    }
-                }
-            }
-        ) {
-            LazyColumn(
-                state = lazyListState,
-                verticalArrangement = Arrangement.spacedBy(spacing),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                contentPadding = it + PaddingValues(spacing)
-            ) {
-                item {
-                    Column(
-                        verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.small),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Text(
-                            stringResource(R.string.core_http_authorization_welcome),
-                            textAlign = TextAlign.Center,
-                            style = OrcaTheme.typography.headlineLarge
-                        )
+    AnimatedVisibility(
+      visible = isHeaderHidden,
+      enter = slideInVertically { -it },
+      exit = slideOutVertically { -it }
+    ) {
+      Column {
+        @OptIn(ExperimentalMaterial3Api::class)
+        TopAppBar(title = { AutoSizeText(headerTitle) }, scrollBehavior = topAppBarScrollBehavior)
 
-                        Text(
-                            headerTitle,
-                            textAlign = TextAlign.Center,
-                            style = OrcaTheme.typography.titleSmall
-                        )
-                    }
-                }
-
-                item(content = searchField)
-                item(content = instanceDomains)
-            }
-        }
-
-        AnimatedVisibility(
-            visible = isHeaderHidden,
-            enter = slideInVertically { -it },
-            exit = slideOutVertically { -it }
-        ) {
-            Column {
-                @OptIn(ExperimentalMaterial3Api::class)
-                TopAppBar(
-                    title = { AutoSizeText(headerTitle) },
-                    scrollBehavior = topAppBarScrollBehavior
-                )
-
-                Divider()
-            }
-        }
+        Divider()
+      }
     }
+  }
 }
 
-/** Preview of a loading [HttpAuthorization] screen. **/
+/** Preview of a loading [HttpAuthorization] screen. */
 @Composable
 @MultiThemePreview
 private fun LoadingHttpAuthorizationPreview() {
-    OrcaTheme {
-        HttpAuthorization()
-    }
+  OrcaTheme { HttpAuthorization() }
 }
 
-/** Preview of a loaded [HttpAuthorization] screen. **/
+/** Preview of a loaded [HttpAuthorization] screen. */
 @Composable
 @MultiThemePreview
 private fun LoadedHttpAuthorizationPreview() {
-    OrcaTheme {
-        HttpAuthorization(
-            searchQuery = "",
-            onSearch = { },
-            instanceDomains = Domain.samples.selectFirst(),
-            onSelection = { },
-            onSignIn = { }
-        )
-    }
+  OrcaTheme {
+    HttpAuthorization(
+      searchQuery = "",
+      onSearch = {},
+      instanceDomains = Domain.samples.selectFirst(),
+      onSelection = {},
+      onSignIn = {}
+    )
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpAuthorizationActivity.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpAuthorizationActivity.kt
@@ -16,53 +16,53 @@ import io.ktor.http.Url
 /**
  * [ComposableActivity] that visually notifies the user of the background authorization process that
  * takes place when this is created and automatically finishes itself when it's done.
- **/
+ */
 class HttpAuthorizationActivity internal constructor() :
-    ComposableActivity(), OnAccessTokenRequestListener {
-    /**
-     * [HttpAuthorizationViewModel] from which the [Url] to the authorization webpage will be
-     * obtained.
-     **/
-    private val viewModel by viewModels<HttpAuthorizationViewModel> {
-        HttpAuthorizationViewModel.createFactory(application, onAccessTokenRequestListener = this)
+  ComposableActivity(), OnAccessTokenRequestListener {
+  /**
+   * [HttpAuthorizationViewModel] from which the [Url] to the authorization webpage will be
+   * obtained.
+   */
+  private val viewModel by
+    viewModels<HttpAuthorizationViewModel> {
+      HttpAuthorizationViewModel.createFactory(application, onAccessTokenRequestListener = this)
     }
 
-    /**
-     * [IllegalStateException] thrown if the [HttpAuthorizationActivity] has been started from a
-     * deep link and an access token isn't provided.
-     **/
-    private class UnprovidedAccessTokenException : IllegalStateException()
+  /**
+   * [IllegalStateException] thrown if the [HttpAuthorizationActivity] has been started from a deep
+   * link and an access token isn't provided.
+   */
+  private class UnprovidedAccessTokenException : IllegalStateException()
 
-    @Throws(UnprovidedAccessTokenException::class)
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        intent?.data?.run(::sendAccessTokenToAuthorizer)
-    }
+  @Throws(UnprovidedAccessTokenException::class)
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    intent?.data?.run(::sendAccessTokenToAuthorizer)
+  }
 
-    @Composable
-    override fun Content() {
-        HttpAuthorization(viewModel)
-    }
+  @Composable
+  override fun Content() {
+    HttpAuthorization(viewModel)
+  }
 
-    override fun onAccessTokenRequest() {
-        val uri = Uri.parse("${viewModel.url}")
-        CustomTabsIntent.Builder().build().launchUrl(this, uri)
-    }
+  override fun onAccessTokenRequest() {
+    val uri = Uri.parse("${viewModel.url}")
+    CustomTabsIntent.Builder().build().launchUrl(this, uri)
+  }
 
-    /**
-     * Sends the access token that might be in the [deepLink] to the [HttpAuthorizer].
-     *
-     * @param deepLink [Uri] from which this [HttpAuthorizationActivity] was started after
-     * requesting for the user to be authorized.
-     * @throws UnprovidedAccessTokenException If an access token hasn't been provided.
-     **/
-    @Throws(UnprovidedAccessTokenException::class)
-    private fun sendAccessTokenToAuthorizer(deepLink: Uri) {
-        val accessToken =
-            deepLink.getQueryParameter("code") ?: throw UnprovidedAccessTokenException()
-        (Injector.from<HttpModule>().instanceProvider().provide() as ContextualHttpInstance)
-            .authorizer
-            .receive(accessToken)
-        finish()
-    }
+  /**
+   * Sends the access token that might be in the [deepLink] to the [HttpAuthorizer].
+   *
+   * @param deepLink [Uri] from which this [HttpAuthorizationActivity] was started after requesting
+   *   for the user to be authorized.
+   * @throws UnprovidedAccessTokenException If an access token hasn't been provided.
+   */
+  @Throws(UnprovidedAccessTokenException::class)
+  private fun sendAccessTokenToAuthorizer(deepLink: Uri) {
+    val accessToken = deepLink.getQueryParameter("code") ?: throw UnprovidedAccessTokenException()
+    (Injector.from<HttpModule>().instanceProvider().provide() as ContextualHttpInstance)
+      .authorizer
+      .receive(accessToken)
+    finish()
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpAuthorizer.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpAuthorizer.kt
@@ -13,25 +13,25 @@ import kotlin.coroutines.suspendCoroutine
  *
  * @param context [Context] through which the [HttpAuthorizationActivity] will be started.
  * @see receive
- **/
+ */
 class HttpAuthorizer(private val context: Context) : Authorizer() {
-    /** [Continuation] of the coroutine that's suspended on authorization. **/
-    private var continuation: Continuation<String>? = null
+  /** [Continuation] of the coroutine that's suspended on authorization. */
+  private var continuation: Continuation<String>? = null
 
-    override suspend fun authorize(): String {
-        return suspendCoroutine {
-            continuation = it
-            context.on<HttpAuthorizationActivity>().asNewTask().start()
-        }
+  override suspend fun authorize(): String {
+    return suspendCoroutine {
+      continuation = it
+      context.on<HttpAuthorizationActivity>().asNewTask().start()
     }
+  }
 
-    /**
-     * Notifies this [HttpAuthorizer] that the [accessToken] has been successfully retrieved,
-     * consequently resuming the suspended coroutine.
-     *
-     * @param accessToken Access token to be received.
-     **/
-    internal fun receive(accessToken: String) {
-        continuation?.resume(accessToken)
-    }
+  /**
+   * Notifies this [HttpAuthorizer] that the [accessToken] has been successfully retrieved,
+   * consequently resuming the suspended coroutine.
+   *
+   * @param accessToken Access token to be received.
+   */
+  internal fun receive(accessToken: String) {
+    continuation?.resume(accessToken)
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpDomainsProvider.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpDomainsProvider.kt
@@ -12,62 +12,57 @@ import io.ktor.client.request.parameter
 import io.ktor.client.request.request
 import kotlinx.serialization.Serializable
 
-/** Provides [Domain]s through [provide]. **/
+/** Provides [Domain]s through [provide]. */
 internal object HttpDomainsProvider {
-    /** [CoreHttpClient] through which the [HttpRequest]s will be sent. **/
-    private val client = CoreHttpClient {
-        defaultRequest {
-            url("https://instances.social")
-        }
-    }
+  /** [CoreHttpClient] through which the [HttpRequest]s will be sent. */
+  private val client = CoreHttpClient { defaultRequest { url("https://instances.social") } }
 
-    /**
-     * Structure returned by the API containing the [instances].
-     *
-     * @param instances [NamedInstance]s that have been found.
-     **/
-    @Serializable
-    private data class PaginatingInstanceList(val instances: List<NamedInstance>)
+  /**
+   * Structure returned by the API containing the [instances].
+   *
+   * @param instances [NamedInstance]s that have been found.
+   */
+  @Serializable private data class PaginatingInstanceList(val instances: List<NamedInstance>)
 
-    /**
-     * Structure returned by the API with a [String] version of the server [Domain].
-     *
-     * @param name [String] that represents the [Domain].
-     **/
-    @Serializable
-    private data class NamedInstance(val name: String) {
-        /** Converts this [NamedInstance] into a [Domain]. **/
-        fun toDomain(): Domain {
-            return Domain(name)
-        }
+  /**
+   * Structure returned by the API with a [String] version of the server [Domain].
+   *
+   * @param name [String] that represents the [Domain].
+   */
+  @Serializable
+  private data class NamedInstance(val name: String) {
+    /** Converts this [NamedInstance] into a [Domain]. */
+    fun toDomain(): Domain {
+      return Domain(name)
     }
+  }
 
-    /** Provides the available Mastodon server [Domain]s. **/
-    suspend fun provide(): List<Domain> {
-        return client
-            .request("/api/1.0/instances/list") {
-                bearerAuth(BuildConfig.instancesSocialtoken)
-                parameter("sort_by", "users")
-            }
-            .body<PaginatingInstanceList>()
-            .instances
-            .map(NamedInstance::toDomain)
-    }
+  /** Provides the available Mastodon server [Domain]s. */
+  suspend fun provide(): List<Domain> {
+    return client
+      .request("/api/1.0/instances/list") {
+        bearerAuth(BuildConfig.instancesSocialtoken)
+        parameter("sort_by", "users")
+      }
+      .body<PaginatingInstanceList>()
+      .instances
+      .map(NamedInstance::toDomain)
+  }
 
-    /**
-     * Provides the available Mastodon server [Domain]s matching the given [query].
-     *
-     * @param query Query to provide the [Domain]s with.
-     **/
-    suspend fun provide(query: String): List<Domain> {
-        return client
-            .request("/api/1.0/instances/search") {
-                bearerAuth(BuildConfig.instancesSocialtoken)
-                parameter("name", true)
-                parameter("q", query)
-            }
-            .body<PaginatingInstanceList>()
-            .instances
-            .map(NamedInstance::toDomain)
-    }
+  /**
+   * Provides the available Mastodon server [Domain]s matching the given [query].
+   *
+   * @param query Query to provide the [Domain]s with.
+   */
+  suspend fun provide(query: String): List<Domain> {
+    return client
+      .request("/api/1.0/instances/search") {
+        bearerAuth(BuildConfig.instancesSocialtoken)
+        parameter("name", true)
+        parameter("q", query)
+      }
+      .body<PaginatingInstanceList>()
+      .instances
+      .map(NamedInstance::toDomain)
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/OnAccessTokenRequestListener.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/OnAccessTokenRequestListener.kt
@@ -1,7 +1,7 @@
 package com.jeanbarrossilva.orca.core.http.auth.authorization
 
-/** Listens to requests for an access token. **/
+/** Listens to requests for an access token. */
 internal interface OnAccessTokenRequestListener {
-    /** Callback run when the access token is requested. **/
-    fun onAccessTokenRequest()
+  /** Callback run when the access token is requested. */
+  fun onAccessTokenRequest()
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/selectable/Selectable.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/selectable/Selectable.kt
@@ -7,7 +7,7 @@ import androidx.annotation.Discouraged
  *
  * @param value Value that's selected or unselected, according to [isSelected].
  * @param isSelected Whether [value] is considered to be selected.
- **/
+ */
 internal data class Selectable<T>
 @Discouraged("Use the `select` or `unselect` extension functions instead.")
 constructor(val value: T, val isSelected: Boolean)

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/selectable/list/Collection.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/selectable/list/Collection.extensions.kt
@@ -6,34 +6,26 @@ import com.jeanbarrossilva.orca.core.http.auth.authorization.selectable.Selectab
  * Converts this [Collection] into a [SelectableList] and selects the given [element].
  *
  * @param element Element to be selected.
- **/
+ */
 internal fun <T> Collection<T>.select(element: T): SelectableList<T> {
-    return selectIf { _, current ->
-        element == current
-    }
+  return selectIf { _, current -> element == current }
 }
 
-/**
- * Converts this [Collection] into a [SelectableList] and selects its first element.
- **/
+/** Converts this [Collection] into a [SelectableList] and selects its first element. */
 internal fun <T> Collection<T>.selectFirst(): SelectableList<T> {
-    return selectIf { index, _ ->
-        index == 0
-    }
+  return selectIf { index, _ -> index == 0 }
 }
 
 /**
  * Converts this [Collection] into a [SelectableList].
  *
  * @param selection Predicate that determines whether the element that's been given to it is
- * selected.
- **/
+ *   selected.
+ */
 private fun <T> Collection<T>.selectIf(selection: (index: Int, T) -> Boolean): SelectableList<T> {
-    val elements = mapIndexed { index, element ->
-        @Suppress("DiscouragedApi")
-        Selectable(element, selection(index, element))
-    }
+  val elements = mapIndexed { index, element ->
+    @Suppress("DiscouragedApi") Selectable(element, selection(index, element))
+  }
 
-    @Suppress("DiscouragedApi")
-    return SelectableList(elements)
+  @Suppress("DiscouragedApi") return SelectableList(elements)
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/selectable/list/SelectableList.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/selectable/list/SelectableList.extensions.kt
@@ -2,19 +2,18 @@ package com.jeanbarrossilva.orca.core.http.auth.authorization.selectable.list
 
 import com.jeanbarrossilva.orca.core.http.auth.authorization.selectable.Selectable
 
-/** Creates an empty [SelectableList]. **/
+/** Creates an empty [SelectableList]. */
 internal inline fun <reified T> emptySelectableList(): SelectableList<T> {
-    return selectableListOf()
+  return selectableListOf()
 }
 
 /**
  * Creates a [SelectableList] with the given [elements].
  *
  * @param elements [Selectable]s to be put in the [SelectableList].
- **/
+ */
 internal fun <T> selectableListOf(vararg elements: Selectable<T>): SelectableList<T> {
-    val list = listOf(*elements)
+  val list = listOf(*elements)
 
-    @Suppress("DiscouragedApi")
-    return SelectableList(list)
+  @Suppress("DiscouragedApi") return SelectableList(list)
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/selectable/list/SelectableList.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/selectable/list/SelectableList.kt
@@ -8,55 +8,52 @@ import com.jeanbarrossilva.orca.core.http.auth.authorization.selectable.Selectab
  *
  * @param elements [Selectable]s contained in this [SelectableList].
  * @throws IllegalStateException If none or more than one [Selectable] is selected.
- **/
+ */
 @JvmInline
 internal value class SelectableList<T>
 @Discouraged("Use `selectableListOf` or `emptySelectableList` instead.")
-internal constructor(private val elements: List<Selectable<T>>) :
-    List<Selectable<T>> by elements {
-    /** Value that's currently selected. **/
-    val selected
-        get() = single(Selectable<T>::isSelected).value
+internal constructor(private val elements: List<Selectable<T>>) : List<Selectable<T>> by elements {
+  /** Value that's currently selected. */
+  val selected
+    get() = single(Selectable<T>::isSelected).value
 
-    /** [IllegalStateException] thrown if more than one [Selectable] are selected. **/
-    class MultipleSelectionException : IllegalStateException("Only one element can be selected.")
+  /** [IllegalStateException] thrown if more than one [Selectable] are selected. */
+  class MultipleSelectionException : IllegalStateException("Only one element can be selected.")
 
-    init {
-        ensureSelectionConstraint()
+  init {
+    ensureSelectionConstraint()
+  }
+
+  /**
+   * Gets the [Selectable] whose [value][Selectable.value] equals to the given one.
+   *
+   * @param value [Value][Selectable.value] of the [Selectable] to be obtained.
+   */
+  @Suppress("KDocUnresolvedReference")
+  operator fun get(value: T): Selectable<T>? {
+    return find { selectable -> selectable.value == value }
+  }
+
+  /**
+   * Selects the [Selectable] whose [value][Selectable.value] equals to the given one.
+   *
+   * @param value [Value][Selectable.value] of the [Selectable] to be selected.
+   */
+  @Suppress("KDocUnresolvedReference")
+  fun select(value: T): SelectableList<T> {
+    return map(Selectable<T>::value).select(value)
+  }
+
+  /**
+   * Ensures that selection is constrained to zero or one [Selectable]s.
+   *
+   * @throws MultipleSelectionException If more than one [Selectable] are selected.
+   */
+  @Throws(MultipleSelectionException::class)
+  private fun ensureSelectionConstraint() {
+    val hasMultipleSelections = elements.count(Selectable<T>::isSelected) > 1
+    if (hasMultipleSelections) {
+      throw MultipleSelectionException()
     }
-
-    /**
-     * Gets the [Selectable] whose [value][Selectable.value] equals to the given one.
-     *
-     * @param value [Value][Selectable.value] of the [Selectable] to be obtained.
-     **/
-    @Suppress("KDocUnresolvedReference")
-    operator fun get(value: T): Selectable<T>? {
-        return find { selectable ->
-            selectable.value == value
-        }
-    }
-
-    /**
-     * Selects the [Selectable] whose [value][Selectable.value] equals to the given one.
-     *
-     * @param value [Value][Selectable.value] of the [Selectable] to be selected.
-     **/
-    @Suppress("KDocUnresolvedReference")
-    fun select(value: T): SelectableList<T> {
-        return map(Selectable<T>::value).select(value)
-    }
-
-    /**
-     * Ensures that selection is constrained to zero or one [Selectable]s.
-     *
-     * @throws MultipleSelectionException If more than one [Selectable] are selected.
-     **/
-    @Throws(MultipleSelectionException::class)
-    private fun ensureSelectionConstraint() {
-        val hasMultipleSelections = elements.count(Selectable<T>::isSelected) > 1
-        if (hasMultipleSelections) {
-            throw MultipleSelectionException()
-        }
-    }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/viewmodel/Flow.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/viewmodel/Flow.extensions.kt
@@ -9,16 +9,16 @@ import kotlinx.coroutines.launch
  * Converts this [Flow] into a [MutableStateFlow] that mirrors its emissions.
  *
  * @param scope [CoroutineScope] from which this [Flow] will be collected and its emissions will be
- * sent to the created [MutableStateFlow].
+ *   sent to the created [MutableStateFlow].
  * @param initialValue [Value][MutableStateFlow.value] that's initially held by the
- * [MutableStateFlow].
- **/
+ *   [MutableStateFlow].
+ */
 @Suppress("KDocUnresolvedReference")
-internal fun <T> Flow<T>.mutableStateIn(scope: CoroutineScope, initialValue: T):
-    MutableStateFlow<T> {
-    return MutableStateFlow(initialValue).apply {
-        scope.launch {
-            this@mutableStateIn.collect(this@apply)
-        }
-    }
+internal fun <T> Flow<T>.mutableStateIn(
+  scope: CoroutineScope,
+  initialValue: T
+): MutableStateFlow<T> {
+  return MutableStateFlow(initialValue).apply {
+    scope.launch { this@mutableStateIn.collect(this@apply) }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/viewmodel/HttpAuthorizationViewModel.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/viewmodel/HttpAuthorizationViewModel.kt
@@ -46,153 +46,142 @@ import kotlinx.coroutines.flow.onStart
  *
  * @param application [Application] that allows [Context]-specific behavior.
  * @param onAccessTokenRequestListener [OnAccessTokenRequestListener] to be notified when an access
- * token is requested.
- **/
-internal class HttpAuthorizationViewModel private constructor(
-    application: Application,
-    private val onAccessTokenRequestListener: OnAccessTokenRequestListener
+ *   token is requested.
+ */
+internal class HttpAuthorizationViewModel
+private constructor(
+  application: Application,
+  private val onAccessTokenRequestListener: OnAccessTokenRequestListener
 ) : AndroidViewModel(application) {
-    /** [MutableStateFlow] to which the search query will be sent. **/
-    @OptIn(FlowPreview::class)
-    private val searchQueryMutableFlow =
-        emptyFlow<String>().debounce(256.milliseconds).mutableStateIn(
-            viewModelScope,
-            initialValue = ""
+  /** [MutableStateFlow] to which the search query will be sent. */
+  @OptIn(FlowPreview::class)
+  private val searchQueryMutableFlow =
+    emptyFlow<String>().debounce(256.milliseconds).mutableStateIn(viewModelScope, initialValue = "")
+
+  /**
+   * [MutableStateFlow] to which the [SelectableList]s of [Domain]s of [Instance]s wrapped by a
+   * [Loadable] will be sent.
+   */
+  private val instanceDomainSelectablesLoadableMutableFlow =
+    searchQueryMutableFlow
+      .filterNot(String::isBlank)
+      .map { query ->
+        HttpDomainsProvider.provide(query).sortedByDescending { domain ->
+          domain.toString().startsWith(query)
+        }
+      }
+      .onStart { emit(HttpDomainsProvider.provide()) }
+      .map(List<Domain>::selectFirst)
+      .loadable(viewModelScope)
+
+  /** [Application] with which this [HttpAuthorizationViewModel] was created. */
+  private val application
+    @JvmName("_application") get() = getApplication<Application>()
+
+  /** [StateFlow] version of the [searchQueryMutableFlow]. */
+  val searchQueryFlow = searchQueryMutableFlow.asStateFlow()
+
+  /** [StateFlow] version of [instanceDomainSelectablesLoadableMutableFlow]. */
+  val instanceDomainSelectablesLoadableFlow =
+    instanceDomainSelectablesLoadableMutableFlow.asStateFlow()
+
+  /** [Url] to be opened in order to authenticate. */
+  val url
+    get() =
+      URLBuilder()
+        .takeFrom(
+          (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance).url
         )
-
-    /**
-     * [MutableStateFlow] to which the [SelectableList]s of [Domain]s of [Instance]s wrapped by a
-     * [Loadable] will be sent.
-     **/
-    private val instanceDomainSelectablesLoadableMutableFlow = searchQueryMutableFlow
-        .filterNot(String::isBlank)
-        .map { query ->
-            HttpDomainsProvider.provide(query).sortedByDescending { domain ->
-                domain.toString().startsWith(query)
-            }
+        .appendPathSegments("oauth", "authorize")
+        .apply {
+          with(application.getString(R.string.scheme)) {
+            parameters["response_type"] = "code"
+            parameters["client_id"] = Mastodon.CLIENT_ID
+            parameters["redirect_uri"] = application.getString(R.string.redirect_uri, this)
+            parameters["scope"] = Mastodon.SCOPES
+          }
         }
-        .onStart { emit(HttpDomainsProvider.provide()) }
-        .map(List<Domain>::selectFirst)
-        .loadable(viewModelScope)
+        .build()
 
-    /** [Application] with which this [HttpAuthorizationViewModel] was created. **/
-    private val application
-        @JvmName("_application")
-        get() = getApplication<Application>()
+  /**
+   * Searches for [Domain]s matching the given [query].
+   *
+   * @param query Query with which the [Domain]s will be filtered.
+   */
+  fun search(query: String) {
+    searchQueryMutableFlow.value = query
+  }
 
-    /** [StateFlow] version of the [searchQueryMutableFlow]. **/
-    val searchQueryFlow = searchQueryMutableFlow.asStateFlow()
+  /**
+   * Selects the [instanceDomain].
+   *
+   * @param instanceDomain [Domain] to be selected.
+   */
+  fun select(instanceDomain: Domain) {
+    with(instanceDomainSelectablesLoadableMutableFlow) {
+      value.ifLoaded { value = Loadable.Loaded(select(instanceDomain)) }
+    }
+  }
 
-    /** [StateFlow] version of [instanceDomainSelectablesLoadableMutableFlow]. **/
-    val instanceDomainSelectablesLoadableFlow =
-        instanceDomainSelectablesLoadableMutableFlow.asStateFlow()
+  /**
+   * Persists the currently selected [Domain], injects the derived [HttpInstance] and notifies the
+   * [onAccessTokenRequestListener].
+   */
+  fun authorize() {
+    persistSelectedDomain()
+    onAccessTokenRequestListener.onAccessTokenRequest()
+  }
 
-    /** [Url] to be opened in order to authenticate. **/
-    val url
-        get() = URLBuilder()
-            .takeFrom(
-                (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance).url
-            )
-            .appendPathSegments("oauth", "authorize")
-            .apply {
-                with(application.getString(R.string.scheme)) {
-                    parameters["response_type"] = "code"
-                    parameters["client_id"] = Mastodon.CLIENT_ID
-                    parameters["redirect_uri"] = application.getString(R.string.redirect_uri, this)
-                    parameters["scope"] = Mastodon.SCOPES
-                }
-            }
-            .build()
+  /** Persists the [Domain] that's currently selected. */
+  private fun persistSelectedDomain() {
+    instanceDomainSelectablesLoadableFlow.value.ifLoaded {
+      getPreferences(application).edit { putString(INSTANCE_DOMAIN_PREFERENCE_KEY, "$selected") }
+    }
+  }
+
+  companion object {
+    /**
+     * Key through which the [Domain] of the [Instance] in which the user has been authorized can be
+     * retrieved.
+     */
+    private const val INSTANCE_DOMAIN_PREFERENCE_KEY = "instance-domain"
 
     /**
-     * Searches for [Domain]s matching the given [query].
+     * Creates a [ViewModelProvider.Factory] that provides an [HttpAuthorizationViewModel].
      *
-     * @param query Query with which the [Domain]s will be filtered.
-     **/
-    fun search(query: String) {
-        searchQueryMutableFlow.value = query
+     * @param application [Application] for [Context]-specific behavior.
+     * @param onAccessTokenRequestListener [OnAccessTokenRequestListener] to be notified when an
+     *   access token is requested.
+     */
+    fun createFactory(
+      application: Application,
+      onAccessTokenRequestListener: OnAccessTokenRequestListener
+    ): ViewModelProvider.Factory {
+      return viewModelFactory {
+        initializer { HttpAuthorizationViewModel(application, onAccessTokenRequestListener) }
+      }
     }
 
     /**
-     * Selects the [instanceDomain].
+     * Gets the [Domain] that's been persisted when the user was authorized.
      *
-     * @param instanceDomain [Domain] to be selected.
-     **/
-    fun select(instanceDomain: Domain) {
-        with(instanceDomainSelectablesLoadableMutableFlow) {
-            value.ifLoaded {
-                value = Loadable.Loaded(select(instanceDomain))
-            }
-        }
+     * @throws IllegalStateException If this method is called before authorization has completed.
+     */
+    @Throws(IllegalStateException::class)
+    fun getInstanceDomain(context: Context): Domain {
+      return getPreferences(context)
+        .getString(INSTANCE_DOMAIN_PREFERENCE_KEY, null)
+        .let(::checkNotNull)
+        .let(::Domain)
     }
 
     /**
-     * Persists the currently selected [Domain], injects the derived [HttpInstance] and notifies the
-     * [onAccessTokenRequestListener].
-     **/
-    fun authorize() {
-        persistSelectedDomain()
-        onAccessTokenRequestListener.onAccessTokenRequest()
+     * Gets the [SharedPreferences] related to the authorization process.
+     *
+     * @param context [Context] from which the [SharedPreferences] will be obtained.
+     */
+    private fun getPreferences(context: Context): SharedPreferences {
+      return context.getSharedPreferences("http-authorization", Context.MODE_PRIVATE)
     }
-
-    /** Persists the [Domain] that's currently selected. **/
-    private fun persistSelectedDomain() {
-        instanceDomainSelectablesLoadableFlow.value.ifLoaded {
-            getPreferences(application).edit {
-                putString(INSTANCE_DOMAIN_PREFERENCE_KEY, "$selected")
-            }
-        }
-    }
-
-    companion object {
-        /**
-         * Key through which the [Domain] of the [Instance] in which the user has been authorized
-         * can be retrieved.
-         **/
-        private const val INSTANCE_DOMAIN_PREFERENCE_KEY = "instance-domain"
-
-        /**
-         * Creates a [ViewModelProvider.Factory] that provides an [HttpAuthorizationViewModel].
-         *
-         * @param application [Application] for [Context]-specific behavior.
-         * @param onAccessTokenRequestListener [OnAccessTokenRequestListener] to be notified when an
-         * access token is requested.
-         **/
-        fun createFactory(
-            application: Application,
-            onAccessTokenRequestListener: OnAccessTokenRequestListener
-        ): ViewModelProvider.Factory {
-            return viewModelFactory {
-                initializer {
-                    HttpAuthorizationViewModel(
-                        application,
-                        onAccessTokenRequestListener
-                    )
-                }
-            }
-        }
-
-        /**
-         * Gets the [Domain] that's been persisted when the user was authorized.
-         *
-         * @throws IllegalStateException If this method is called before authorization has
-         * completed.
-         **/
-        @Throws(IllegalStateException::class)
-        fun getInstanceDomain(context: Context): Domain {
-            return getPreferences(context)
-                .getString(INSTANCE_DOMAIN_PREFERENCE_KEY, null)
-                .let(::checkNotNull)
-                .let(::Domain)
-        }
-
-        /**
-         * Gets the [SharedPreferences] related to the authorization process.
-         *
-         * @param context [Context] from which the [SharedPreferences] will be obtained.
-         **/
-        private fun getPreferences(context: Context): SharedPreferences {
-            return context.getSharedPreferences("http-authorization", Context.MODE_PRIVATE)
-        }
-    }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/client/Logger.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/client/Logger.kt
@@ -2,53 +2,54 @@ package com.jeanbarrossilva.orca.core.http.client
 
 import android.util.Log
 
-/** Logs messages with different severity levels. **/
+/** Logs messages with different severity levels. */
 abstract class Logger {
-    /**
-     * Logs additional information.
-     *
-     * @param info [String] with the information to be logged.
-     **/
-    internal fun info(info: String) {
-        onInfo(info)
-    }
+  /**
+   * Logs additional information.
+   *
+   * @param info [String] with the information to be logged.
+   */
+  internal fun info(info: String) {
+    onInfo(info)
+  }
 
-    /**
-     * Logs the occurrence of an error.
-     *
-     * @param error [String] describing the error to be logged.
-     **/
-    internal fun error(error: String) {
-        onError(error)
-    }
+  /**
+   * Logs the occurrence of an error.
+   *
+   * @param error [String] describing the error to be logged.
+   */
+  internal fun error(error: String) {
+    onError(error)
+  }
 
-    /**
-     * Logs additional information.
-     *
-     * @param info [String] with the information to be logged.
-     **/
-    protected abstract fun onInfo(info: String)
+  /**
+   * Logs additional information.
+   *
+   * @param info [String] with the information to be logged.
+   */
+  protected abstract fun onInfo(info: String)
 
-    /**
-     * Logs the occurrence of an error.
-     *
-     * @param error [String] describing the error to be logged.
-     **/
-    protected abstract fun onError(error: String)
+  /**
+   * Logs the occurrence of an error.
+   *
+   * @param error [String] describing the error to be logged.
+   */
+  protected abstract fun onError(error: String)
 
-    companion object {
-        /** Tag to which logs sent by [android] will be attached. **/
-        const val ANDROID_LOGGER_TAG = "CoreHttpClient"
+  companion object {
+    /** Tag to which logs sent by [android] will be attached. */
+    const val ANDROID_LOGGER_TAG = "CoreHttpClient"
 
-        /** [Logger] that uses the Android [Log]. **/
-        val android = object : Logger() {
-            override fun onInfo(info: String) {
-                Log.i(ANDROID_LOGGER_TAG, info)
-            }
-
-            override fun onError(error: String) {
-                Log.e(ANDROID_LOGGER_TAG, error)
-            }
+    /** [Logger] that uses the Android [Log]. */
+    val android =
+      object : Logger() {
+        override fun onInfo(info: String) {
+          Log.i(ANDROID_LOGGER_TAG, info)
         }
-    }
+
+        override fun onError(error: String) {
+          Log.e(ANDROID_LOGGER_TAG, error)
+        }
+      }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/FeedTootPaginateSource.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/FeedTootPaginateSource.kt
@@ -3,7 +3,7 @@ package com.jeanbarrossilva.orca.core.http.feed
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.HttpToot
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.pagination.HttpTootPaginateSource
 
-/** [HttpTootPaginateSource] that paginates through [HttpToot]s of the feed. **/
+/** [HttpTootPaginateSource] that paginates through [HttpToot]s of the feed. */
 internal object FeedTootPaginateSource : HttpTootPaginateSource() {
-    override val route = "/api/v1/timelines/home"
+  override val route = "/api/v1/timelines/home"
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/HttpFeedProvider.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/HttpFeedProvider.kt
@@ -9,24 +9,22 @@ import com.jeanbarrossilva.orca.core.http.feed.profile.toot.HttpToot
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.pagination.HttpTootPaginateSource
 import kotlinx.coroutines.flow.Flow
 
-/** [FeedProvider] that requests the feed's [HttpToot]s to the API. **/
-class HttpFeedProvider internal constructor(
-    private val actorProvider: ActorProvider,
-    override val termMuter: TermMuter
-) : FeedProvider() {
-    /** [Flow] of paginated [HttpToot]s to be provided. **/
-    private val flow =
-        FeedTootPaginateSource.loadAllPagesItems(HttpTootPaginateSource.DEFAULT_COUNT)
+/** [FeedProvider] that requests the feed's [HttpToot]s to the API. */
+class HttpFeedProvider
+internal constructor(private val actorProvider: ActorProvider, override val termMuter: TermMuter) :
+  FeedProvider() {
+  /** [Flow] of paginated [HttpToot]s to be provided. */
+  private val flow = FeedTootPaginateSource.loadAllPagesItems(HttpTootPaginateSource.DEFAULT_COUNT)
 
-    override suspend fun onProvide(userID: String, page: Int): Flow<List<HttpToot>> {
-        FeedTootPaginateSource.paginateTo(page)
-        return flow
-    }
+  override suspend fun onProvide(userID: String, page: Int): Flow<List<HttpToot>> {
+    FeedTootPaginateSource.paginateTo(page)
+    return flow
+  }
 
-    override suspend fun containsUser(userID: String): Boolean {
-        return when (actorProvider.provide()) {
-            is Actor.Unauthenticated -> false
-            is Actor.Authenticated -> true
-        }
+  override suspend fun containsUser(userID: String): Boolean {
+    return when (actorProvider.provide()) {
+      is Actor.Unauthenticated -> false
+      is Actor.Authenticated -> true
     }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/HttpProfile.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/HttpProfile.kt
@@ -15,26 +15,24 @@ import kotlinx.coroutines.flow.Flow
  * [tootPaginateSource].
  *
  * @param tootPaginateSourceProvider [ProfileTootPaginateSource] for paginating through the
- * [HttpToot]s.
- **/
+ *   [HttpToot]s.
+ */
 internal data class HttpProfile(
-    private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider,
-    override val id: String,
-    override val account: Account,
-    override val avatarURL: URL,
-    override val name: String,
-    override val bio: StyledString,
-    override val followerCount: Int,
-    override val followingCount: Int,
-    override val url: URL
+  private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider,
+  override val id: String,
+  override val account: Account,
+  override val avatarURL: URL,
+  override val name: String,
+  override val bio: StyledString,
+  override val followerCount: Int,
+  override val followingCount: Int,
+  override val url: URL
 ) : Profile {
-    private val tootPaginateSource = tootPaginateSourceProvider.provide(id)
-    private val tootsFlow = tootPaginateSource.loadAllPagesItems(
-        HttpTootPaginateSource.DEFAULT_COUNT
-    )
+  private val tootPaginateSource = tootPaginateSourceProvider.provide(id)
+  private val tootsFlow = tootPaginateSource.loadAllPagesItems(HttpTootPaginateSource.DEFAULT_COUNT)
 
-    override suspend fun getToots(page: Int): Flow<List<Toot>> {
-        tootPaginateSource.paginateTo(page)
-        return tootsFlow
-    }
+  override suspend fun getToots(page: Int): Flow<List<Toot>> {
+    tootPaginateSource.paginateTo(page)
+    return tootsFlow
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/HttpProfileProvider.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/HttpProfileProvider.kt
@@ -11,15 +11,15 @@ import kotlinx.coroutines.flow.flowOf
  * they're available.
  *
  * @param cache [Cache] of [HttpProfile] by which [HttpProfile]s will be obtained.
- **/
+ */
 class HttpProfileProvider internal constructor(private val cache: Cache<Profile>) :
-    ProfileProvider() {
-    override suspend fun contains(id: String): Boolean {
-        return true
-    }
+  ProfileProvider() {
+  override suspend fun contains(id: String): Boolean {
+    return true
+  }
 
-    override suspend fun onProvide(id: String): Flow<Profile> {
-        val profile = cache.get(id)
-        return flowOf(profile)
-    }
+  override suspend fun onProvide(id: String): Flow<Profile> {
+    val profile = cache.get(id)
+    return flowOf(profile)
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/ProfileTootPaginateSource.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/ProfileTootPaginateSource.kt
@@ -7,18 +7,18 @@ import com.jeanbarrossilva.orca.core.http.feed.profile.toot.pagination.HttpTootP
  * [HttpTootPaginateSource] that paginates through an [HttpProfile]'s [HttpToot]s.
  *
  * @param id ID of the [HttpProfile].
- **/
+ */
 internal class ProfileTootPaginateSource(id: String) : HttpTootPaginateSource() {
-    override val route = "/api/v1/accounts/$id/statuses"
+  override val route = "/api/v1/accounts/$id/statuses"
 
-    /** Provides a [ProfileTootPaginateSource] through [provide]. **/
-    fun interface Provider {
-        /**
-         * Provides a [ProfileTootPaginateSource] that paginates through the [HttpToot]s of an
-         * [HttpProfile] identified as [id].
-         *
-         * id ID of the [HttpProfile].
-         **/
-        fun provide(id: String): ProfileTootPaginateSource
-    }
+  /** Provides a [ProfileTootPaginateSource] through [provide]. */
+  fun interface Provider {
+    /**
+     * Provides a [ProfileTootPaginateSource] that paginates through the [HttpToot]s of an
+     * [HttpProfile] identified as [id].
+     *
+     * id ID of the [HttpProfile].
+     */
+    fun provide(id: String): ProfileTootPaginateSource
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/account/HttpRelationship.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/account/HttpRelationship.kt
@@ -8,22 +8,22 @@ import kotlinx.serialization.Serializable
  * Structure returned by the API when the relationship between two [HttpAccount]s is requested.
  *
  * @param following Whether the currently [authenticated][Actor.Authenticated] [Actor] is following
- * the other [HttpAccount] to which this refers to.
- **/
+ *   the other [HttpAccount] to which this refers to.
+ */
 @Serializable
 internal data class HttpRelationship(val following: Boolean) {
-    /**
-     * Converts this [HttpRelationship] into an [HttpAccount].
-     *
-     * @param account [HttpAccount] of the user that has a relationship with the currently
-     * [authenticated][Actor.Authenticated] [Actor].
-     **/
-    fun toFollow(account: HttpAccount): Follow {
-        return when {
-            account.locked && following -> Follow.Private.following()
-            account.locked -> Follow.Private.unfollowed()
-            following -> Follow.Public.following()
-            else -> Follow.Public.unfollowed()
-        }
+  /**
+   * Converts this [HttpRelationship] into an [HttpAccount].
+   *
+   * @param account [HttpAccount] of the user that has a relationship with the currently
+   *   [authenticated][Actor.Authenticated] [Actor].
+   */
+  fun toFollow(account: HttpAccount): Follow {
+    return when {
+      account.locked && following -> Follow.Private.following()
+      account.locked -> Follow.Private.unfollowed()
+      following -> Follow.Public.following()
+      else -> Follow.Public.unfollowed()
     }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/cache/HttpProfileFetcher.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/cache/HttpProfileFetcher.kt
@@ -16,17 +16,17 @@ import io.ktor.client.call.body
  * [Fetcher] for [Profile]s.
  *
  * @param tootPaginateSourceProvider [ProfileTootPaginateSource.Provider] by which a
- * [ProfileTootPaginateSource] for paginating through a [HttpProfile]'s [HttpToot]s will be
- * provided.
- **/
+ *   [ProfileTootPaginateSource] for paginating through a [HttpProfile]'s [HttpToot]s will be
+ *   provided.
+ */
 internal class HttpProfileFetcher(
-    private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
+  private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
 ) : Fetcher<Profile>() {
-    override suspend fun onFetch(key: String): Profile {
-        return (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
-            .client
-            .authenticateAndGet("/api/v1/accounts/$key")
-            .body<HttpAccount>()
-            .toProfile(tootPaginateSourceProvider)
-    }
+  override suspend fun onFetch(key: String): Profile {
+    return (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+      .client
+      .authenticateAndGet("/api/v1/accounts/$key")
+      .body<HttpAccount>()
+      .toProfile(tootPaginateSourceProvider)
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/cache/storage/HttpProfileEntity.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/cache/storage/HttpProfileEntity.kt
@@ -23,110 +23,108 @@ import java.net.URL
  * @param avatarURL URL [String] that leads to the avatar image.
  * @param bio Describes who the owner is and/or provides information regarding the [HttpProfile].
  * @param type Determines whether the [HttpProfile] is an [HttpEditableProfile] or an
- * [HttpFollowableProfile].
+ *   [HttpFollowableProfile].
  * @param follow [String] version of the [HttpFollowableProfile]'s
- * [follow][HttpFollowableProfile.follow] or `null` if the [HttpProfile] is of a different type.
+ *   [follow][HttpFollowableProfile.follow] or `null` if the [HttpProfile] is of a different type.
  * @param followerCount Amount of followers the [HttpProfile] has.
  * @param followingCount Amount of other [HttpProfile]s the one this [HttpProfileEntity] refers to
- * follows.
- **/
+ *   follows.
+ */
 @Entity(tableName = "profiles")
-data class HttpProfileEntity internal constructor(
-    @PrimaryKey internal val id: String,
-    internal val account: String,
-    @ColumnInfo(name = "avatar_url") internal val avatarURL: String,
-    internal val name: String,
-    internal val bio: String,
-    @Type internal val type: Int,
-    internal val follow: String?,
-    @ColumnInfo(name = "follower_count") internal val followerCount: Int,
-    @ColumnInfo(name = "following_count") internal val followingCount: Int,
-    internal val url: String
+data class HttpProfileEntity
+internal constructor(
+  @PrimaryKey internal val id: String,
+  internal val account: String,
+  @ColumnInfo(name = "avatar_url") internal val avatarURL: String,
+  internal val name: String,
+  internal val bio: String,
+  @Type internal val type: Int,
+  internal val follow: String?,
+  @ColumnInfo(name = "follower_count") internal val followerCount: Int,
+  @ColumnInfo(name = "following_count") internal val followingCount: Int,
+  internal val url: String
 ) {
-    /** Constrains the [type] to the known ones. **/
-    @IntDef(EDITABLE_TYPE, FOLLOWABLE_TYPE)
-    internal annotation class Type
+  /** Constrains the [type] to the known ones. */
+  @IntDef(EDITABLE_TYPE, FOLLOWABLE_TYPE) internal annotation class Type
 
-    /**
-     * Converts this [HttpProfileEntity] into a [Profile].
-     *
-     * @param tootPaginateSourceProvider [ProfileTootPaginateSource.Provider] by which a
-     * [ProfileTootPaginateSource] for paginating through the resulting [HttpProfile]'s [HttpToot]s
-     * will be provided.
-     * @throws IllegalStateException If the [type] is unknown.
-     **/
-    @Throws(IllegalStateException::class)
-    internal fun toProfile(
-        tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
-    ): Profile {
-        return when (type) {
-            EDITABLE_TYPE -> toMastodonEditableProfile(tootPaginateSourceProvider)
-            FOLLOWABLE_TYPE -> toMastodonFollowableProfile(tootPaginateSourceProvider)
-            else -> throw IllegalStateException("Unknown profile entity type: $type.")
-        }
+  /**
+   * Converts this [HttpProfileEntity] into a [Profile].
+   *
+   * @param tootPaginateSourceProvider [ProfileTootPaginateSource.Provider] by which a
+   *   [ProfileTootPaginateSource] for paginating through the resulting [HttpProfile]'s [HttpToot]s
+   *   will be provided.
+   * @throws IllegalStateException If the [type] is unknown.
+   */
+  @Throws(IllegalStateException::class)
+  internal fun toProfile(tootPaginateSourceProvider: ProfileTootPaginateSource.Provider): Profile {
+    return when (type) {
+      EDITABLE_TYPE -> toMastodonEditableProfile(tootPaginateSourceProvider)
+      FOLLOWABLE_TYPE -> toMastodonFollowableProfile(tootPaginateSourceProvider)
+      else -> throw IllegalStateException("Unknown profile entity type: $type.")
     }
+  }
 
-    /**
-     * Converts this [HttpProfileEntity] into an [HttpEditableProfile].
-     *
-     * @param tootPaginateSourceProvider [ProfileTootPaginateSource.Provider] by which a
-     * [ProfileTootPaginateSource] for paginating through the resulting [HttpEditableProfile]'s
-     * [HttpToot]s will be provided.
-     **/
-    private fun toMastodonEditableProfile(
-        tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
-    ): HttpEditableProfile {
-        val account = Account.of(account)
-        val avatarURL = URL(avatarURL)
-        val bio = bio.toStyledString()
-        val url = URL(url)
-        return HttpEditableProfile(
-            tootPaginateSourceProvider,
-            id,
-            account,
-            avatarURL,
-            name,
-            bio,
-            followerCount,
-            followingCount,
-            url
-        )
-    }
+  /**
+   * Converts this [HttpProfileEntity] into an [HttpEditableProfile].
+   *
+   * @param tootPaginateSourceProvider [ProfileTootPaginateSource.Provider] by which a
+   *   [ProfileTootPaginateSource] for paginating through the resulting [HttpEditableProfile]'s
+   *   [HttpToot]s will be provided.
+   */
+  private fun toMastodonEditableProfile(
+    tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
+  ): HttpEditableProfile {
+    val account = Account.of(account)
+    val avatarURL = URL(avatarURL)
+    val bio = bio.toStyledString()
+    val url = URL(url)
+    return HttpEditableProfile(
+      tootPaginateSourceProvider,
+      id,
+      account,
+      avatarURL,
+      name,
+      bio,
+      followerCount,
+      followingCount,
+      url
+    )
+  }
 
-    /**
-     * Converts this [HttpProfileEntity] into an [HttpFollowableProfile].
-     *
-     * @param tootPaginateSourceProvider [ProfileTootPaginateSource.Provider] by which a
-     * [ProfileTootPaginateSource] for paginating through the resulting [HttpFollowableProfile]'s
-     * [HttpToot]s will be provided.
-     **/
-    private fun toMastodonFollowableProfile(
-        tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
-    ): HttpFollowableProfile<Follow> {
-        val account = Account.of(account)
-        val avatarURL = URL(avatarURL)
-        val bio = bio.toStyledString()
-        val follow = Follow.of(checkNotNull(follow))
-        val url = URL(url)
-        return HttpFollowableProfile(
-            tootPaginateSourceProvider,
-            id,
-            account,
-            avatarURL,
-            name,
-            bio,
-            follow,
-            followerCount,
-            followingCount,
-            url
-        )
-    }
+  /**
+   * Converts this [HttpProfileEntity] into an [HttpFollowableProfile].
+   *
+   * @param tootPaginateSourceProvider [ProfileTootPaginateSource.Provider] by which a
+   *   [ProfileTootPaginateSource] for paginating through the resulting [HttpFollowableProfile]'s
+   *   [HttpToot]s will be provided.
+   */
+  private fun toMastodonFollowableProfile(
+    tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
+  ): HttpFollowableProfile<Follow> {
+    val account = Account.of(account)
+    val avatarURL = URL(avatarURL)
+    val bio = bio.toStyledString()
+    val follow = Follow.of(checkNotNull(follow))
+    val url = URL(url)
+    return HttpFollowableProfile(
+      tootPaginateSourceProvider,
+      id,
+      account,
+      avatarURL,
+      name,
+      bio,
+      follow,
+      followerCount,
+      followingCount,
+      url
+    )
+  }
 
-    companion object {
-        /** [Int] that represents an [HttpEditableProfile]. **/
-        internal const val EDITABLE_TYPE = 0
+  companion object {
+    /** [Int] that represents an [HttpEditableProfile]. */
+    internal const val EDITABLE_TYPE = 0
 
-        /** [Int] that represents an [HttpFollowableProfile]. **/
-        internal const val FOLLOWABLE_TYPE = 1
-    }
+    /** [Int] that represents an [HttpFollowableProfile]. */
+    internal const val FOLLOWABLE_TYPE = 1
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/cache/storage/HttpProfileEntityDao.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/cache/storage/HttpProfileEntityDao.kt
@@ -6,43 +6,39 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
 
-/** Performs SQL transactions regarding [HTTP profile entities][HttpProfileEntity]. **/
+/** Performs SQL transactions regarding [HTTP profile entities][HttpProfileEntity]. */
 @Dao
 internal interface HttpProfileEntityDao {
-    /**
-     * Returns the amount of [HTTP profile entities][HttpProfileEntity] identified as [id].
-     *
-     * @param id ID for which the counting will be performed.
-     **/
-    @Query("SELECT COUNT(id) FROM profiles WHERE id = :id")
-    suspend fun count(id: String): Int
+  /**
+   * Returns the amount of [HTTP profile entities][HttpProfileEntity] identified as [id].
+   *
+   * @param id ID for which the counting will be performed.
+   */
+  @Query("SELECT COUNT(id) FROM profiles WHERE id = :id") suspend fun count(id: String): Int
 
-    /**
-     * Returns a [Flow] to which the [HttpProfileEntity] identified as [id] will be emitted or an
-     * empty one if none is found.
-     *
-     * @param id ID of the [HttpProfileEntity] to be obtained.
-     **/
-    @Query("SELECT * FROM profiles WHERE id = :id LIMIT 1")
-    fun selectByID(id: String): Flow<HttpProfileEntity>
+  /**
+   * Returns a [Flow] to which the [HttpProfileEntity] identified as [id] will be emitted or an
+   * empty one if none is found.
+   *
+   * @param id ID of the [HttpProfileEntity] to be obtained.
+   */
+  @Query("SELECT * FROM profiles WHERE id = :id LIMIT 1")
+  fun selectByID(id: String): Flow<HttpProfileEntity>
 
-    /**
-     * Inserts the [entity].
-     *
-     * @param entity [HttpProfileEntity] to be inserted.
-     **/
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(entity: HttpProfileEntity)
+  /**
+   * Inserts the [entity].
+   *
+   * @param entity [HttpProfileEntity] to be inserted.
+   */
+  @Insert(onConflict = OnConflictStrategy.REPLACE) suspend fun insert(entity: HttpProfileEntity)
 
-    /**
-     * Deletes the [HttpProfileEntity] identified as [id].
-     *
-     * @param id ID of the [HttpProfileEntity] to be deleted.
-     **/
-    @Query("DELETE FROM profiles WHERE id = :id")
-    suspend fun delete(id: String)
+  /**
+   * Deletes the [HttpProfileEntity] identified as [id].
+   *
+   * @param id ID of the [HttpProfileEntity] to be deleted.
+   */
+  @Query("DELETE FROM profiles WHERE id = :id") suspend fun delete(id: String)
 
-    /** Deletes all [HTTP profile entities][HttpProfileEntity]. **/
-    @Query("DELETE FROM profiles")
-    suspend fun deleteAll()
+  /** Deletes all [HTTP profile entities][HttpProfileEntity]. */
+  @Query("DELETE FROM profiles") suspend fun deleteAll()
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/cache/storage/HttpProfileStorage.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/cache/storage/HttpProfileStorage.kt
@@ -11,33 +11,33 @@ import kotlinx.coroutines.flow.first
  * [Storage] for [Profile]s.
  *
  * @param tootPaginateSourceProvider [ProfileTootPaginateSource.Provider] by which a
- * [ProfileTootPaginateSource] for paginating through a [HttpProfile]'s [HttpToot]s will be
- * provided.
+ *   [ProfileTootPaginateSource] for paginating through a [HttpProfile]'s [HttpToot]s will be
+ *   provided.
  * @param entityDao [HttpProfileEntityDao] that will perform SQL transactions on
- * [HTTP profile entities][HttpProfileEntity].
- **/
+ *   [HTTP profile entities][HttpProfileEntity].
+ */
 internal class HttpProfileStorage(
-    private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider,
-    private val entityDao: HttpProfileEntityDao
+  private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider,
+  private val entityDao: HttpProfileEntityDao
 ) : Storage<Profile>() {
-    override suspend fun onStore(key: String, value: Profile) {
-        val entity = value.toMastodonProfileEntity().copy(id = key)
-        entityDao.insert(entity)
-    }
+  override suspend fun onStore(key: String, value: Profile) {
+    val entity = value.toMastodonProfileEntity().copy(id = key)
+    entityDao.insert(entity)
+  }
 
-    override suspend fun onContains(key: String): Boolean {
-        return entityDao.count(key) > 0
-    }
+  override suspend fun onContains(key: String): Boolean {
+    return entityDao.count(key) > 0
+  }
 
-    override suspend fun onGet(key: String): Profile {
-        return entityDao.selectByID(key).first().toProfile(tootPaginateSourceProvider)
-    }
+  override suspend fun onGet(key: String): Profile {
+    return entityDao.selectByID(key).first().toProfile(tootPaginateSourceProvider)
+  }
 
-    override suspend fun onRemove(key: String) {
-        entityDao.delete(key)
-    }
+  override suspend fun onRemove(key: String) {
+    entityDao.delete(key)
+  }
 
-    override suspend fun onClear() {
-        entityDao.deleteAll()
-    }
+  override suspend fun onClear() {
+    entityDao.deleteAll()
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/cache/storage/Profile.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/cache/storage/Profile.extensions.kt
@@ -8,24 +8,25 @@ import com.jeanbarrossilva.orca.core.feed.profile.type.followable.FollowableProf
  * Converts this [Profile] into an [HttpProfileEntity].
  *
  * @throws IllegalStateException If no [HttpProfileEntity] type has been mapped to this specific
- * type of [Profile].
+ *   type of [Profile].
  * @see HttpProfileEntity.Type
- **/
+ */
 internal fun Profile.toMastodonProfileEntity(): HttpProfileEntity {
-    return HttpProfileEntity(
-        id,
-        "$account",
-        "$avatarURL",
-        name,
-        "$bio",
-        type = when (this) {
-            is EditableProfile -> HttpProfileEntity.EDITABLE_TYPE
-            is FollowableProfile<*> -> HttpProfileEntity.FOLLOWABLE_TYPE
-            else -> throw IllegalStateException("No entity type for ${this::class.simpleName}.")
-        },
-        follow = if (this is FollowableProfile<*>) "$follow" else null,
-        followerCount,
-        followingCount,
-        "$url"
-    )
+  return HttpProfileEntity(
+    id,
+    "$account",
+    "$avatarURL",
+    name,
+    "$bio",
+    type =
+      when (this) {
+        is EditableProfile -> HttpProfileEntity.EDITABLE_TYPE
+        is FollowableProfile<*> -> HttpProfileEntity.FOLLOWABLE_TYPE
+        else -> throw IllegalStateException("No entity type for ${this::class.simpleName}.")
+      },
+    follow = if (this is FollowableProfile<*>) "$follow" else null,
+    followerCount,
+    followingCount,
+    "$url"
+  )
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/HttpProfileSearcher.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/HttpProfileSearcher.kt
@@ -10,25 +10,24 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
- * [ProfileSearcher] that searches for [ProfileSearchResult]s and caches them to prevent excessive resource
- * consumption.
+ * [ProfileSearcher] that searches for [ProfileSearchResult]s and caches them to prevent excessive
+ * resource consumption.
  *
  * @param cache [Cache] by which the [ProfileSearchResult]s will be cached.
- **/
-class HttpProfileSearcher internal constructor(
-    private val cache: Cache<List<ProfileSearchResult>>
-) : ProfileSearcher() {
-    /**
-     * [MutableStateFlow] to which searched [Loadable]s of [ProfileSearchResult] are emitted and
-     * that is later unwrapped.
-     *
-     * @see unwrap
-     **/
-    private val searchResultsFlow = loadableFlow<List<ProfileSearchResult>>()
+ */
+class HttpProfileSearcher
+internal constructor(private val cache: Cache<List<ProfileSearchResult>>) : ProfileSearcher() {
+  /**
+   * [MutableStateFlow] to which searched [Loadable]s of [ProfileSearchResult] are emitted and that
+   * is later unwrapped.
+   *
+   * @see unwrap
+   */
+  private val searchResultsFlow = loadableFlow<List<ProfileSearchResult>>()
 
-    override suspend fun onSearch(query: String): Flow<List<ProfileSearchResult>> {
-        val searchResults = cache.get(query)
-        searchResultsFlow.value = Loadable.Loaded(searchResults)
-        return searchResultsFlow.unwrap()
-    }
+  override suspend fun onSearch(query: String): Flow<List<ProfileSearchResult>> {
+    val searchResults = cache.get(query)
+    searchResultsFlow.value = Loadable.Loaded(searchResults)
+    return searchResultsFlow.unwrap()
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/HttpProfileSearchResultsFetcher.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/HttpProfileSearchResultsFetcher.kt
@@ -14,13 +14,13 @@ import io.ktor.client.call.body
 import io.ktor.client.request.parameter
 
 internal class HttpProfileSearchResultsFetcher(
-    private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
+  private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
 ) : Fetcher<List<ProfileSearchResult>>() {
-    override suspend fun onFetch(key: String): List<ProfileSearchResult> {
-        return (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
-            .client
-            .authenticateAndGet("/api/v1/accounts/search") { parameter("q", key) }
-            .body<List<HttpAccount>>()
-            .map { it.toProfile(tootPaginateSourceProvider).toProfileSearchResult() }
-    }
+  override suspend fun onFetch(key: String): List<ProfileSearchResult> {
+    return (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+      .client
+      .authenticateAndGet("/api/v1/accounts/search") { parameter("q", key) }
+      .body<List<HttpAccount>>()
+      .map { it.toProfile(tootPaginateSourceProvider).toProfileSearchResult() }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/storage/HttpProfileSearchResultEntity.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/storage/HttpProfileSearchResultEntity.kt
@@ -13,25 +13,25 @@ import java.net.URL
  * @param query Search query to which the [ProfileSearchResult] is associated.
  * @param id Unique identifier.
  * @param account [String] representation of the [HttpProfileSearchResultEntity]'s
- * [account][HttpProfileSearchResultEntity.account].
+ *   [account][HttpProfileSearchResultEntity.account].
  * @param avatarURL URL [String] that leads to the avatar image.
  * @param name Name to be displayed.
  * @param url URL [String] that leads to the owner.
- **/
+ */
 @Entity(tableName = "profile_search_results")
 data class HttpProfileSearchResultEntity(
-    @PrimaryKey internal val query: String,
-    internal val id: String,
-    internal val account: String,
-    @ColumnInfo(name = "avatar_url") internal val avatarURL: String,
-    internal val name: String,
-    internal val url: String
+  @PrimaryKey internal val query: String,
+  internal val id: String,
+  internal val account: String,
+  @ColumnInfo(name = "avatar_url") internal val avatarURL: String,
+  internal val name: String,
+  internal val url: String
 ) {
-    /** Converts this [HttpProfileSearchResultEntity] into a [ProfileSearchResult]. **/
-    internal fun toProfileSearchResult(): ProfileSearchResult {
-        val account = Account.of(account, fallbackDomain = "mastodon.social")
-        val avatarURL = URL(avatarURL)
-        val url = URL(url)
-        return ProfileSearchResult(id, account, avatarURL, name, url)
-    }
+  /** Converts this [HttpProfileSearchResultEntity] into a [ProfileSearchResult]. */
+  internal fun toProfileSearchResult(): ProfileSearchResult {
+    val account = Account.of(account, fallbackDomain = "mastodon.social")
+    val avatarURL = URL(avatarURL)
+    val url = URL(url)
+    return ProfileSearchResult(id, account, avatarURL, name, url)
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/storage/HttpProfileSearchResultEntityDao.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/storage/HttpProfileSearchResultEntityDao.kt
@@ -9,53 +9,52 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Performs SQL transactions regarding
  * [HTTP profile search result entities][HttpProfileSearchResultEntity].
- **/
+ */
 @Dao
 internal interface HttpProfileSearchResultEntityDao {
-    /**
-     * Returns the amount of [HTTP profile search result entities][HttpProfileSearchResultEntity]
-     * that have been previously found by searching with the given [query].
-     *
-     * @param query Query through which the
-     * [HTTP profile search result entities][HttpProfileSearchResultEntity] to be counted have been
-     * found.
-     **/
-    @Query("SELECT COUNT() FROM profile_search_results WHERE `query` = :query")
-    suspend fun count(query: String): Int
+  /**
+   * Returns the amount of [HTTP profile search result entities][HttpProfileSearchResultEntity] that
+   * have been previously found by searching with the given [query].
+   *
+   * @param query Query through which the
+   *   [HTTP profile search result entities][HttpProfileSearchResultEntity] to be counted have been
+   *   found.
+   */
+  @Query("SELECT COUNT() FROM profile_search_results WHERE `query` = :query")
+  suspend fun count(query: String): Int
 
-    /**
-     * Returns a [Flow] to which the [HttpProfileSearchResultEntity] that's been previously found by
-     * searching with the given [query] will be emitted or an empty one either if none has or if no
-     * [HTTP profile search result entities][HttpProfileSearchResultEntity] were persisted with this
-     * constraint.
-     *
-     * @param query Query through which the [HttpProfileSearchResultEntity] to be obtained has
-     * been found.
-     **/
-    @Query("SELECT * FROM profile_search_results WHERE `query` = :query")
-    fun selectByQuery(query: String): Flow<List<HttpProfileSearchResultEntity>>
+  /**
+   * Returns a [Flow] to which the [HttpProfileSearchResultEntity] that's been previously found by
+   * searching with the given [query] will be emitted or an empty one either if none has or if no
+   * [HTTP profile search result entities][HttpProfileSearchResultEntity] were persisted with this
+   * constraint.
+   *
+   * @param query Query through which the [HttpProfileSearchResultEntity] to be obtained has been
+   *   found.
+   */
+  @Query("SELECT * FROM profile_search_results WHERE `query` = :query")
+  fun selectByQuery(query: String): Flow<List<HttpProfileSearchResultEntity>>
 
-    /**
-     * Inserts the [entities].
-     *
-     * @param entities [HTTP profile search result entities][HttpProfileSearchResultEntity] to be
-     * inserted.
-     **/
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(entities: List<HttpProfileSearchResultEntity>)
+  /**
+   * Inserts the [entities].
+   *
+   * @param entities [HTTP profile search result entities][HttpProfileSearchResultEntity] to be
+   *   inserted.
+   */
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun insert(entities: List<HttpProfileSearchResultEntity>)
 
-    /**
-     * Deletes [HTTP profile search result entities][HttpProfileSearchResultEntity] that have been
-     * found by searching with the given [query].
-     *
-     * @param query Query through which the
-     * [HTTP profile search result entities][HttpProfileSearchResultEntity] to be deleted have been
-     * found.
-     **/
-    @Query("DELETE FROM profile_search_results WHERE `query` = :query")
-    suspend fun delete(query: String)
+  /**
+   * Deletes [HTTP profile search result entities][HttpProfileSearchResultEntity] that have been
+   * found by searching with the given [query].
+   *
+   * @param query Query through which the
+   *   [HTTP profile search result entities][HttpProfileSearchResultEntity] to be deleted have been
+   *   found.
+   */
+  @Query("DELETE FROM profile_search_results WHERE `query` = :query")
+  suspend fun delete(query: String)
 
-    /** Deletes all [HTTP profile search result entities][HttpProfileSearchResultEntity]. **/
-    @Query("DELETE FROM profile_search_results")
-    suspend fun deleteAll()
+  /** Deletes all [HTTP profile search result entities][HttpProfileSearchResultEntity]. */
+  @Query("DELETE FROM profile_search_results") suspend fun deleteAll()
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/storage/HttpProfileSearchResultsStorage.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/storage/HttpProfileSearchResultsStorage.kt
@@ -5,28 +5,29 @@ import com.jeanbarrossilva.orca.platform.cache.Storage
 import kotlinx.coroutines.flow.first
 
 internal class HttpProfileSearchResultsStorage(
-    private val entityDao: HttpProfileSearchResultEntityDao
+  private val entityDao: HttpProfileSearchResultEntityDao
 ) : Storage<List<ProfileSearchResult>>() {
-    override suspend fun onStore(key: String, value: List<ProfileSearchResult>) {
-        val entities = value.map { it.toProfileSearchResultEntity(key) }
-        entityDao.insert(entities)
-    }
+  override suspend fun onStore(key: String, value: List<ProfileSearchResult>) {
+    val entities = value.map { it.toProfileSearchResultEntity(key) }
+    entityDao.insert(entities)
+  }
 
-    override suspend fun onContains(key: String): Boolean {
-        return entityDao.count(key) > 0
-    }
+  override suspend fun onContains(key: String): Boolean {
+    return entityDao.count(key) > 0
+  }
 
-    override suspend fun onGet(key: String): List<ProfileSearchResult> {
-        return entityDao.selectByQuery(key).first().map(
-            HttpProfileSearchResultEntity::toProfileSearchResult
-        )
-    }
+  override suspend fun onGet(key: String): List<ProfileSearchResult> {
+    return entityDao
+      .selectByQuery(key)
+      .first()
+      .map(HttpProfileSearchResultEntity::toProfileSearchResult)
+  }
 
-    override suspend fun onRemove(key: String) {
-        entityDao.delete(key)
-    }
+  override suspend fun onRemove(key: String) {
+    entityDao.delete(key)
+  }
 
-    override suspend fun onClear() {
-        entityDao.deleteAll()
-    }
+  override suspend fun onClear() {
+    entityDao.deleteAll()
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/storage/ProfileSearchResult.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/storage/ProfileSearchResult.extensions.kt
@@ -6,8 +6,9 @@ import com.jeanbarrossilva.orca.core.feed.profile.search.ProfileSearchResult
  * Converts this [ProfileSearchResult] into an [HttpProfileSearchResultEntity].
  *
  * @param query Query with which this [ProfileSearchResult] was obtained.
- **/
-internal fun ProfileSearchResult.toProfileSearchResultEntity(query: String):
-    HttpProfileSearchResultEntity {
-    return HttpProfileSearchResultEntity(query, id, "$account", "$avatarURL", name, "$url")
+ */
+internal fun ProfileSearchResult.toProfileSearchResultEntity(
+  query: String
+): HttpProfileSearchResultEntity {
+  return HttpProfileSearchResultEntity(query, id, "$account", "$avatarURL", name, "$url")
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/HttpContext.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/HttpContext.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
  *
  * @param ancestors [HttpStatus]es to which the referred one is a comment.
  * @param descendants [HttpStatus]es that have been published as comments to the one this
- * [HttpContext] refers to.
- **/
+ *   [HttpContext] refers to.
+ */
 @Serializable
 internal data class HttpContext(val ancestors: List<HttpStatus>, val descendants: List<HttpStatus>)

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/HttpToot.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/HttpToot.kt
@@ -16,18 +16,19 @@ import java.time.ZonedDateTime
  * @param commentCount Amount of comments that this [HttpToot] has received.
  * @param favoriteCount Amount of times that this [HttpToot] has been marked as favorite.
  * @param reblogCount Amount of times that this [HttpToot] has been reblogged.
- **/
-data class HttpToot internal constructor(
-    override val id: String,
-    override val author: Author,
-    override val content: Content,
-    override val publicationDateTime: ZonedDateTime,
-    private val commentCount: Int,
-    private val favoriteCount: Int,
-    private val reblogCount: Int,
-    override val url: URL
+ */
+data class HttpToot
+internal constructor(
+  override val id: String,
+  override val author: Author,
+  override val content: Content,
+  override val publicationDateTime: ZonedDateTime,
+  private val commentCount: Int,
+  private val favoriteCount: Int,
+  private val reblogCount: Int,
+  override val url: URL
 ) : Toot() {
-    override val comment = CommentStat(id, commentCount)
-    override val favorite = FavoriteStat(id, favoriteCount)
-    override val reblog = ReblogStat(id, reblogCount)
+  override val comment = CommentStat(id, commentCount)
+  override val favorite = FavoriteStat(id, favoriteCount)
+  override val reblog = ReblogStat(id, reblogCount)
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/HttpTootProvider.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/HttpTootProvider.kt
@@ -10,10 +10,10 @@ import kotlinx.coroutines.flow.flowOf
  * available.
  *
  * @param cache [Cache] of [HttpToot]s by which [HttpToot]s will be obtained.
- **/
+ */
 class HttpTootProvider internal constructor(private val cache: Cache<HttpToot>) : TootProvider {
-    override suspend fun provide(id: String): Flow<HttpToot> {
-        val toot = cache.get(id)
-        return flowOf(toot)
-    }
+  override suspend fun provide(id: String): Flow<HttpToot> {
+    val toot = cache.get(id)
+    return flowOf(toot)
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/HttpTootFetcher.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/HttpTootFetcher.kt
@@ -10,13 +10,13 @@ import com.jeanbarrossilva.orca.platform.cache.Fetcher
 import com.jeanbarrossilva.orca.std.injector.Injector
 import io.ktor.client.call.body
 
-/** [Fetcher] that requests [HttpToot]s to the API. **/
+/** [Fetcher] that requests [HttpToot]s to the API. */
 internal object HttpTootFetcher : Fetcher<HttpToot>() {
-    override suspend fun onFetch(key: String): HttpToot {
-        return (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
-            .client
-            .authenticateAndGet("/api/v1/statuses/$key")
-            .body<HttpStatus>()
-            .toToot()
-    }
+  override suspend fun onFetch(key: String): HttpToot {
+    return (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+      .client
+      .authenticateAndGet("/api/v1/statuses/$key")
+      .body<HttpStatus>()
+      .toToot()
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/HttpTootEntity.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/HttpTootEntity.kt
@@ -23,90 +23,91 @@ import java.time.ZonedDateTime
  * @param id Unique identifier.
  * @param authorID ID of the [Author] that has authored the [HttpToot].
  * @param headlineTitle Title of the [HttpToot]'s [content][HttpToot.content]'s
- * [highlight][Content.highlight] [headline][Highlight.headline].
+ *   [highlight][Content.highlight] [headline][Highlight.headline].
  * @param headlineSubtitle Subtitle of the [HttpToot]'s [content][HttpToot.content]'s
- * [highlight][Content.highlight] [headline][Highlight.headline].
+ *   [highlight][Content.highlight] [headline][Highlight.headline].
  * @param headlineCoverURL URL [String] that leads to the cover image of the [HttpToot]'s
- * [content][HttpToot.content]'s [highlight][Content.highlight] [headline][Highlight.headline].
+ *   [content][HttpToot.content]'s [highlight][Content.highlight] [headline][Highlight.headline].
  * @param publicationDateTime [String] representation of the moment in which the [HttpToot] was
- * published.
+ *   published.
  * @param commentCount Amount of comments that the [HttpToot] has received.
  * @param isFavorite Whether the [HttpToot] has been favorited by the currently
- * [authenticated][Actor.Authenticated] [Actor].
+ *   [authenticated][Actor.Authenticated] [Actor].
  * @param isReblogged Whether the [HttpToot] is reblogged.
  * @param reblogCount Amount of times the [HttpToot] has been reblogged.
  * @param url URL [String] that leads to the [HttpToot].
- **/
+ */
 @Entity(tableName = "toots")
 internal data class HttpTootEntity(
-    @PrimaryKey val id: String,
-    @ColumnInfo(name = "author_id") val authorID: String,
-    val text: String,
-    @ColumnInfo(name = "headline_title") val headlineTitle: String?,
-    @ColumnInfo(name = "headline_subtitle") val headlineSubtitle: String?,
-    @ColumnInfo(name = "headline_cover_url") val headlineCoverURL: String?,
-    @ColumnInfo(name = "publication_date_time") val publicationDateTime: String,
-    @ColumnInfo(name = "comment_count") val commentCount: Int,
-    @ColumnInfo(name = "is_favorite") val isFavorite: Boolean,
-    @ColumnInfo(name = "favorite_count") val favoriteCount: Int,
-    @ColumnInfo(name = "is_reblogged") val isReblogged: Boolean,
-    @ColumnInfo(name = "reblog_count") val reblogCount: Int,
-    @ColumnInfo(name = "url") val url: String
+  @PrimaryKey val id: String,
+  @ColumnInfo(name = "author_id") val authorID: String,
+  val text: String,
+  @ColumnInfo(name = "headline_title") val headlineTitle: String?,
+  @ColumnInfo(name = "headline_subtitle") val headlineSubtitle: String?,
+  @ColumnInfo(name = "headline_cover_url") val headlineCoverURL: String?,
+  @ColumnInfo(name = "publication_date_time") val publicationDateTime: String,
+  @ColumnInfo(name = "comment_count") val commentCount: Int,
+  @ColumnInfo(name = "is_favorite") val isFavorite: Boolean,
+  @ColumnInfo(name = "favorite_count") val favoriteCount: Int,
+  @ColumnInfo(name = "is_reblogged") val isReblogged: Boolean,
+  @ColumnInfo(name = "reblog_count") val reblogCount: Int,
+  @ColumnInfo(name = "url") val url: String
 ) {
-    /**
-     * Converts this [HttpTootEntity] into an [HttpToot].
-     *
-     * @param profileCache [Cache] from which the [Author]'s [Profile] will be retrieved.
-     * @param dao [HttpTootEntityDao] that will select the persisted
-     * [HTTP style entities][HttpStyleEntity].
-     **/
-    suspend fun toHttpToot(profileCache: Cache<Profile>, dao: HttpTootEntityDao): HttpToot {
-        val author = profileCache.get(authorID).toAuthor()
-        val styles = dao.selectWithStylesByID(id).styles
-        val text = text.toStyledString { URL(styles.startingAt(it).url) }
-        val content = Content.from(text) {
-            if (headlineTitle != null && headlineCoverURL != null) {
-                Headline(headlineTitle, headlineSubtitle, URL(headlineCoverURL))
-            } else {
-                null
-            }
+  /**
+   * Converts this [HttpTootEntity] into an [HttpToot].
+   *
+   * @param profileCache [Cache] from which the [Author]'s [Profile] will be retrieved.
+   * @param dao [HttpTootEntityDao] that will select the persisted
+   *   [HTTP style entities][HttpStyleEntity].
+   */
+  suspend fun toHttpToot(profileCache: Cache<Profile>, dao: HttpTootEntityDao): HttpToot {
+    val author = profileCache.get(authorID).toAuthor()
+    val styles = dao.selectWithStylesByID(id).styles
+    val text = text.toStyledString { URL(styles.startingAt(it).url) }
+    val content =
+      Content.from(text) {
+        if (headlineTitle != null && headlineCoverURL != null) {
+          Headline(headlineTitle, headlineSubtitle, URL(headlineCoverURL))
+        } else {
+          null
         }
-        val publicationDateTime = ZonedDateTime.parse(publicationDateTime)
-        val url = URL(url)
-        return HttpToot(
-            id,
-            author,
-            content,
-            publicationDateTime,
-            commentCount,
-            favoriteCount,
-            reblogCount,
-            url
-        )
-    }
+      }
+    val publicationDateTime = ZonedDateTime.parse(publicationDateTime)
+    val url = URL(url)
+    return HttpToot(
+      id,
+      author,
+      content,
+      publicationDateTime,
+      commentCount,
+      favoriteCount,
+      reblogCount,
+      url
+    )
+  }
 
-    companion object {
-        /**
-         * Creates an [HttpTootEntity] from the given [toot].
-         *
-         * @param toot [HttpToot] from which the [HttpTootEntity] will be created.
-         **/
-        fun from(toot: HttpToot): HttpTootEntity {
-            return HttpTootEntity(
-                toot.id,
-                toot.author.id,
-                "${toot.content.text}",
-                toot.content.highlight?.headline?.title,
-                toot.content.highlight?.headline?.subtitle,
-                "${toot.content.highlight?.headline?.coverURL}",
-                "${toot.publicationDateTime}",
-                toot.comment.countFlow.value,
-                toot.favorite.isEnabled,
-                toot.favorite.count,
-                toot.reblog.isEnabled,
-                toot.reblog.count,
-                "${toot.url}"
-            )
-        }
+  companion object {
+    /**
+     * Creates an [HttpTootEntity] from the given [toot].
+     *
+     * @param toot [HttpToot] from which the [HttpTootEntity] will be created.
+     */
+    fun from(toot: HttpToot): HttpTootEntity {
+      return HttpTootEntity(
+        toot.id,
+        toot.author.id,
+        "${toot.content.text}",
+        toot.content.highlight?.headline?.title,
+        toot.content.highlight?.headline?.subtitle,
+        "${toot.content.highlight?.headline?.coverURL}",
+        "${toot.publicationDateTime}",
+        toot.comment.countFlow.value,
+        toot.favorite.isEnabled,
+        toot.favorite.count,
+        toot.reblog.isEnabled,
+        toot.reblog.count,
+        "${toot.url}"
+      )
     }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/HttpTootEntityDao.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/HttpTootEntityDao.kt
@@ -8,53 +8,48 @@ import androidx.room.Transaction
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.cache.storage.style.HttpStyleEntity
 import kotlinx.coroutines.flow.Flow
 
-/** Performs SQL transactions regarding [HTTP toot entities][HttpTootEntity]. **/
+/** Performs SQL transactions regarding [HTTP toot entities][HttpTootEntity]. */
 @Dao
 internal interface HttpTootEntityDao {
-    /**
-     * Returns the amount of [HTTP toot entities][HttpTootEntity] identified as [id].
-     *
-     * @param id ID for which the counting will be performed.
-     **/
-    @Query("SELECT COUNT() FROM toots WHERE id = :id")
-    suspend fun count(id: String): Int
+  /**
+   * Returns the amount of [HTTP toot entities][HttpTootEntity] identified as [id].
+   *
+   * @param id ID for which the counting will be performed.
+   */
+  @Query("SELECT COUNT() FROM toots WHERE id = :id") suspend fun count(id: String): Int
 
-    /**
-     * Returns a [Flow] to which the [HttpTootEntity] identified as [id] will be emitted or an empty
-     * one if none is found.
-     *
-     * @param id ID of the [HttpTootEntity] to be obtained.
-     **/
-    @Query("SELECT * FROM toots WHERE id = :id")
-    suspend fun selectByID(id: String): HttpTootEntity
+  /**
+   * Returns a [Flow] to which the [HttpTootEntity] identified as [id] will be emitted or an empty
+   * one if none is found.
+   *
+   * @param id ID of the [HttpTootEntity] to be obtained.
+   */
+  @Query("SELECT * FROM toots WHERE id = :id") suspend fun selectByID(id: String): HttpTootEntity
 
-    /**
-     * Returns a [Flow] to which the [HttpTootEntity] identified as [id] alongside its associated
-     * [HTTP style entities][HttpStyleEntity] will be emitted or an empty one if none is found.
-     *
-     * @param id ID of the [HttpTootEntity].
-     **/
-    @Query("SELECT * FROM toots WHERE id = :id")
-    @Transaction
-    suspend fun selectWithStylesByID(id: String): HttpTootWithStyles
+  /**
+   * Returns a [Flow] to which the [HttpTootEntity] identified as [id] alongside its associated
+   * [HTTP style entities][HttpStyleEntity] will be emitted or an empty one if none is found.
+   *
+   * @param id ID of the [HttpTootEntity].
+   */
+  @Query("SELECT * FROM toots WHERE id = :id")
+  @Transaction
+  suspend fun selectWithStylesByID(id: String): HttpTootWithStyles
 
-    /**
-     * Inserts the [entity].
-     *
-     * @param entity [HttpTootEntity] to be inserted.
-     **/
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(entity: HttpTootEntity)
+  /**
+   * Inserts the [entity].
+   *
+   * @param entity [HttpTootEntity] to be inserted.
+   */
+  @Insert(onConflict = OnConflictStrategy.REPLACE) suspend fun insert(entity: HttpTootEntity)
 
-    /**
-     * Deletes the [HttpTootEntity] identified as [id].
-     *
-     * @param id ID of the [HttpTootEntity] to be deleted.
-     **/
-    @Query("DELETE FROM toots WHERE id = :id")
-    suspend fun delete(id: String)
+  /**
+   * Deletes the [HttpTootEntity] identified as [id].
+   *
+   * @param id ID of the [HttpTootEntity] to be deleted.
+   */
+  @Query("DELETE FROM toots WHERE id = :id") suspend fun delete(id: String)
 
-    /** Deletes all [HTTP toot entities][HttpTootEntity]. **/
-    @Query("DELETE FROM toots")
-    suspend fun deleteAll()
+  /** Deletes all [HTTP toot entities][HttpTootEntity]. */
+  @Query("DELETE FROM toots") suspend fun deleteAll()
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/HttpTootStorage.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/HttpTootStorage.kt
@@ -12,39 +12,39 @@ import com.jeanbarrossilva.orca.platform.cache.Storage
  * [Storage] for [HttpToot]s.
  *
  * @param profileCache [Cache] of [Profile]s with which [HTTP toot entities][HttpTootEntity] will be
- * converted to [HttpToot]s.
+ *   converted to [HttpToot]s.
  * @param tootEntityDao [HttpStyleEntityDao] that will perform SQL transactions on
- * [HTTP toot entities][HttpTootEntity].
+ *   [HTTP toot entities][HttpTootEntity].
  * @param styleEntityDao [HttpStyleEntityDao] for inserting and deleting
- * [HTTP style entities][HttpStyleEntity].
- **/
+ *   [HTTP style entities][HttpStyleEntity].
+ */
 internal class HttpTootStorage(
-    private val profileCache: Cache<Profile>,
-    private val tootEntityDao: HttpTootEntityDao,
-    private val styleEntityDao: HttpStyleEntityDao
+  private val profileCache: Cache<Profile>,
+  private val tootEntityDao: HttpTootEntityDao,
+  private val styleEntityDao: HttpStyleEntityDao
 ) : Storage<HttpToot>() {
-    override suspend fun onStore(key: String, value: HttpToot) {
-        val tootEntity = HttpTootEntity.from(value)
-        val styleEntities = value.content.text.styles.map { it.toHttpStyleEntity(value.id) }
-        tootEntityDao.insert(tootEntity)
-        styleEntityDao.insert(styleEntities)
-    }
+  override suspend fun onStore(key: String, value: HttpToot) {
+    val tootEntity = HttpTootEntity.from(value)
+    val styleEntities = value.content.text.styles.map { it.toHttpStyleEntity(value.id) }
+    tootEntityDao.insert(tootEntity)
+    styleEntityDao.insert(styleEntities)
+  }
 
-    override suspend fun onContains(key: String): Boolean {
-        return tootEntityDao.count(key) > 0
-    }
+  override suspend fun onContains(key: String): Boolean {
+    return tootEntityDao.count(key) > 0
+  }
 
-    override suspend fun onGet(key: String): HttpToot {
-        return tootEntityDao.selectByID(key).toHttpToot(profileCache, tootEntityDao)
-    }
+  override suspend fun onGet(key: String): HttpToot {
+    return tootEntityDao.selectByID(key).toHttpToot(profileCache, tootEntityDao)
+  }
 
-    override suspend fun onRemove(key: String) {
-        val mentionEntities = styleEntityDao.selectByTootID(key)
-        styleEntityDao.delete(mentionEntities)
-        tootEntityDao.delete(key)
-    }
+  override suspend fun onRemove(key: String) {
+    val mentionEntities = styleEntityDao.selectByTootID(key)
+    styleEntityDao.delete(mentionEntities)
+    tootEntityDao.delete(key)
+  }
 
-    override suspend fun onClear() {
-        tootEntityDao.deleteAll()
-    }
+  override suspend fun onClear() {
+    tootEntityDao.deleteAll()
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/HttpTootWithStyles.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/HttpTootWithStyles.kt
@@ -9,8 +9,8 @@ import com.jeanbarrossilva.orca.core.http.feed.profile.toot.cache.storage.style.
  *
  * @param toot [HttpTootEntity] to which the [styles] are applied.
  * @param styles [HTTP style entities][HttpStyleEntity] that belong to the [toot].
- **/
+ */
 internal data class HttpTootWithStyles(
-    @Embedded val toot: HttpTootEntity,
-    @Relation(parentColumn = "id", entityColumn = "toot_id") val styles: List<HttpStyleEntity>
+  @Embedded val toot: HttpTootEntity,
+  @Relation(parentColumn = "id", entityColumn = "toot_id") val styles: List<HttpStyleEntity>
 )

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/Profile.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/Profile.extensions.kt
@@ -3,7 +3,7 @@ package com.jeanbarrossilva.orca.core.http.feed.profile.toot.cache.storage
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Author
 
-/** Converts this [Profile] into an [Author]. **/
+/** Converts this [Profile] into an [Author]. */
 internal fun Profile.toAuthor(): Author {
-    return Author(id, avatarURL, name, account, profileURL = url)
+  return Author(id, avatarURL, name, account, profileURL = url)
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/style/Collection.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/style/Collection.extensions.kt
@@ -4,9 +4,7 @@ package com.jeanbarrossilva.orca.core.http.feed.profile.toot.cache.storage.style
  * Gets the [HttpStyleEntity] that starts at the given [index].
  *
  * @param index Index at which the [HttpStyleEntity] to be obtained starts.
- **/
+ */
 internal fun Collection<HttpStyleEntity>.startingAt(index: Int): HttpStyleEntity {
-    return first {
-        it.startIndex == index
-    }
+  return first { it.startIndex == index }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/style/HttpStyleEntity.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/style/HttpStyleEntity.kt
@@ -14,17 +14,17 @@ import com.jeanbarrossilva.orca.std.styledstring.type.Link
  * @param id Automatically generated unique identifier.
  * @param tootID ID of the [Toot] to which the [Style] belongs.
  * @param startIndex Indicates the first index in the [Toot]'s [content][Toot.content]'s
- * [text][Content.text] to which the [Style] has been applied.
+ *   [text][Content.text] to which the [Style] has been applied.
  * @param endIndex Final position in the [Toot]'s [content][Toot.content]'s [text][Content.text]
- * that has the [Style].
+ *   that has the [Style].
  * @param url URL [String] to which the styled portion leads if it happens to be a [Link] or `null`
- * if it isn't.
- **/
+ *   if it isn't.
+ */
 @Entity(tableName = "styles")
 internal data class HttpStyleEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long,
-    @ColumnInfo(name = "toot_id") val tootID: String,
-    @ColumnInfo(name = "start_index") val startIndex: Int,
-    @ColumnInfo(name = "end_index") val endIndex: Int,
-    @ColumnInfo(name = "url") val url: String?
+  @PrimaryKey(autoGenerate = true) val id: Long,
+  @ColumnInfo(name = "toot_id") val tootID: String,
+  @ColumnInfo(name = "start_index") val startIndex: Int,
+  @ColumnInfo(name = "end_index") val endIndex: Int,
+  @ColumnInfo(name = "url") val url: String?
 )

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/style/HttpStyleEntityDao.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/style/HttpStyleEntityDao.kt
@@ -8,31 +8,30 @@ import androidx.room.Query
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
 import kotlinx.coroutines.flow.Flow
 
-/** Performs SQL transactions regarding [HTTP style entities][HttpStyleEntity]. **/
+/** Performs SQL transactions regarding [HTTP style entities][HttpStyleEntity]. */
 @Dao
 internal interface HttpStyleEntityDao {
-    /**
-     * Returns a [Flow] to which the [HttpStyleEntity] whose [Toot]'s identified as [tootID] will be
-     * emitted or an empty one if none is found.
-     *
-     * @param tootID ID of the [Toot] to which the [HttpStyleEntity] to be obtained belongs.
-     **/
-    @Query("SELECT * FROM styles WHERE toot_id = :tootID")
-    suspend fun selectByTootID(tootID: String): List<HttpStyleEntity>
+  /**
+   * Returns a [Flow] to which the [HttpStyleEntity] whose [Toot]'s identified as [tootID] will be
+   * emitted or an empty one if none is found.
+   *
+   * @param tootID ID of the [Toot] to which the [HttpStyleEntity] to be obtained belongs.
+   */
+  @Query("SELECT * FROM styles WHERE toot_id = :tootID")
+  suspend fun selectByTootID(tootID: String): List<HttpStyleEntity>
 
-    /**
-     * Inserts the [HTTP style entities][HttpStyleEntity].
-     *
-     * @param entities [HTTP style entities][HttpStyleEntity] to be inserted.
-     **/
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(entities: List<HttpStyleEntity>)
+  /**
+   * Inserts the [HTTP style entities][HttpStyleEntity].
+   *
+   * @param entities [HTTP style entities][HttpStyleEntity] to be inserted.
+   */
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun insert(entities: List<HttpStyleEntity>)
 
-    /**
-     * Deletes the [HTTP style entities][HttpStyleEntity].
-     *
-     * @param entities [HTTP style entities][HttpStyleEntity] to be deleted.
-     **/
-    @Delete
-    suspend fun delete(entities: List<HttpStyleEntity>)
+  /**
+   * Deletes the [HTTP style entities][HttpStyleEntity].
+   *
+   * @param entities [HTTP style entities][HttpStyleEntity] to be deleted.
+   */
+  @Delete suspend fun delete(entities: List<HttpStyleEntity>)
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/style/Style.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/style/Style.extensions.kt
@@ -8,8 +8,8 @@ import com.jeanbarrossilva.orca.std.styledstring.type.Mention
  * Converts this [Style] into an [HttpStyleEntity].
  *
  * @param tootID ID of the [Toot] to which this [Style] belongs.
- **/
+ */
 internal fun Style.toHttpStyleEntity(tootID: String): HttpStyleEntity {
-    val url = if (this is Mention) url.toString() else null
-    return HttpStyleEntity(id = 0, tootID, indices.first, indices.last, url)
+  val url = if (this is Mention) url.toString() else null
+  return HttpStyleEntity(id = 0, tootID, indices.first, indices.last, url)
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/pagination/Headers.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/pagination/Headers.extensions.kt
@@ -10,15 +10,16 @@ import io.ktor.util.toMap
  * Parametrized URIs present in the Link header, each represented by a [LinkHeader].
  *
  * @see HttpHeaders.Link
- **/
+ */
 internal val Headers.links
-    get() = filter { key, _ -> key == HttpHeaders.Link }
-        .toMap()
-        .values
-        .flatten()
-        .map {
-            LinkHeader(
-                uri = it.substringAfter('<').substringBefore('>'),
-                rel = it.substringAfter("rel=\"").substringBeforeLast('"')
-            )
-        }
+  get() =
+    filter { key, _ -> key == HttpHeaders.Link }
+      .toMap()
+      .values
+      .flatten()
+      .map {
+        LinkHeader(
+          uri = it.substringAfter('<').substringBefore('>'),
+          rel = it.substringAfter("rel=\"").substringBeforeLast('"')
+        )
+      }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/pagination/HttpTootPaginateSource.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/pagination/HttpTootPaginateSource.kt
@@ -17,83 +17,81 @@ import io.ktor.client.request.HttpRequest
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.Url
 
-/** [BasePaginateSource] that requests and paginates through [Toot]s. **/
+/** [BasePaginateSource] that requests and paginates through [Toot]s. */
 internal abstract class HttpTootPaginateSource internal constructor() :
-    BasePaginateSource<Url, HttpToot>() {
-    /** Index of the page that's the current one. **/
-    private var page = 0
-        set(index) { field = minOf(0, index) }
-
-    /** URL [String] to which the [HttpRequest] should be sent. **/
-    protected abstract val route: String
-
-    override suspend fun fetch(
-        count: Int,
-        key: Url?,
-        direction: PageDirection,
-        currentPageCount: Int
-    ): PagedResult<Url, HttpToot> {
-        val response = getStatusesResponse(key)
-        val headerLinks = response.headers.links
-        val nextUrl = headerLinks.getOrNull(1)?.uri?.let(::Url)
-        val toots = response.body<List<HttpStatus>>().map(HttpStatus::toToot)
-        val firstKey = toots.firstOrNull()?.url?.toString()?.let(::Url)
-        val lastKey = toots.lastOrNull()?.url?.toString()?.let(::Url)
-        val pageInfo = PageInfo(
-            page,
-            hasPreviousPage = page > 0,
-            hasNextPage = nextUrl != null,
-            firstKey,
-            lastKey
-        )
-        updatePage(direction)
-        return PagedResult(pageInfo, toots)
+  BasePaginateSource<Url, HttpToot>() {
+  /** Index of the page that's the current one. */
+  private var page = 0
+    set(index) {
+      field = minOf(0, index)
     }
 
-    /**
-     * Iteratively iterates through the [Toot]s until the given [page] is reached.
-     *
-     * @param page Page to paginate to.
-     * @param count Amount of [Toot]s that should be in each page.
-     **/
-    internal suspend fun paginateTo(page: Int, count: Int = DEFAULT_COUNT) {
-        while (this.page != page) {
-            if (this.page < page) {
-                next(count)
-                this.page++
-            } else {
-                previous(count)
-                this.page--
-            }
-        }
-    }
+  /** URL [String] to which the [HttpRequest] should be sent. */
+  protected abstract val route: String
 
-    /**
-     * Updates the [page] based on the given [direction]: if it's [before][PageDirection.BEFORE],
-     * decreases it; otherwise, if it's [after][PageDirection.AFTER], increases it.
-     *
-     * @param direction Indicates whether pagination is backwards or forward.
-     **/
-    private fun updatePage(direction: PageDirection) {
-        page += when (direction) {
-            PageDirection.BEFORE -> -1
-            PageDirection.AFTER -> 1
-        }
-    }
+  override suspend fun fetch(
+    count: Int,
+    key: Url?,
+    direction: PageDirection,
+    currentPageCount: Int
+  ): PagedResult<Url, HttpToot> {
+    val response = getStatusesResponse(key)
+    val headerLinks = response.headers.links
+    val nextUrl = headerLinks.getOrNull(1)?.uri?.let(::Url)
+    val toots = response.body<List<HttpStatus>>().map(HttpStatus::toToot)
+    val firstKey = toots.firstOrNull()?.url?.toString()?.let(::Url)
+    val lastKey = toots.lastOrNull()?.url?.toString()?.let(::Url)
+    val pageInfo =
+      PageInfo(page, hasPreviousPage = page > 0, hasNextPage = nextUrl != null, firstKey, lastKey)
+    updatePage(direction)
+    return PagedResult(pageInfo, toots)
+  }
 
-    /**
-     * Gets the [HttpResponse] for the requested [HttpStatus]es at the [url].
-     *
-     * @param url [Url] to which the [HttpRequest] will be made.
-     **/
-    private suspend fun getStatusesResponse(url: Url?): HttpResponse {
-        return (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
-            .client
-            .authenticateAndGet(url?.toString() ?: route)
+  /**
+   * Iteratively iterates through the [Toot]s until the given [page] is reached.
+   *
+   * @param page Page to paginate to.
+   * @param count Amount of [Toot]s that should be in each page.
+   */
+  internal suspend fun paginateTo(page: Int, count: Int = DEFAULT_COUNT) {
+    while (this.page != page) {
+      if (this.page < page) {
+        next(count)
+        this.page++
+      } else {
+        previous(count)
+        this.page--
+      }
     }
+  }
 
-    companion object {
-        /** Default amount of [Toot]s that's returned by the API. **/
-        internal const val DEFAULT_COUNT = 20
-    }
+  /**
+   * Updates the [page] based on the given [direction]: if it's [before][PageDirection.BEFORE],
+   * decreases it; otherwise, if it's [after][PageDirection.AFTER], increases it.
+   *
+   * @param direction Indicates whether pagination is backwards or forward.
+   */
+  private fun updatePage(direction: PageDirection) {
+    page +=
+      when (direction) {
+        PageDirection.BEFORE -> -1
+        PageDirection.AFTER -> 1
+      }
+  }
+
+  /**
+   * Gets the [HttpResponse] for the requested [HttpStatus]es at the [url].
+   *
+   * @param url [Url] to which the [HttpRequest] will be made.
+   */
+  private suspend fun getStatusesResponse(url: Url?): HttpResponse {
+    return (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+      .client
+      .authenticateAndGet(url?.toString() ?: route)
+  }
+
+  companion object {
+    /** Default amount of [Toot]s that's returned by the API. */
+    internal const val DEFAULT_COUNT = 20
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/stat/Stat.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/stat/Stat.extensions.kt
@@ -18,20 +18,20 @@ import kotlinx.coroutines.flow.flow
  *
  * @param id ID of the [HttpToot] for which the [Stat] is.
  * @param count Amount of comments that the [HttpToot] has received.
- **/
+ */
 @Suppress("FunctionName")
 internal fun CommentStat(id: String, count: Int): Stat<Toot> {
-    return Stat(count) {
-        get {
-            flow {
-                (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
-                    .client
-                    .authenticateAndGet("/api/v1/statuses/$id/context")
-                    .body<HttpContext>()
-                    .descendants
-                    .map(HttpStatus::toToot)
-                    .also { emit(it) }
-            }
-        }
+  return Stat(count) {
+    get {
+      flow {
+        (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+          .client
+          .authenticateAndGet("/api/v1/statuses/$id/context")
+          .body<HttpContext>()
+          .descendants
+          .map(HttpStatus::toToot)
+          .also { emit(it) }
+      }
     }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/stat/ToggleableStat.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/stat/ToggleableStat.extensions.kt
@@ -14,22 +14,22 @@ import com.jeanbarrossilva.orca.std.injector.Injector
  *
  * @param id ID of the [HttpToot] for which the [ToggleableStat] is.
  * @param count Amount of times that the [HttpToot] has been marked as favorite.
- **/
+ */
 @Suppress("FunctionName")
 internal fun FavoriteStat(id: String, count: Int): ToggleableStat<Profile> {
-    return ToggleableStat(count) {
-        setEnabled { isEnabled ->
-            val route = if (isEnabled) {
-                "/api/v1/statuses/$id/favourite"
-            } else {
-                @Suppress("SpellCheckingInspection")
-                "/api/v1/statuses/$id/unfavourite"
-            }
-            (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
-                .client
-                .authenticateAndPost(route)
+  return ToggleableStat(count) {
+    setEnabled { isEnabled ->
+      val route =
+        if (isEnabled) {
+          "/api/v1/statuses/$id/favourite"
+        } else {
+          @Suppress("SpellCheckingInspection") "/api/v1/statuses/$id/unfavourite"
         }
+      (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+        .client
+        .authenticateAndPost(route)
     }
+  }
 }
 
 /**
@@ -37,16 +37,15 @@ internal fun FavoriteStat(id: String, count: Int): ToggleableStat<Profile> {
  *
  * @param id ID of the [HttpToot] for which the [ToggleableStat] is.
  * @param count Amount of times that the [HttpToot] has been reblogged.
- **/
+ */
 @Suppress("FunctionName")
 internal fun ReblogStat(id: String, count: Int): ToggleableStat<Profile> {
-    return ToggleableStat(count) {
-        setEnabled { isEnabled ->
-            val route =
-                if (isEnabled) "/api/v1/statuses/$id/reblog" else "/api/v1/statuses/$id/unreblog"
-            (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
-                .client
-                .authenticateAndPost(route)
-        }
+  return ToggleableStat(count) {
+    setEnabled { isEnabled ->
+      val route = if (isEnabled) "/api/v1/statuses/$id/reblog" else "/api/v1/statuses/$id/unreblog"
+      (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+        .client
+        .authenticateAndPost(route)
     }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/status/HttpAttachment.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/status/HttpAttachment.kt
@@ -10,11 +10,11 @@ import kotlinx.serialization.Serializable
  *
  * @param previewUrl [String] URL that leads to the image to be shown as a preview.
  * @param description Describes the contents of the media.
- **/
+ */
 @Serializable
 internal data class HttpAttachment(val previewUrl: String, val description: String?) {
-    /** Converts this [HttpAttachment] into an [Attachment]. **/
-    fun toAttachment(): Attachment {
-        return Attachment(description?.ifBlank { null }, URL(previewUrl))
-    }
+  /** Converts this [HttpAttachment] into an [Attachment]. */
+  fun toAttachment(): Attachment {
+    return Attachment(description?.ifBlank { null }, URL(previewUrl))
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/status/HttpCard.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/status/HttpCard.kt
@@ -11,22 +11,22 @@ import kotlinx.serialization.Serializable
  * @param title Title of the webpage.
  * @param description Description of the webpage.
  * @param image URL [String] that leads to the cover image.
- **/
+ */
 @Serializable
 internal data class HttpCard(
-    val url: String,
-    val title: String,
-    val description: String,
-    val image: String?
+  val url: String,
+  val title: String,
+  val description: String,
+  val image: String?
 ) {
-    /**
-     * Converts this [HttpCard] into a [Headline].
-     *
-     * @return Resulting [Headline] or `null` if the [image] is unavailable.
-     **/
-    fun toHeadline(): Headline? {
-        return image?.let {
-            Headline(title, subtitle = description.ifEmpty { null }, coverURL = URL(image))
-        }
+  /**
+   * Converts this [HttpCard] into a [Headline].
+   *
+   * @return Resulting [Headline] or `null` if the [image] is unavailable.
+   */
+  fun toHeadline(): Headline? {
+    return image?.let {
+      Headline(title, subtitle = description.ifEmpty { null }, coverURL = URL(image))
     }
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/status/HttpStatus.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/status/HttpStatus.kt
@@ -24,42 +24,43 @@ import kotlinx.serialization.Serializable
  * @param content Text that's been written.
  * @param mediaAttachments [HttpAttachment]s of attached media.
  * @param favourited Whether it's been favorited by the currently
- * [authenticated][Actor.Authenticated] [Actor].
+ *   [authenticated][Actor.Authenticated] [Actor].
  * @param reblogged Whether the [authenticated][Actor.Authenticated] [Actor] has reblogged this
- * [HttpStatus].
- **/
+ *   [HttpStatus].
+ */
 @Serializable
-data class HttpStatus internal constructor(
-    internal val id: String,
-    internal val createdAt: String,
-    internal val account: HttpAccount,
-    internal val reblogsCount: Int,
-    internal val favouritesCount: Int,
-    internal val repliesCount: Int,
-    internal val url: String,
-    internal val card: HttpCard?,
-    internal val content: String,
-    internal val mediaAttachments: List<HttpAttachment>,
-    internal val favourited: Boolean?,
-    internal val reblogged: Boolean?
+data class HttpStatus
+internal constructor(
+  internal val id: String,
+  internal val createdAt: String,
+  internal val account: HttpAccount,
+  internal val reblogsCount: Int,
+  internal val favouritesCount: Int,
+  internal val repliesCount: Int,
+  internal val url: String,
+  internal val card: HttpCard?,
+  internal val content: String,
+  internal val mediaAttachments: List<HttpAttachment>,
+  internal val favourited: Boolean?,
+  internal val reblogged: Boolean?
 ) {
-    /** Converts this [HttpStatus] into an [HttpToot]. **/
-    internal fun toToot(): HttpToot {
-        val author = this.account.toAuthor()
-        val text = StyledString.fromHtml(content)
-        val attachments = mediaAttachments.map(HttpAttachment::toAttachment)
-        val content = Content.from(text, attachments) { card?.toHeadline() }
-        val publicationDateTime = ZonedDateTime.parse(createdAt)
-        val url = URL(url)
-        return HttpToot(
-            id,
-            author,
-            content,
-            publicationDateTime,
-            commentCount = repliesCount,
-            favouritesCount,
-            reblogsCount,
-            url
-        )
-    }
+  /** Converts this [HttpStatus] into an [HttpToot]. */
+  internal fun toToot(): HttpToot {
+    val author = this.account.toAuthor()
+    val text = StyledString.fromHtml(content)
+    val attachments = mediaAttachments.map(HttpAttachment::toAttachment)
+    val content = Content.from(text, attachments) { card?.toHeadline() }
+    val publicationDateTime = ZonedDateTime.parse(createdAt)
+    val url = URL(url)
+    return HttpToot(
+      id,
+      author,
+      content,
+      publicationDateTime,
+      commentCount = repliesCount,
+      favouritesCount,
+      reblogsCount,
+      url
+    )
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/type/editable/HttpEditableProfile.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/type/editable/HttpEditableProfile.kt
@@ -13,31 +13,31 @@ import java.net.URL
  * [HttpProfile] that can be edited.
  *
  * @param tootPaginateSourceProvider [ProfileTootPaginateSource.Provider] by which a
- * [ProfileTootPaginateSource] for paginating through the [HttpProfile]'s [HttpToot]s will be
- * provided.
- **/
+ *   [ProfileTootPaginateSource] for paginating through the [HttpProfile]'s [HttpToot]s will be
+ *   provided.
+ */
 internal data class HttpEditableProfile(
-    private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider,
-    override val id: String,
-    override val account: Account,
-    override val avatarURL: URL,
-    override val name: String,
-    override val bio: StyledString,
-    override val followerCount: Int,
-    override val followingCount: Int,
-    override val url: URL
+  private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider,
+  override val id: String,
+  override val account: Account,
+  override val avatarURL: URL,
+  override val name: String,
+  override val bio: StyledString,
+  override val followerCount: Int,
+  override val followingCount: Int,
+  override val url: URL
 ) :
-    Profile by HttpProfile(
-        tootPaginateSourceProvider,
-        id,
-        account,
-        avatarURL,
-        name,
-        bio,
-        followerCount,
-        followingCount,
-        url
-    ),
-    EditableProfile() {
-    override val editor = HttpEditor()
+  Profile by HttpProfile(
+    tootPaginateSourceProvider,
+    id,
+    account,
+    avatarURL,
+    name,
+    bio,
+    followerCount,
+    followingCount,
+    url
+  ),
+  EditableProfile() {
+  override val editor = HttpEditor()
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/type/editable/HttpEditor.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/type/editable/HttpEditor.kt
@@ -19,39 +19,36 @@ import java.net.URL
 import java.nio.file.Path
 import kotlin.io.path.name
 
-/** [Editor] whose actions send [HttpRequest]s to the API. **/
+/** [Editor] whose actions send [HttpRequest]s to the API. */
 internal class HttpEditor : Editor {
-    @Suppress("UNREACHABLE_CODE", "UNUSED_VARIABLE")
-    override suspend fun setAvatarURL(avatarURL: URL) {
-        val file: Path = TODO()
-        val fileAsFile = file.toFile()
-        val fileLength = fileAsFile.length()
-        val inputProvider = InputProvider(fileLength) { fileAsFile.inputStream().asInput() }
-        val contentDisposition = "form-data; name=\"avatar\" filename=\"${file.name}\""
-        val headers = Headers.build { append(HttpHeaders.ContentDisposition, contentDisposition) }
-        val formData = formData { append("avatar", inputProvider, headers) }
-        (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
-            .client
-            .authenticateAndSubmitFormWithBinaryData(ROUTE, formData)
-    }
+  @Suppress("UNREACHABLE_CODE", "UNUSED_VARIABLE")
+  override suspend fun setAvatarURL(avatarURL: URL) {
+    val file: Path = TODO()
+    val fileAsFile = file.toFile()
+    val fileLength = fileAsFile.length()
+    val inputProvider = InputProvider(fileLength) { fileAsFile.inputStream().asInput() }
+    val contentDisposition = "form-data; name=\"avatar\" filename=\"${file.name}\""
+    val headers = Headers.build { append(HttpHeaders.ContentDisposition, contentDisposition) }
+    val formData = formData { append("avatar", inputProvider, headers) }
+    (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+      .client
+      .authenticateAndSubmitFormWithBinaryData(ROUTE, formData)
+  }
 
-    override suspend fun setName(name: String) {
-        (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
-            .client
-            .authenticateAndSubmitForm(ROUTE, parametersOf("display_name", name))
-    }
+  override suspend fun setName(name: String) {
+    (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+      .client
+      .authenticateAndSubmitForm(ROUTE, parametersOf("display_name", name))
+  }
 
-    override suspend fun setBio(bio: StyledString) {
-        (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
-            .client
-            .authenticateAndSubmitForm(
-                ROUTE,
-                parametersOf("note", "$bio")
-            )
-    }
+  override suspend fun setBio(bio: StyledString) {
+    (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+      .client
+      .authenticateAndSubmitForm(ROUTE, parametersOf("note", "$bio"))
+  }
 
-    companion object {
-        /** Route to which the [HttpRequest]s will be sent for editing an [HttpEditableProfile]. **/
-        private const val ROUTE = "api/v1/accounts/update_credentials"
-    }
+  companion object {
+    /** Route to which the [HttpRequest]s will be sent for editing an [HttpEditableProfile]. */
+    private const val ROUTE = "api/v1/accounts/update_credentials"
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/type/followable/Follow.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/type/followable/Follow.extensions.kt
@@ -7,12 +7,12 @@ import com.jeanbarrossilva.orca.core.feed.profile.type.followable.Follow
  * Gets the route to which a call would equate to this [Follow]'s [toggled][Follow.toggled] state.
  *
  * @param profile [Profile] to which this [Follow] is related.
- **/
+ */
 internal fun Follow.getToggledRoute(profile: Profile): String {
-    return when (this) {
-        Follow.Public.following(), Follow.Private.requested(), Follow.Private.following() ->
-            "/api/v1/accounts/${profile.id}/unfollow"
-        else ->
-            "/api/v1/accounts/${profile.id}/follow"
-    }
+  return when (this) {
+    Follow.Public.following(),
+    Follow.Private.requested(),
+    Follow.Private.following() -> "/api/v1/accounts/${profile.id}/unfollow"
+    else -> "/api/v1/accounts/${profile.id}/follow"
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/type/followable/HttpFollowableProfile.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/type/followable/HttpFollowableProfile.kt
@@ -19,37 +19,37 @@ import java.net.URL
  * [HttpProfile] that can be followed.
  *
  * @param tootPaginateSourceProvider [ProfileTootPaginateSource.Provider] by which a
- * [ProfileTootPaginateSource] for paginating through the [HttpProfile]'s [HttpToot]s will be
- * provided.
- **/
+ *   [ProfileTootPaginateSource] for paginating through the [HttpProfile]'s [HttpToot]s will be
+ *   provided.
+ */
 internal data class HttpFollowableProfile<T : Follow>(
-    private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider,
-    override val id: String,
-    override val account: Account,
-    override val avatarURL: URL,
-    override val name: String,
-    override val bio: StyledString,
-    override val follow: T,
-    override val followerCount: Int,
-    override val followingCount: Int,
-    override val url: URL
+  private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider,
+  override val id: String,
+  override val account: Account,
+  override val avatarURL: URL,
+  override val name: String,
+  override val bio: StyledString,
+  override val follow: T,
+  override val followerCount: Int,
+  override val followingCount: Int,
+  override val url: URL
 ) :
-    Profile by HttpProfile(
-        tootPaginateSourceProvider,
-        id,
-        account,
-        avatarURL,
-        name,
-        bio,
-        followerCount,
-        followingCount,
-        url
-    ),
-    FollowableProfile<T>() {
-    override suspend fun onChangeFollowTo(follow: T) {
-        val toggledRoute = follow.getToggledRoute(this)
-        (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
-            .client
-            .authenticateAndPost(toggledRoute)
-    }
+  Profile by HttpProfile(
+    tootPaginateSourceProvider,
+    id,
+    account,
+    avatarURL,
+    name,
+    bio,
+    followerCount,
+    followingCount,
+    url
+  ),
+  FollowableProfile<T>() {
+  override suspend fun onChangeFollowTo(follow: T) {
+    val toggledRoute = follow.getToggledRoute(this)
+    (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+      .client
+      .authenticateAndPost(toggledRoute)
+  }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/ContextualHttpInstance.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/ContextualHttpInstance.kt
@@ -34,68 +34,67 @@ import com.jeanbarrossilva.orca.platform.cache.Cache
  * @param domain Unique identifier of the server.
  * @param authorizer [HttpAuthorizer] by which the user will be authorized.
  * @param actorProvider [ActorProvider] that will provide [Actor]s to the [authenticator], the
- * [authenticationLock] and the [feedProvider].
+ *   [authenticationLock] and the [feedProvider].
  * @param termMuter [TermMuter] by which [Toot]s with muted terms will be filtered out.
  */
 class ContextualHttpInstance(
-    context: Context,
-    domain: Domain,
-    authorizer: HttpAuthorizer,
-    override val authenticator: HttpAuthenticator,
-    actorProvider: ActorProvider,
-    override val authenticationLock: AuthenticationLock<HttpAuthenticator>,
-    termMuter: TermMuter
+  context: Context,
+  domain: Domain,
+  authorizer: HttpAuthorizer,
+  override val authenticator: HttpAuthenticator,
+  actorProvider: ActorProvider,
+  override val authenticationLock: AuthenticationLock<HttpAuthenticator>,
+  termMuter: TermMuter
 ) : HttpInstance<HttpAuthorizer, HttpAuthenticator>(domain, authorizer) {
-    /** [HttpDatabase] in which cached structures will be persisted. */
-    private val database = HttpDatabase.getInstance(context)
+  /** [HttpDatabase] in which cached structures will be persisted. */
+  private val database = HttpDatabase.getInstance(context)
 
-    /**
-     * [ProfileTootPaginateSource.Provider] that provides the [ProfileTootPaginateSource] to be used
-     * by [profileFetcher], [profileStorage] and [profileSearchResultsFetcher].
-     */
-    private val profileTootPaginateSourceProvider =
-        ProfileTootPaginateSource.Provider(::ProfileTootPaginateSource)
+  /**
+   * [ProfileTootPaginateSource.Provider] that provides the [ProfileTootPaginateSource] to be used
+   * by [profileFetcher], [profileStorage] and [profileSearchResultsFetcher].
+   */
+  private val profileTootPaginateSourceProvider =
+    ProfileTootPaginateSource.Provider(::ProfileTootPaginateSource)
 
-    /** [HttpProfileFetcher] by which [HttpProfile]s will be fetched from the API. */
-    private val profileFetcher = HttpProfileFetcher(profileTootPaginateSourceProvider)
+  /** [HttpProfileFetcher] by which [HttpProfile]s will be fetched from the API. */
+  private val profileFetcher = HttpProfileFetcher(profileTootPaginateSourceProvider)
 
-    /** [HttpProfileStorage] that will store fetched [HttpProfile]s. */
-    private val profileStorage =
-        HttpProfileStorage(profileTootPaginateSourceProvider, database.profileEntityDao)
+  /** [HttpProfileStorage] that will store fetched [HttpProfile]s. */
+  private val profileStorage =
+    HttpProfileStorage(profileTootPaginateSourceProvider, database.profileEntityDao)
 
-    /** [Cache] that decides how to obtain [HttpProfile]s. */
-    private val profileCache =
-        Cache.of(context, name = "profile-cache", profileFetcher, profileStorage)
+  /** [Cache] that decides how to obtain [HttpProfile]s. */
+  private val profileCache =
+    Cache.of(context, name = "profile-cache", profileFetcher, profileStorage)
 
-    /**
-     * [HttpProfileSearchResultsFetcher] by which [ProfileSearchResult]s will be fetched from the
-     * API.
-     */
-    private val profileSearchResultsFetcher =
-        HttpProfileSearchResultsFetcher(profileTootPaginateSourceProvider)
+  /**
+   * [HttpProfileSearchResultsFetcher] by which [ProfileSearchResult]s will be fetched from the API.
+   */
+  private val profileSearchResultsFetcher =
+    HttpProfileSearchResultsFetcher(profileTootPaginateSourceProvider)
 
-    /** [HttpProfileSearchResultsStorage] that will store fetched [ProfileSearchResult]s. */
-    private val profileSearchResultsStorage =
-        HttpProfileSearchResultsStorage(database.profileSearchResultEntityDao)
+  /** [HttpProfileSearchResultsStorage] that will store fetched [ProfileSearchResult]s. */
+  private val profileSearchResultsStorage =
+    HttpProfileSearchResultsStorage(database.profileSearchResultEntityDao)
 
-    /** [Cache] that decides how to obtain [ProfileSearchResult]s. */
-    private val profileSearchResultsCache =
-        Cache.of(
-            context,
-            name = "profile-search-results-cache",
-            profileSearchResultsFetcher,
-            profileSearchResultsStorage
-        )
+  /** [Cache] that decides how to obtain [ProfileSearchResult]s. */
+  private val profileSearchResultsCache =
+    Cache.of(
+      context,
+      name = "profile-search-results-cache",
+      profileSearchResultsFetcher,
+      profileSearchResultsStorage
+    )
 
-    /** [HttpTootStorage] that will store fetched [HttpToot]s. */
-    private val tootStorage =
-        HttpTootStorage(profileCache, database.tootEntityDao, database.styleEntityDao)
+  /** [HttpTootStorage] that will store fetched [HttpToot]s. */
+  private val tootStorage =
+    HttpTootStorage(profileCache, database.tootEntityDao, database.styleEntityDao)
 
-    /** [Cache] that decides how to obtain [HttpToot]s. */
-    private val tootCache = Cache.of(context, name = "toot-cache", HttpTootFetcher, tootStorage)
+  /** [Cache] that decides how to obtain [HttpToot]s. */
+  private val tootCache = Cache.of(context, name = "toot-cache", HttpTootFetcher, tootStorage)
 
-    override val feedProvider = HttpFeedProvider(actorProvider, termMuter)
-    override val profileProvider = HttpProfileProvider(profileCache)
-    override val profileSearcher = HttpProfileSearcher(profileSearchResultsCache)
-    override val tootProvider = HttpTootProvider(tootCache)
+  override val feedProvider = HttpFeedProvider(actorProvider, termMuter)
+  override val profileProvider = HttpProfileProvider(profileCache)
+  override val profileSearcher = HttpProfileSearcher(profileSearchResultsCache)
+  override val tootProvider = HttpTootProvider(tootCache)
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/HttpInstance.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/HttpInstance.kt
@@ -24,16 +24,12 @@ internal typealias SomeHttpInstance = HttpInstance<*, *>
  * @param authorizer [Authorizer] by which the user will be authorized.
  */
 abstract class HttpInstance<F : Authorizer, S : Authenticator>(
-    final override val domain: Domain,
-    internal val authorizer: F
+  final override val domain: Domain,
+  internal val authorizer: F
 ) : Instance<S>() {
-    /** [Url] to which routes will be appended when [HttpRequest]s are sent. */
-    internal val url = URLBuilder().apply { set(scheme = "https", host = "$domain") }.build()
+  /** [Url] to which routes will be appended when [HttpRequest]s are sent. */
+  internal val url = URLBuilder().apply { set(scheme = "https", host = "$domain") }.build()
 
-    /** [HttpClient] by which [HttpRequest]s will be sent. */
-    open val client = CoreHttpClient {
-        defaultRequest {
-            url.takeFrom(this@HttpInstance.url)
-        }
-    }
+  /** [HttpClient] by which [HttpRequest]s will be sent. */
+  open val client = CoreHttpClient { defaultRequest { url.takeFrom(this@HttpInstance.url) } }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/HttpInstanceProvider.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/HttpInstanceProvider.kt
@@ -20,23 +20,21 @@ import com.jeanbarrossilva.orca.std.injector.Injector
  * [InstanceProvider] that provides a [ContextualHttpInstance].
  *
  * @param context [Context] through which the [Domain] of the [ContextualHttpInstance] will
- * retrieved.
- **/
+ *   retrieved.
+ */
 class HttpInstanceProvider(private val context: Context) : InstanceProvider {
-    private val module by lazy {
-        Injector.from<HttpModule>()
-    }
+  private val module by lazy { Injector.from<HttpModule>() }
 
-    override fun provide(): SomeInstance {
-        @Suppress("UNCHECKED_CAST")
-        return ContextualHttpInstance(
-            context,
-            HttpAuthorizationViewModel.getInstanceDomain(context),
-            module.authorizer() as HttpAuthorizer,
-            module.authenticator() as HttpAuthenticator,
-            module.actorProvider(),
-            module.authenticationLock() as AuthenticationLock<HttpAuthenticator>,
-            module.termMuter()
-        )
-    }
+  override fun provide(): SomeInstance {
+    @Suppress("UNCHECKED_CAST")
+    return ContextualHttpInstance(
+      context,
+      HttpAuthorizationViewModel.getInstanceDomain(context),
+      module.authorizer() as HttpAuthorizer,
+      module.authenticator() as HttpAuthenticator,
+      module.actorProvider(),
+      module.authenticationLock() as AuthenticationLock<HttpAuthenticator>,
+      module.termMuter()
+    )
+  }
 }

--- a/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/CoreHttpClientTests.kt
+++ b/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/CoreHttpClientTests.kt
@@ -10,76 +10,75 @@ import io.ktor.http.parametersOf
 import kotlin.test.Test
 
 internal class CoreHttpClientTests {
-    @Test
-    fun requestsAuthenticationOnAuthenticateAndGetWithAnUnauthenticatedActor() {
-        var isAuthenticated = false
-        runUnauthenticatedTest(onAuthentication = { isAuthenticated = true }) {
-            client.authenticateAndGet(route = "")
-            assertThat(isAuthenticated).isTrue()
-        }
+  @Test
+  fun requestsAuthenticationOnAuthenticateAndGetWithAnUnauthenticatedActor() {
+    var isAuthenticated = false
+    runUnauthenticatedTest(onAuthentication = { isAuthenticated = true }) {
+      client.authenticateAndGet(route = "")
+      assertThat(isAuthenticated).isTrue()
     }
+  }
 
-    @Test
-    fun setsBearerAuthHeaderOnAuthenticateAndGetWithAnAuthenticatedActor() {
-        runAuthenticatedTest {
-            assertThatRequestAuthorizationHeaderOf(client.authenticateAndGet(route = "")).isEqualTo(
-                "Bearer ${actor.accessToken}"
-            )
-        }
+  @Test
+  fun setsBearerAuthHeaderOnAuthenticateAndGetWithAnAuthenticatedActor() {
+    runAuthenticatedTest {
+      assertThatRequestAuthorizationHeaderOf(client.authenticateAndGet(route = ""))
+        .isEqualTo("Bearer ${actor.accessToken}")
     }
+  }
 
-    @Test
-    fun requestsAuthenticationOnAuthenticateAndPostWithAnUnauthenticatedActor() {
-        var isAuthenticated = false
-        runUnauthenticatedTest(onAuthentication = { isAuthenticated = true }) {
-            client.authenticateAndPost(route = "")
-            assertThat(isAuthenticated).isTrue()
-        }
+  @Test
+  fun requestsAuthenticationOnAuthenticateAndPostWithAnUnauthenticatedActor() {
+    var isAuthenticated = false
+    runUnauthenticatedTest(onAuthentication = { isAuthenticated = true }) {
+      client.authenticateAndPost(route = "")
+      assertThat(isAuthenticated).isTrue()
     }
+  }
 
-    @Test
-    fun setsBearerAuthHeaderOnAuthenticateAndPostWithAnAuthenticatedActor() {
-        runAuthenticatedTest {
-            assertThatRequestAuthorizationHeaderOf(client.authenticateAndPost(route = ""))
-                .isEqualTo("Bearer ${actor.accessToken}")
-        }
+  @Test
+  fun setsBearerAuthHeaderOnAuthenticateAndPostWithAnAuthenticatedActor() {
+    runAuthenticatedTest {
+      assertThatRequestAuthorizationHeaderOf(client.authenticateAndPost(route = ""))
+        .isEqualTo("Bearer ${actor.accessToken}")
     }
+  }
 
-    @Test
-    fun requestsAuthenticationOnAuthenticateAndSubmitFormWithAnUnauthenticatedActor() {
-        var isAuthenticated = false
-        runUnauthenticatedTest(onAuthentication = { isAuthenticated = true }) {
-            client.authenticateAndSubmitForm(route = "", parametersOf())
-            assertThat(isAuthenticated).isTrue()
-        }
+  @Test
+  fun requestsAuthenticationOnAuthenticateAndSubmitFormWithAnUnauthenticatedActor() {
+    var isAuthenticated = false
+    runUnauthenticatedTest(onAuthentication = { isAuthenticated = true }) {
+      client.authenticateAndSubmitForm(route = "", parametersOf())
+      assertThat(isAuthenticated).isTrue()
     }
+  }
 
-    @Test
-    fun setsBearerAuthHeaderOnAuthenticateAndSubmitFormWithAnAuthenticatedActor() {
-        runAuthenticatedTest {
-            assertThatRequestAuthorizationHeaderOf(
-                client.authenticateAndSubmitForm(route = "", parametersOf())
-            )
-                .isEqualTo("Bearer ${actor.accessToken}")
-        }
+  @Test
+  fun setsBearerAuthHeaderOnAuthenticateAndSubmitFormWithAnAuthenticatedActor() {
+    runAuthenticatedTest {
+      assertThatRequestAuthorizationHeaderOf(
+          client.authenticateAndSubmitForm(route = "", parametersOf())
+        )
+        .isEqualTo("Bearer ${actor.accessToken}")
     }
+  }
 
-    @Test
-    fun requestsAuthenticationOnAuthenticateAndSubmitFormWithBinaryDataWithAnUnauthenticatedActor() { // ktlint-disable max-line-length
-        var isAuthenticated = false
-        runUnauthenticatedTest(onAuthentication = { isAuthenticated = true }) {
-            client.authenticateAndSubmitFormWithBinaryData(route = "", formData = emptyList())
-            assertThat(isAuthenticated).isTrue()
-        }
+  @Test
+  fun requestsAuthenticationOnAuthenticateAndSubmitFormWithBinaryDataWithAnUnauthenticatedActor() {
+    var isAuthenticated = false
+    runUnauthenticatedTest(onAuthentication = { isAuthenticated = true }) {
+      client.authenticateAndSubmitFormWithBinaryData(route = "", formData = emptyList())
+      assertThat(isAuthenticated).isTrue()
     }
+  }
 
-    @Test
-    fun setsBearerAuthHeaderOnAuthenticateAndSubmitFormWithBinaryDataWithAnAuthenticatedActor() {
-        runAuthenticatedTest {
-            assertThatRequestAuthorizationHeaderOf(
-                client.authenticateAndSubmitFormWithBinaryData(route = "", formData = emptyList())
-            )
-                .isEqualTo("Bearer ${actor.accessToken}")
-        }
+  @Test
+  fun setsBearerAuthHeaderOnAuthenticateAndSubmitFormWithBinaryDataWithAnAuthenticatedActor() {
+    runAuthenticatedTest {
+      assertThatRequestAuthorizationHeaderOf(
+          client.authenticateAndSubmitFormWithBinaryData(route = "", formData = emptyList())
+        )
+        .isEqualTo("Bearer ${actor.accessToken}")
     }
+  }
 }

--- a/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/Assert.extensions.kt
+++ b/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/Assert.extensions.kt
@@ -10,7 +10,7 @@ import io.ktor.http.HttpHeaders
  * Creates an [Assert] on the [response]'s authorization [HttpHeader].
  *
  * @param response [HttpResponse] whose header will be the basis of the [Assert].
- **/
+ */
 internal fun assertThatRequestAuthorizationHeaderOf(response: HttpResponse): Assert<String?> {
-    return assertThat(response.request.headers[HttpHeaders.Authorization])
+  return assertThat(response.request.headers[HttpHeaders.Authorization])
 }

--- a/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/TestScope.extensions.kt
+++ b/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/TestScope.extensions.kt
@@ -5,10 +5,6 @@ import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.auth.actor.ActorProvider
 import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.client.CoreHttpClient
-import com.jeanbarrossilva.orca.core.http.client.authenticateAndGet
-import com.jeanbarrossilva.orca.core.http.client.authenticateAndPost
-import com.jeanbarrossilva.orca.core.http.client.authenticateAndSubmitForm
-import com.jeanbarrossilva.orca.core.http.client.authenticateAndSubmitFormWithBinaryData
 import com.jeanbarrossilva.orca.core.http.client.test.instance.TestHttpInstance
 import com.jeanbarrossilva.orca.core.http.client.test.instance.TestHttpInstanceProvider
 import com.jeanbarrossilva.orca.core.sample.auth.actor.sample
@@ -30,28 +26,27 @@ import kotlinx.coroutines.test.runTest
  *
  * @param T Specified [Actor] for performing the testing.
  * @param delegate [TestScope] that's been launched and will provide [CoroutineScope]-like
- * functionality to this [CoreHttpClientTestScope].
+ *   functionality to this [CoreHttpClientTestScope].
  * @param client [CoreHttpClient] for executing the intended [HttpRequest]s.
  * @param actor [Actor] used when running the test.
- **/
+ */
 internal class CoreHttpClientTestScope<T : Actor>(
-    delegate: TestScope,
-    val client: HttpClient,
-    val actor: T
+  delegate: TestScope,
+  val client: HttpClient,
+  val actor: T
 ) : CoroutineScope by delegate
 
 /**
  * [ActorProvider] that provides only the specified [actor].
  *
  * @param actor [Actor] to be provided unconditionally.
- **/
+ */
 internal class FixedActorProvider(private val actor: Actor) : TestActorProvider() {
-    override suspend fun remember(actor: Actor) {
-    }
+  override suspend fun remember(actor: Actor) {}
 
-    override suspend fun retrieve(): Actor {
-        return actor
-    }
+  override suspend fun retrieve(): Actor {
+    return actor
+  }
 }
 
 /**
@@ -59,12 +54,12 @@ internal class FixedActorProvider(private val actor: Actor) : TestActorProvider(
  * [authenticated][Actor.Authenticated] [Actor], providing the proper [CoreHttpClientTestScope].
  *
  * @param body Callback run when the environment has been set up and is, therefore, ready to be
- * used.
- **/
+ *   used.
+ */
 internal fun runAuthenticatedTest(
-    body: suspend CoreHttpClientTestScope<Actor.Authenticated>.() -> Unit
+  body: suspend CoreHttpClientTestScope<Actor.Authenticated>.() -> Unit
 ) {
-    runCoreHttpClientTest(Actor.Authenticated.sample, onAuthentication = { }, body)
+  runCoreHttpClientTest(Actor.Authenticated.sample, onAuthentication = {}, body)
 }
 
 /**
@@ -73,13 +68,13 @@ internal fun runAuthenticatedTest(
  *
  * @param onAuthentication Action run whenever the [Actor] is authenticated.
  * @param body Callback run when the environment has been set up and is, therefore, ready to be
- * used.
- **/
+ *   used.
+ */
 internal fun runUnauthenticatedTest(
-    onAuthentication: () -> Unit,
-    body: suspend CoreHttpClientTestScope<Actor.Unauthenticated>.() -> Unit
+  onAuthentication: () -> Unit,
+  body: suspend CoreHttpClientTestScope<Actor.Unauthenticated>.() -> Unit
 ) {
-    runCoreHttpClientTest(Actor.Unauthenticated, onAuthentication, body)
+  runCoreHttpClientTest(Actor.Unauthenticated, onAuthentication, body)
 }
 
 /**
@@ -88,40 +83,41 @@ internal fun runUnauthenticatedTest(
  *
  * @param T [Actor] to run the test with.
  * @param actor [Actor] to be fixedly provided by the underlying [ActorProvider]. Determines the
- * behavior of `authenticateAnd*` calls done on the [CoreHttpClient] within the [body], given that
- * an [unauthenticated][Actor.Unauthenticated] [Actor] will be requested to be authenticated when
- * such invocations take place, while having an [authenticated][Actor.Authenticated] [Actor] would
- * simply mean that the operation derived from the [HttpMethod] will be performed.
+ *   behavior of `authenticateAnd*` calls done on the [CoreHttpClient] within the [body], given that
+ *   an [unauthenticated][Actor.Unauthenticated] [Actor] will be requested to be authenticated when
+ *   such invocations take place, while having an [authenticated][Actor.Authenticated] [Actor] would
+ *   simply mean that the operation derived from the [HttpMethod] will be performed.
  * @param onAuthentication Action run whenever the [Actor] is authenticated. At this point, the most
- * up-to-date [Actor] is probably different from the one with which the test has been configured and
- * that is in the [CoreHttpClientTestScope] given to the [body].
+ *   up-to-date [Actor] is probably different from the one with which the test has been configured
+ *   and that is in the [CoreHttpClientTestScope] given to the [body].
  * @param body Callback run when the environment has been set up and is, therefore, ready to be
- * used.
+ *   used.
  * @see HttpClient.authenticateAndGet
  * @see HttpClient.authenticateAndPost
  * @see HttpClient.authenticateAndSubmitForm
  * @see HttpClient.authenticateAndSubmitFormWithBinaryData
- **/
+ */
 private fun <T : Actor> runCoreHttpClientTest(
-    actor: T,
-    onAuthentication: () -> Unit,
-    body: suspend CoreHttpClientTestScope<T>.() -> Unit
+  actor: T,
+  onAuthentication: () -> Unit,
+  body: suspend CoreHttpClientTestScope<T>.() -> Unit
 ) {
-    val authorizer = TestAuthorizer()
-    val actorProvider = FixedActorProvider(actor)
-    val authenticator = TestAuthenticator(authorizer, actorProvider) { onAuthentication() }
-    val authenticationLock = AuthenticationLock(authenticator, actorProvider)
-    val instance = TestHttpInstance(authorizer, authenticator, authenticationLock)
-    val module = HttpModule(
-        { authorizer },
-        { authenticator },
-        { actorProvider },
-        { authenticationLock },
-        { SampleTermMuter() }
+  val authorizer = TestAuthorizer()
+  val actorProvider = FixedActorProvider(actor)
+  val authenticator = TestAuthenticator(authorizer, actorProvider) { onAuthentication() }
+  val authenticationLock = AuthenticationLock(authenticator, actorProvider)
+  val instance = TestHttpInstance(authorizer, authenticator, authenticationLock)
+  val module =
+    HttpModule(
+      { authorizer },
+      { authenticator },
+      { actorProvider },
+      { authenticationLock },
+      { SampleTermMuter() }
     ) {
-        TestHttpInstanceProvider(authorizer, authenticator, authenticationLock)
+      TestHttpInstanceProvider(authorizer, authenticator, authenticationLock)
     }
-    Injector.register(module)
-    runTest { CoreHttpClientTestScope(delegate = this, instance.client, actor).body() }
-    Injector.clear()
+  Injector.register(module)
+  runTest { CoreHttpClientTestScope(delegate = this, instance.client, actor).body() }
+  Injector.clear()
 }

--- a/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/instance/TestHttpInstance.kt
+++ b/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/instance/TestHttpInstance.kt
@@ -19,27 +19,26 @@ import io.ktor.client.request.HttpRequest
  * [HttpInstance] whose [client] responds OK to each sent [HttpRequest].
  *
  * @param authorizer [TestAuthorizer] with which the user will be authorized.
- **/
+ */
 internal class TestHttpInstance(
-    authorizer: TestAuthorizer,
-    override val authenticator: TestAuthenticator,
-    override val authenticationLock: AuthenticationLock<TestAuthenticator>
+  authorizer: TestAuthorizer,
+  override val authenticator: TestAuthenticator,
+  override val authenticationLock: AuthenticationLock<TestAuthenticator>
 ) : HttpInstance<TestAuthorizer, TestAuthenticator>(Instance.sample.domain, authorizer) {
-    /**
-     * [HttpClientEngineFactory] that creates a [MockEngine] that sends an OK response to each
-     * [HttpRequest].
-     **/
-    private val clientEngineFactory = object : HttpClientEngineFactory<MockEngineConfig> {
-        override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine {
-            return MockEngine { respondOk() }.apply {
-                block(config)
-            }
-        }
+  /**
+   * [HttpClientEngineFactory] that creates a [MockEngine] that sends an OK response to each
+   * [HttpRequest].
+   */
+  private val clientEngineFactory =
+    object : HttpClientEngineFactory<MockEngineConfig> {
+      override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine {
+        return MockEngine { respondOk() }.apply { block(config) }
+      }
     }
 
-    override val feedProvider = Instance.sample.feedProvider
-    override val profileProvider = Instance.sample.profileProvider
-    override val profileSearcher = Instance.sample.profileSearcher
-    override val tootProvider = Instance.sample.tootProvider
-    override val client = CoreHttpClient(clientEngineFactory, Logger.test)
+  override val feedProvider = Instance.sample.feedProvider
+  override val profileProvider = Instance.sample.profileProvider
+  override val profileSearcher = Instance.sample.profileSearcher
+  override val tootProvider = Instance.sample.tootProvider
+  override val client = CoreHttpClient(clientEngineFactory, Logger.test)
 }

--- a/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/instance/TestHttpInstanceProvider.kt
+++ b/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/instance/TestHttpInstanceProvider.kt
@@ -11,14 +11,14 @@ import com.jeanbarrossilva.orca.core.test.TestAuthorizer
  * @param authorizer [TestAuthorizer] with which the user will be authorized.
  * @param authenticator [TestAuthenticator] through which authentication can be done.
  * @param authenticationLock [AuthenticationLock] by which features can be locked or unlocked by an
- * authentication "wall".
- **/
+ *   authentication "wall".
+ */
 internal class TestHttpInstanceProvider(
-    private val authorizer: TestAuthorizer,
-    private val authenticator: TestAuthenticator,
-    private val authenticationLock: AuthenticationLock<TestAuthenticator>
+  private val authorizer: TestAuthorizer,
+  private val authenticator: TestAuthenticator,
+  private val authenticationLock: AuthenticationLock<TestAuthenticator>
 ) : InstanceProvider {
-    override fun provide(): TestHttpInstance {
-        return TestHttpInstance(authorizer, authenticator, authenticationLock)
-    }
+  override fun provide(): TestHttpInstance {
+    return TestHttpInstance(authorizer, authenticator, authenticationLock)
+  }
 }

--- a/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/instance/TestLogger.extensions.kt
+++ b/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/instance/TestLogger.extensions.kt
@@ -2,15 +2,14 @@ package com.jeanbarrossilva.orca.core.http.client.test.instance
 
 import com.jeanbarrossilva.orca.core.http.client.Logger
 
-/** [Logger] returned by [test]. **/
-private val testLogger = object : Logger() {
-    override fun onInfo(info: String) {
-    }
+/** [Logger] returned by [test]. */
+private val testLogger =
+  object : Logger() {
+    override fun onInfo(info: String) {}
 
-    override fun onError(error: String) {
-    }
-}
+    override fun onError(error: String) {}
+  }
 
-/** A no-op [Logger]. **/
+/** A no-op [Logger]. */
 internal val Logger.Companion.test
-    get() = testLogger
+  get() = testLogger

--- a/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/pagination/HeadersExtensionsTests.kt
+++ b/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/pagination/HeadersExtensionsTests.kt
@@ -6,16 +6,17 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class HeadersExtensionsTests {
-    @Test
-    fun `GIVEN String Link headers WHEN converting each into a LinkHeader THEN they're converted`() { // ktlint-disable max-line-length
-        val headers = headers {
-            append(HttpHeaders.Link, """<https://example.com/next>; rel="next"""")
-            append(HttpHeaders.Link, """<https://example.com/previous>; rel="previous"""")
+  @Test
+  fun `GIVEN String Link headers WHEN converting each into a LinkHeader THEN they're converted`() {
+    val headers =
+      headers {
+          append(HttpHeaders.Link, """<https://example.com/next>; rel="next"""")
+          append(HttpHeaders.Link, """<https://example.com/previous>; rel="previous"""")
         }
-            .links
-        assertEquals("https://example.com/next", headers.first().uri)
-        assertEquals("https://example.com/previous", headers[1].uri)
-        assertEquals("next", headers.first().parameter("rel"))
-        assertEquals("previous", headers[1].parameter("rel"))
-    }
+        .links
+    assertEquals("https://example.com/next", headers.first().uri)
+    assertEquals("https://example.com/previous", headers[1].uri)
+    assertEquals("next", headers.first().parameter("rel"))
+    assertEquals("previous", headers[1].parameter("rel"))
+  }
 }

--- a/core/sample-test/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/test/SampleTestRule.kt
+++ b/core/sample-test/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/test/SampleTestRule.kt
@@ -7,10 +7,10 @@ import org.junit.rules.ExternalResource
 /**
  * [ExternalResource] that resets the sample writers (such as [SampleProfileWriter] and
  * [SampleTootWriter]) at the end of each test.
- **/
+ */
 class SampleTestRule : ExternalResource() {
-    override fun after() {
-        SampleProfileWriter.reset()
-        SampleTootWriter.reset()
-    }
+  override fun after() {
+    SampleProfileWriter.reset()
+    SampleTootWriter.reset()
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/auth/Authorizer.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/auth/Authorizer.extensions.kt
@@ -2,13 +2,14 @@ package com.jeanbarrossilva.orca.core.sample.auth
 
 import com.jeanbarrossilva.orca.core.auth.Authorizer
 
-/** [Authorizer] returned by [sample]. **/
-private val sampleAuthorizer = object : Authorizer() {
+/** [Authorizer] returned by [sample]. */
+private val sampleAuthorizer =
+  object : Authorizer() {
     override suspend fun authorize(): String {
-        return "sample-authorization-code"
+      return "sample-authorization-code"
     }
-}
+  }
 
-/** [Authorizer] that provides a sample authorization code. **/
+/** [Authorizer] that provides a sample authorization code. */
 val Authorizer.Companion.sample
-    get() = sampleAuthorizer
+  get() = sampleAuthorizer

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/auth/SampleAuthenticator.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/auth/SampleAuthenticator.kt
@@ -10,13 +10,13 @@ import com.jeanbarrossilva.orca.core.sample.auth.actor.sample
  * [Authenticator] that provides a sample [Actor].
  *
  * @param actorProvider [ActorProvider] to which the [authenticated][Actor.Authenticated] [Actor]
- * will be sent to be remembered when authentication occurs.
- **/
+ *   will be sent to be remembered when authentication occurs.
+ */
 internal object SampleAuthenticator : Authenticator() {
-    override val authorizer: Authorizer = Authorizer.sample
-    override val actorProvider = ActorProvider.sample
+  override val authorizer: Authorizer = Authorizer.sample
+  override val actorProvider = ActorProvider.sample
 
-    override suspend fun onAuthenticate(authorizationCode: String): Actor {
-        return Actor.Authenticated.sample
-    }
+  override suspend fun onAuthenticate(authorizationCode: String): Actor {
+    return Actor.Authenticated.sample
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/auth/SampleAuthorizer.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/auth/SampleAuthorizer.kt
@@ -2,9 +2,9 @@ package com.jeanbarrossilva.orca.core.sample.auth
 
 import com.jeanbarrossilva.orca.core.auth.Authorizer
 
-/** [Authorizer] that provides a sample authorization code. **/
+/** [Authorizer] that provides a sample authorization code. */
 internal object SampleAuthorizer : Authorizer() {
-    override suspend fun authorize(): String {
-        return "sample-authorization-code"
-    }
+  override suspend fun authorize(): String {
+    return "sample-authorization-code"
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/auth/actor/Actor.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/auth/actor/Actor.extensions.kt
@@ -3,9 +3,9 @@ package com.jeanbarrossilva.orca.core.sample.auth.actor
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.sample.feed.profile.sample
 
-/** [Actor.Authenticated] returned by [sample]. **/
+/** [Actor.Authenticated] returned by [sample]. */
 private val authenticatedActorSample = Actor.Authenticated("sample-id", "sample-access-token")
 
-/** Sample [authenticated][Actor.Authenticated] [Actor]. **/
+/** Sample [authenticated][Actor.Authenticated] [Actor]. */
 val Actor.Authenticated.Companion.sample
-    get() = authenticatedActorSample
+  get() = authenticatedActorSample

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/auth/actor/ActorProvider.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/auth/actor/ActorProvider.extensions.kt
@@ -3,16 +3,16 @@ package com.jeanbarrossilva.orca.core.sample.auth.actor
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.auth.actor.ActorProvider
 
-/** [ActorProvider] returned by [sample]. **/
-private val sampleActorProvider = object : ActorProvider() {
-    override suspend fun remember(actor: Actor) {
-    }
+/** [ActorProvider] returned by [sample]. */
+private val sampleActorProvider =
+  object : ActorProvider() {
+    override suspend fun remember(actor: Actor) {}
 
     override suspend fun retrieve(): Actor {
-        return Actor.Authenticated.sample
+      return Actor.Authenticated.sample
     }
-}
+  }
 
-/** [ActorProvider] that always provides a sample [authenticated][Actor.Authenticated] [Actor]. **/
+/** [ActorProvider] that always provides a sample [authenticated][Actor.Authenticated] [Actor]. */
 val ActorProvider.Companion.sample
-    get() = sampleActorProvider
+  get() = sampleActorProvider

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/auth/actor/SampleActorProvider.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/auth/actor/SampleActorProvider.kt
@@ -3,12 +3,11 @@ package com.jeanbarrossilva.orca.core.sample.auth.actor
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.auth.actor.ActorProvider
 
-/** [ActorProvider] that always provides a sample [authenticated][Actor.Authenticated] [Actor]. **/
+/** [ActorProvider] that always provides a sample [authenticated][Actor.Authenticated] [Actor]. */
 internal object SampleActorProvider : ActorProvider() {
-    override suspend fun remember(actor: Actor) {
-    }
+  override suspend fun remember(actor: Actor) {}
 
-    override suspend fun retrieve(): Actor {
-        return Actor.Authenticated.sample
-    }
+  override suspend fun retrieve(): Actor {
+    return Actor.Authenticated.sample
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/SampleFeedProvider.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/SampleFeedProvider.kt
@@ -11,22 +11,20 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 
-/** [FeedProvider] that provides a feed for a sample [Profile]. **/
+/** [FeedProvider] that provides a feed for a sample [Profile]. */
 internal object SampleFeedProvider : FeedProvider() {
-    /** [Flow] with the toots to be provided in the feed. **/
-    private val tootsFlow = SampleTootProvider.tootsFlow.asStateFlow()
+  /** [Flow] with the toots to be provided in the feed. */
+  private val tootsFlow = SampleTootProvider.tootsFlow.asStateFlow()
 
-    override val termMuter = SampleTermMuter()
+  override val termMuter = SampleTermMuter()
 
-    override suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>> {
-        return tootsFlow.map {
-            it.chunked(SampleProfile.TOOTS_PER_PAGE).getOrElse(page) {
-                emptyList()
-            }
-        }
+  override suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>> {
+    return tootsFlow.map {
+      it.chunked(SampleProfile.TOOTS_PER_PAGE).getOrElse(page) { emptyList() }
     }
+  }
 
-    override suspend fun containsUser(userID: String): Boolean {
-        return userID == Profile.sample.id
-    }
+  override suspend fun containsUser(userID: String): Boolean {
+    return userID == Profile.sample.id
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/Profile.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/Profile.extensions.kt
@@ -6,22 +6,24 @@ import com.jeanbarrossilva.orca.core.sample.feed.profile.account.sample
 import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.sample
 import com.jeanbarrossilva.orca.std.styledstring.StyledString
 
-/** [Profile] returned by [sample]'s getter. **/
+/** [Profile] returned by [sample]'s getter. */
 @Suppress("SpellCheckingInspection")
-private val sampleProfile: Profile = object : SampleProfile {
+private val sampleProfile: Profile =
+  object : SampleProfile {
     override val id = Author.sample.id
     override val account = Author.sample.account
     override val avatarURL = Author.sample.avatarURL
     override val name = Author.sample.name
-    override val bio = StyledString(
+    override val bio =
+      StyledString(
         "Co-founder @ Grupo Estoa, software engineer, author, writer and content creator; " +
-            "neuroscience, quantum physics and philosophy enthusiast."
-    )
+          "neuroscience, quantum physics and philosophy enthusiast."
+      )
     override val followerCount = 1_024
     override val followingCount = 64
     override val url = Author.sample.profileURL
-}
+  }
 
-/** A sample [Profile]. **/
+/** A sample [Profile]. */
 val Profile.Companion.sample
-    get() = sampleProfile
+  get() = sampleProfile

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/SampleProfile.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/SampleProfile.kt
@@ -7,18 +7,16 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 
-/** [Profile] whose operations are performed in memory and serves as a sample. **/
+/** [Profile] whose operations are performed in memory and serves as a sample. */
 internal interface SampleProfile : Profile {
-    override suspend fun getToots(page: Int): Flow<List<Toot>> {
-        return SampleTootProvider.provideBy(id).filterNotNull().map {
-            it.windowed(TOOTS_PER_PAGE, partialWindows = true).getOrElse(page) {
-                emptyList()
-            }
-        }
+  override suspend fun getToots(page: Int): Flow<List<Toot>> {
+    return SampleTootProvider.provideBy(id).filterNotNull().map {
+      it.windowed(TOOTS_PER_PAGE, partialWindows = true).getOrElse(page) { emptyList() }
     }
+  }
 
-    companion object {
-        /** Maximum amount of [Toot]s emitted to [getToots]. **/
-        const val TOOTS_PER_PAGE = 50
-    }
+  companion object {
+    /** Maximum amount of [Toot]s emitted to [getToots]. */
+    const val TOOTS_PER_PAGE = 50
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/SampleProfileProvider.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/SampleProfileProvider.kt
@@ -6,24 +6,20 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.mapNotNull
 
-/** [ProfileProvider] that provides sample [Profile]s. **/
+/** [ProfileProvider] that provides sample [Profile]s. */
 internal object SampleProfileProvider : ProfileProvider() {
-    /** [Profile]s that are present by default. **/
-    internal val defaultProfiles = listOf(Profile.sample)
+  /** [Profile]s that are present by default. */
+  internal val defaultProfiles = listOf(Profile.sample)
 
-    /** [MutableStateFlow] that provides the [Profile]s. **/
-    internal val profilesFlow = MutableStateFlow(defaultProfiles)
+  /** [MutableStateFlow] that provides the [Profile]s. */
+  internal val profilesFlow = MutableStateFlow(defaultProfiles)
 
-    public override suspend fun contains(id: String): Boolean {
-        val ids = profilesFlow.value.map(Profile::id)
-        return id in ids
-    }
+  public override suspend fun contains(id: String): Boolean {
+    val ids = profilesFlow.value.map(Profile::id)
+    return id in ids
+  }
 
-    override suspend fun onProvide(id: String): Flow<Profile> {
-        return profilesFlow.mapNotNull { profiles ->
-            profiles.find { profile ->
-                profile.id == id
-            }
-        }
-    }
+  override suspend fun onProvide(id: String): Flow<Profile> {
+    return profilesFlow.mapNotNull { profiles -> profiles.find { profile -> profile.id == id } }
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/SampleProfileWriter.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/SampleProfileWriter.kt
@@ -7,73 +7,63 @@ import com.jeanbarrossilva.orca.core.sample.feed.profile.type.editable.replacing
 import com.jeanbarrossilva.orca.core.sample.feed.profile.type.followable.SampleFollowableProfile
 import kotlinx.coroutines.flow.update
 
-/** Performs [Profile]-related writing operations. **/
+/** Performs [Profile]-related writing operations. */
 object SampleProfileWriter {
-    /**
-     * Inserts the given [profile], replacing the existing one that has the same [ID][Profile.id] if
-     * it's there.
-     *
-     * @param profile [Profile] to be added.
-     **/
-    fun insert(profile: Profile) {
-        delete(profile.id)
-        SampleProfileProvider.profilesFlow.update { it + profile }
-    }
+  /**
+   * Inserts the given [profile], replacing the existing one that has the same [ID][Profile.id] if
+   * it's there.
+   *
+   * @param profile [Profile] to be added.
+   */
+  fun insert(profile: Profile) {
+    delete(profile.id)
+    SampleProfileProvider.profilesFlow.update { it + profile }
+  }
 
-    /** Resets this [SampleProfileProvider] to its default state. **/
-    fun reset() {
-        SampleProfileProvider.profilesFlow.value = SampleProfileProvider.defaultProfiles
-    }
+  /** Resets this [SampleProfileProvider] to its default state. */
+  fun reset() {
+    SampleProfileProvider.profilesFlow.value = SampleProfileProvider.defaultProfiles
+  }
 
-    /**
-     * Updates the [follow][SampleFollowableProfile.follow] status of the [Profile] whose
-     * [ID][SampleFollowableProfile.id] is equal the given [id].
-     *
-     * @param id [Profile]'s [ID][SampleFollowableProfile.id].
-     * @param follow [Follow] status to update the [SampleFollowableProfile.follow] to.
-     **/
-    internal suspend fun <T : Follow> updateFollow(id: String, follow: T) {
-        update(id) {
-            @Suppress("UNCHECKED_CAST")
-            (this as SampleFollowableProfile<T>).copy(follow = follow)
-        }
+  /**
+   * Updates the [follow][SampleFollowableProfile.follow] status of the [Profile] whose
+   * [ID][SampleFollowableProfile.id] is equal the given [id].
+   *
+   * @param id [Profile]'s [ID][SampleFollowableProfile.id].
+   * @param follow [Follow] status to update the [SampleFollowableProfile.follow] to.
+   */
+  internal suspend fun <T : Follow> updateFollow(id: String, follow: T) {
+    update(id) {
+      @Suppress("UNCHECKED_CAST") (this as SampleFollowableProfile<T>).copy(follow = follow)
     }
+  }
 
-    /**
-     * Deletes the [Profile] whose [ID][Profile.id] equals to the given one.
-     *
-     * @param id ID of the [Profile] to be deleted.
-     **/
-    private fun delete(id: String) {
-        SampleProfileProvider.profilesFlow.update { profiles ->
-            profiles
-                .toMutableList()
-                .apply {
-                    removeIf { profile ->
-                        profile.id == id
-                    }
-                }
-                .toList()
-        }
+  /**
+   * Deletes the [Profile] whose [ID][Profile.id] equals to the given one.
+   *
+   * @param id ID of the [Profile] to be deleted.
+   */
+  private fun delete(id: String) {
+    SampleProfileProvider.profilesFlow.update { profiles ->
+      profiles.toMutableList().apply { removeIf { profile -> profile.id == id } }.toList()
     }
+  }
 
-    /**
-     * Replaces the currently existing [Profile] identified as [id] by its updated version.
-     *
-     * @param id ID of the [Profile] to be updated.
-     * @param update Changes to be made to the existing [Profile].
-     * @throws ProfileProvider.NonexistentProfileException If no [Profile] with such
-     * [ID][Profile.id] exists.
-     **/
-    private suspend fun update(id: String, update: Profile.() -> Profile) {
-        if (SampleProfileProvider.contains(id)) {
-            SampleProfileProvider.profilesFlow.update { profiles ->
-                profiles.replacingOnceBy(update) { profile ->
-                    profile.id == id
-                }
-            }
-        } else {
-            throw ProfileProvider.NonexistentProfileException(id)
-        }
+  /**
+   * Replaces the currently existing [Profile] identified as [id] by its updated version.
+   *
+   * @param id ID of the [Profile] to be updated.
+   * @param update Changes to be made to the existing [Profile].
+   * @throws ProfileProvider.NonexistentProfileException If no [Profile] with such [ID][Profile.id]
+   *   exists.
+   */
+  private suspend fun update(id: String, update: Profile.() -> Profile) {
+    if (SampleProfileProvider.contains(id)) {
+      SampleProfileProvider.profilesFlow.update { profiles ->
+        profiles.replacingOnceBy(update) { profile -> profile.id == id }
+      }
+    } else {
+      throw ProfileProvider.NonexistentProfileException(id)
     }
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/account/Account.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/account/Account.extensions.kt
@@ -5,9 +5,9 @@ import com.jeanbarrossilva.orca.core.feed.profile.account.at
 import com.jeanbarrossilva.orca.core.instance.domain.Domain
 import com.jeanbarrossilva.orca.core.sample.instance.domain.sample
 
-/** [Account] returned by [sample]. **/
+/** [Account] returned by [sample]. */
 private val sampleAccount = "jeanbarrossilva" at Domain.sample.toString()
 
-/** A sample [Account]. **/
+/** A sample [Account]. */
 val Account.Companion.sample
-    get() = sampleAccount
+  get() = sampleAccount

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/search/ProfileSearchResult.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/search/ProfileSearchResult.extensions.kt
@@ -4,19 +4,20 @@ import com.jeanbarrossilva.orca.core.feed.profile.search.ProfileSearchResult
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Author
 import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.sample
 
-/** [ProfileSearchResult] returned by [sample]'s getter. **/
-private val sampleProfileSearchResult = ProfileSearchResult(
+/** [ProfileSearchResult] returned by [sample]'s getter. */
+private val sampleProfileSearchResult =
+  ProfileSearchResult(
     Author.sample.id,
     Author.sample.account,
     Author.sample.avatarURL,
     Author.sample.name,
     Author.sample.profileURL
-)
+  )
 
-/** A sample [ProfileSearchResult]. **/
+/** A sample [ProfileSearchResult]. */
 val ProfileSearchResult.Companion.sample
-    get() = sampleProfileSearchResult
+  get() = sampleProfileSearchResult
 
-/** [ProfileSearchResult] samples. **/
+/** [ProfileSearchResult] samples. */
 val ProfileSearchResult.Companion.samples
-    get() = List(64) { sample }
+  get() = List(64) { sample }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/search/SampleProfileSearcher.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/search/SampleProfileSearcher.kt
@@ -8,14 +8,14 @@ import com.jeanbarrossilva.orca.core.sample.feed.profile.SampleProfileProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-/** [ProfileSearcher] that searches through the sample [Profile]s. **/
+/** [ProfileSearcher] that searches through the sample [Profile]s. */
 internal object SampleProfileSearcher : ProfileSearcher() {
-    override suspend fun onSearch(query: String): Flow<List<ProfileSearchResult>> {
-        return SampleProfileProvider.profilesFlow.map { profiles ->
-            profiles.map(Profile::toProfileSearchResult).filter { profile ->
-                profile.account.toString().contains(query, ignoreCase = true) ||
-                    profile.name.contains(query, ignoreCase = true)
-            }
-        }
+  override suspend fun onSearch(query: String): Flow<List<ProfileSearchResult>> {
+    return SampleProfileProvider.profilesFlow.map { profiles ->
+      profiles.map(Profile::toProfileSearchResult).filter { profile ->
+        profile.account.toString().contains(query, ignoreCase = true) ||
+          profile.name.contains(query, ignoreCase = true)
+      }
     }
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/Author.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/Author.extensions.kt
@@ -7,17 +7,17 @@ import com.jeanbarrossilva.orca.core.sample.auth.actor.sample
 import com.jeanbarrossilva.orca.core.sample.feed.profile.account.sample
 import java.net.URL
 
-/** [Author] returned by [sample]'s getter. **/
-private val sampleAuthor = Author(
+/** [Author] returned by [sample]'s getter. */
+private val sampleAuthor =
+  Author(
     Actor.Authenticated.sample.id,
-    avatarURL = URL(
-        "https://en.gravatar.com/userimage/153558542/08942ba9443ce68bf66345a2e6db656e.png"
-    ),
+    avatarURL =
+      URL("https://en.gravatar.com/userimage/153558542/08942ba9443ce68bf66345a2e6db656e.png"),
     name = "Jean Silva",
     Account.sample,
     profileURL = URL("https://mastodon.social/@jeanbarrossilva")
-)
+  )
 
-/** A sample [Author]. **/
+/** A sample [Author]. */
 val Author.Companion.sample
-    get() = sampleAuthor
+  get() = sampleAuthor

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/SampleToot.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/SampleToot.kt
@@ -9,15 +9,15 @@ import com.jeanbarrossilva.orca.core.feed.profile.toot.stat.toggleable.Toggleabl
 import java.net.URL
 import java.time.ZonedDateTime
 
-/** [Toot] whose operations are performed in memory and serves as a sample. **/
+/** [Toot] whose operations are performed in memory and serves as a sample. */
 internal data class SampleToot(
-    override val id: String,
-    override val author: Author,
-    override val content: Content,
-    override val publicationDateTime: ZonedDateTime,
-    override val url: URL
+  override val id: String,
+  override val author: Author,
+  override val content: Content,
+  override val publicationDateTime: ZonedDateTime,
+  override val url: URL
 ) : Toot() {
-    override val comment = Stat<Toot>()
-    override val favorite = ToggleableStat<Profile>()
-    override val reblog = ToggleableStat<Profile>()
+  override val comment = Stat<Toot>()
+  override val favorite = ToggleableStat<Profile>()
+  override val reblog = ToggleableStat<Profile>()
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/SampleTootProvider.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/SampleTootProvider.kt
@@ -9,44 +9,36 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 
-/** [TootProvider] that provides sample [Toot]s. **/
+/** [TootProvider] that provides sample [Toot]s. */
 object SampleTootProvider : TootProvider {
-    /** [Toot]s that are present by default. **/
-    internal val defaultToots = Toot.samples
+  /** [Toot]s that are present by default. */
+  internal val defaultToots = Toot.samples
 
-    /** [MutableStateFlow] that provides the [Toot]s. **/
-    internal val tootsFlow = MutableStateFlow(defaultToots)
+  /** [MutableStateFlow] that provides the [Toot]s. */
+  internal val tootsFlow = MutableStateFlow(defaultToots)
 
-    /** [IllegalArgumentException] thrown if a nonexistent [Author]'s [Toot]s are requested. **/
-    class NonexistentAuthorException internal constructor(id: String) :
-        IllegalArgumentException("Author identified as \"$id\" doesn't exist.")
+  /** [IllegalArgumentException] thrown if a nonexistent [Author]'s [Toot]s are requested. */
+  class NonexistentAuthorException internal constructor(id: String) :
+    IllegalArgumentException("Author identified as \"$id\" doesn't exist.")
 
-    /** [IllegalArgumentException] thrown if a nonexistent [Toot] is requested. **/
-    class NonexistentTootException internal constructor(id: String) :
-        IllegalArgumentException("Toot identified as \"$id\" doesn't exist.")
+  /** [IllegalArgumentException] thrown if a nonexistent [Toot] is requested. */
+  class NonexistentTootException internal constructor(id: String) :
+    IllegalArgumentException("Toot identified as \"$id\" doesn't exist.")
 
-    override suspend fun provide(id: String): Flow<Toot> {
-        return tootsFlow.mapNotNull { toots ->
-            toots.find { toot ->
-                toot.id == id
-            }
-        }
+  override suspend fun provide(id: String): Flow<Toot> {
+    return tootsFlow.mapNotNull { toots -> toots.find { toot -> toot.id == id } }
+  }
+
+  /**
+   * Provides the [Toot]s made by the author whose ID equals to the given one.
+   *
+   * @param authorID ID of the author whose [Toot]s will be provided.
+   */
+  internal suspend fun provideBy(authorID: String): Flow<List<Toot>> {
+    return if (SampleProfileProvider.contains(authorID)) {
+      tootsFlow.map { toots -> toots.filter { toot -> toot.author.id == authorID } }
+    } else {
+      throw NonexistentAuthorException(authorID)
     }
-
-    /**
-     * Provides the [Toot]s made by the author whose ID equals to the given one.
-     *
-     * @param authorID ID of the author whose [Toot]s will be provided.
-     **/
-    internal suspend fun provideBy(authorID: String): Flow<List<Toot>> {
-        return if (SampleProfileProvider.contains(authorID)) {
-            tootsFlow.map { toots ->
-                toots.filter { toot ->
-                    toot.author.id == authorID
-                }
-            }
-        } else {
-            throw NonexistentAuthorException(authorID)
-        }
-    }
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/SampleTootWriter.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/SampleTootWriter.kt
@@ -3,17 +3,15 @@ package com.jeanbarrossilva.orca.core.sample.feed.profile.toot
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
 import kotlinx.coroutines.flow.update
 
-/** Performs [Toot]-related writing operations. **/
+/** Performs [Toot]-related writing operations. */
 object SampleTootWriter {
-    /** Clears all added [Toot]s, including the default ones. **/
-    fun clear() {
-        SampleTootProvider.tootsFlow.update {
-            emptyList()
-        }
-    }
+  /** Clears all added [Toot]s, including the default ones. */
+  fun clear() {
+    SampleTootProvider.tootsFlow.update { emptyList() }
+  }
 
-    /** Resets this [SampleTootWriter] to its default state. **/
-    fun reset() {
-        SampleTootProvider.tootsFlow.value = SampleTootProvider.defaultToots
-    }
+  /** Resets this [SampleTootWriter] to its default state. */
+  fun reset() {
+    SampleTootProvider.tootsFlow.value = SampleTootProvider.defaultToots
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/Toot.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/Toot.extensions.kt
@@ -9,29 +9,27 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.UUID
 
-/** [Toot] returned by [sample]'s getter. **/
+/** [Toot] returned by [sample]'s getter. */
 private val sampleToot = createSample()
 
-/** [Toot]s returned by [samples]' getter. **/
+/** [Toot]s returned by [samples]' getter. */
 private val sampleToots = listOf(sampleToot) + List(31) { createSample() }
 
-/** A sample [Toot]. **/
+/** A sample [Toot]. */
 val Toot.Companion.sample: Toot
-    get() = sampleToot
+  get() = sampleToot
 
-/**
- * Sample [Toot]s.
- **/
+/** Sample [Toot]s. */
 val Toot.Companion.samples
-    get() = sampleToots
+  get() = sampleToots
 
-/** Creates a sample [Toot]. **/
+/** Creates a sample [Toot]. */
 private fun createSample(): Toot {
-    return SampleToot(
-        "${UUID.randomUUID()}",
-        Author.sample,
-        Content.sample,
-        publicationDateTime = ZonedDateTime.of(2_003, 10, 8, 8, 0, 0, 0, ZoneId.of("GMT-3")),
-        URL("https://mastodon.social/@christianselig/110492858891694580")
-    )
+  return SampleToot(
+    "${UUID.randomUUID()}",
+    Author.sample,
+    Content.sample,
+    publicationDateTime = ZonedDateTime.of(2_003, 10, 8, 8, 0, 0, 0, ZoneId.of("GMT-3")),
+    URL("https://mastodon.social/@christianselig/110492858891694580")
+  )
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/Content.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/Content.extensions.kt
@@ -8,26 +8,28 @@ import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.content.highlight.
 import com.jeanbarrossilva.orca.std.styledstring.buildStyledString
 import java.net.URL
 
-/** [Content] that's returned by [sample]'s getter. **/
-private val sampleContent = Content.from(
+/** [Content] that's returned by [sample]'s getter. */
+private val sampleContent =
+  Content.from(
     buildStyledString {
-        +"This is a "
-        bold { +"sample" }
-        italic { +"toot" }
-        +"that has the sole purpose of allowing one to see how it would look like in Orca."
-        +"\n".repeat(2)
-        +Highlight.sample.url.toString()
+      +"This is a "
+      bold { +"sample" }
+      italic { +"toot" }
+      +"that has the sole purpose of allowing one to see how it would look like in Orca."
+      +"\n".repeat(2)
+      +Highlight.sample.url.toString()
     },
-    attachments = listOf(
+    attachments =
+      listOf(
         Attachment(
-            description = "Abstract art",
-            URL("https://images.unsplash.com/photo-1692890846581-da1a95435f34")
+          description = "Abstract art",
+          URL("https://images.unsplash.com/photo-1692890846581-da1a95435f34")
         )
-    )
-) {
+      )
+  ) {
     Headline.sample
-}
+  }
 
-/** Sample [Content]. **/
+/** Sample [Content]. */
 val Content.Companion.sample
-    get() = sampleContent
+  get() = sampleContent

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/highlight/Headline.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/highlight/Headline.extensions.kt
@@ -3,15 +3,15 @@ package com.jeanbarrossilva.orca.core.sample.feed.profile.toot.content.highlight
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Headline
 import java.net.URL
 
-/** [Headline] that's returned by [sample]'s getter. **/
-private val sampleHeadline = Headline(
+/** [Headline] that's returned by [sample]'s getter. */
+private val sampleHeadline =
+  Headline(
     title = "Mastodon",
     subtitle = "The original server operated by the Mastodon gGmbH non-profit.",
-    coverURL = URL(
-        "https://files.mastodon.social/site_uploads/files/000/000/001/@1x/57c12f441d083cde.png"
-    )
-)
+    coverURL =
+      URL("https://files.mastodon.social/site_uploads/files/000/000/001/@1x/57c12f441d083cde.png")
+  )
 
-/** Sample [Headline]. **/
+/** Sample [Headline]. */
 val Headline.Companion.sample
-    get() = sampleHeadline
+  get() = sampleHeadline

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/highlight/Highlight.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/highlight/Highlight.extensions.kt
@@ -4,9 +4,9 @@ import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Headlin
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Highlight
 import java.net.URL
 
-/** [Highlight] that's returned by [sample]'s getter. **/
+/** [Highlight] that's returned by [sample]'s getter. */
 private val sampleHighlight = Highlight(Headline.sample, URL("https://mastodon.social"))
 
-/** Sample [Highlight]. **/
+/** Sample [Highlight]. */
 val Highlight.Companion.sample
-    get() = sampleHighlight
+  get() = sampleHighlight

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/muting/SampleTermMuter.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/muting/SampleTermMuter.kt
@@ -3,13 +3,13 @@ package com.jeanbarrossilva.orca.core.sample.feed.profile.toot.muting
 import com.jeanbarrossilva.orca.core.feed.profile.toot.muting.TermMuter
 import kotlinx.coroutines.flow.MutableStateFlow
 
-/** An in-memory [TermMuter]. **/
+/** An in-memory [TermMuter]. */
 @Suppress("FunctionName")
 fun SampleTermMuter(): TermMuter {
-    val termsFlow = MutableStateFlow(emptyList<String>())
-    return TermMuter {
-        getTerms { termsFlow }
-        mute { termsFlow.value += it }
-        unmute { termsFlow.value -= it }
-    }
+  val termsFlow = MutableStateFlow(emptyList<String>())
+  return TermMuter {
+    getTerms { termsFlow }
+    mute { termsFlow.value += it }
+    unmute { termsFlow.value -= it }
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/editable/Collection.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/editable/Collection.extensions.kt
@@ -5,12 +5,12 @@ package com.jeanbarrossilva.orca.core.sample.feed.profile.type.editable
  * that match the [predicate] and have been replaced by the result of [replacement].
  *
  * @param replacement Lambda that receives the candidate being currently iterated and returns the
- * replacement of the one that matches the [predicate].
+ *   replacement of the one that matches the [predicate].
  * @param predicate Indicates whether the given candidate should be replaced by the result of
- * [replacement].
- **/
+ *   [replacement].
+ */
 fun <T> Collection<T>.replacingBy(replacement: T.() -> T, predicate: (T) -> Boolean): List<T> {
-    return toMutableList().apply { replaceBy(replacement, predicate) }.toList()
+  return toMutableList().apply { replaceBy(replacement, predicate) }.toList()
 }
 
 /**
@@ -18,12 +18,14 @@ fun <T> Collection<T>.replacingBy(replacement: T.() -> T, predicate: (T) -> Bool
  * that match the [predicate] and have been replaced by the result of [replacement].
  *
  * @param replacement Lambda that receives the candidate being currently iterated and returns the
- * replacement of the one that matches the [predicate].
+ *   replacement of the one that matches the [predicate].
  * @param predicate Indicates whether the given candidate should be replaced by the result of
- * [replacement].
+ *   [replacement].
  * @throws IllegalStateException If multiple elements match the [predicate].
- **/
-internal fun <T> Collection<T>.replacingOnceBy(replacement: T.() -> T, predicate: (T) -> Boolean):
-    List<T> {
-    return toMutableList().apply { replaceOnceBy(replacement, predicate) }.toList()
+ */
+internal fun <T> Collection<T>.replacingOnceBy(
+  replacement: T.() -> T,
+  predicate: (T) -> Boolean
+): List<T> {
+  return toMutableList().apply { replaceOnceBy(replacement, predicate) }.toList()
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/editable/EditableProfile.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/editable/EditableProfile.extensions.kt
@@ -4,8 +4,9 @@ import com.jeanbarrossilva.orca.core.feed.profile.Profile
 import com.jeanbarrossilva.orca.core.feed.profile.type.editable.EditableProfile
 import com.jeanbarrossilva.orca.core.sample.feed.profile.sample
 
-/** [EditableProfile] returned by [sample]'s getter. **/
-private val sampleEditableProfile: EditableProfile = SampleEditableProfile.createInstance(
+/** [EditableProfile] returned by [sample]'s getter. */
+private val sampleEditableProfile: EditableProfile =
+  SampleEditableProfile.createInstance(
     Profile.sample.id,
     Profile.sample.account,
     Profile.sample.avatarURL,
@@ -14,8 +15,8 @@ private val sampleEditableProfile: EditableProfile = SampleEditableProfile.creat
     Profile.sample.followerCount,
     Profile.sample.followingCount,
     Profile.sample.url
-)
+  )
 
-/** A sample [EditableProfile]. **/
+/** A sample [EditableProfile]. */
 val EditableProfile.Companion.sample
-    get() = sampleEditableProfile
+  get() = sampleEditableProfile

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/editable/MutableCollection.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/editable/MutableCollection.extensions.kt
@@ -5,38 +5,36 @@ package com.jeanbarrossilva.orca.core.sample.feed.profile.type.editable
  * that match the [predicate] and have been replaced by the result of [replacement].
  *
  * @param replacement Lambda that receives the candidate being currently iterated and returns the
- * replacement of the one that matches the [predicate].
+ *   replacement of the one that matches the [predicate].
  * @param predicate Indicates whether the given candidate should be replaced by the result of
- * [replacement].
+ *   [replacement].
  * @return Whether an element matching the [predicate] has been found and replaced.
  * @throws IllegalStateException If multiple elements match the [predicate].
- **/
+ */
 fun <T> MutableList<T>.replaceOnceBy(replacement: T.() -> T, predicate: (T) -> Boolean): Boolean {
-    var replaced: T? = null
-    replaceBy(replacement) {
-        val isMatch = predicate(it)
-        if (isMatch) {
-            if (replaced == null) {
-                replaced = it
-            } else {
-                throw IllegalStateException("Multiple predicate matches: $replaced and $it.")
-            }
-        }
-        isMatch
+  var replaced: T? = null
+  replaceBy(replacement) {
+    val isMatch = predicate(it)
+    if (isMatch) {
+      if (replaced == null) {
+        replaced = it
+      } else {
+        throw IllegalStateException("Multiple predicate matches: $replaced and $it.")
+      }
     }
-    return replaced != null
+    isMatch
+  }
+  return replaced != null
 }
 
 /**
  * Replaces the elements that match the [predicate] by the result of [replacement].
  *
  * @param replacement Lambda that receives the candidate being currently iterated and returns the
- * replacement of the one that matches the [predicate].
+ *   replacement of the one that matches the [predicate].
  * @param predicate Indicates whether the given candidate should be replaced by the result of
- * [replacement].
- **/
+ *   [replacement].
+ */
 internal fun <T> MutableList<T>.replaceBy(replacement: T.() -> T, predicate: (T) -> Boolean) {
-    replaceAll {
-        if (predicate(it)) it.replacement() else it
-    }
+  replaceAll { if (predicate(it)) it.replacement() else it }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/editable/SampleEditableProfile.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/editable/SampleEditableProfile.kt
@@ -11,57 +11,55 @@ import java.net.URL
  * [SampleProfile] that's also editable.
  *
  * @see EditableProfile
- **/
+ */
 abstract class SampleEditableProfile private constructor() : SampleProfile, EditableProfile() {
-    abstract override var avatarURL: URL
-    abstract override var name: String
-    abstract override var bio: StyledString
+  abstract override var avatarURL: URL
+  abstract override var name: String
+  abstract override var bio: StyledString
 
-    override val editor: Editor by lazy {
-        SampleEditor(id)
-    }
+  override val editor: Editor by lazy { SampleEditor(id) }
 
-    override fun toString(): String {
-        return "SampleEditableProfile(id=$id, account=$account, avatarURL=$avatarURL, " +
-            "name=$name, bio=$bio, followerCount=$followerCount, followingCount=$followingCount, " +
-            "url=$url)"
-    }
+  override fun toString(): String {
+    return "SampleEditableProfile(id=$id, account=$account, avatarURL=$avatarURL, " +
+      "name=$name, bio=$bio, followerCount=$followerCount, followingCount=$followingCount, " +
+      "url=$url)"
+  }
 
-    companion object {
-        /**
-         * Creates an instance of a [SampleEditableProfile].
-         *
-         * @param id Unique identifier.
-         * @param account Unique identifier within an instance.
-         * @param avatarURL [URL] that leads to the avatar image.
-         * @param name Name to be displayed.
-         * @param bio Describes who the owner is and/or provides information regarding this
-         * [SampleEditableProfile].
-         * @param followerCount Amount of followers.
-         * @param followingCount Amount of following.
-         * @param url [URL] that leads to the webpage of the instance through which this
-         * [SampleEditableProfile] can be accessed.
-         **/
-        fun createInstance(
-            id: String,
-            account: Account,
-            avatarURL: URL,
-            name: String,
-            bio: StyledString,
-            followerCount: Int,
-            followingCount: Int,
-            url: URL
-        ): SampleEditableProfile {
-            return object : SampleEditableProfile() {
-                override val id = id
-                override val account = account
-                override var avatarURL = avatarURL
-                override var name = name
-                override var bio = bio
-                override val followerCount = followerCount
-                override val followingCount = followingCount
-                override val url = url
-            }
-        }
+  companion object {
+    /**
+     * Creates an instance of a [SampleEditableProfile].
+     *
+     * @param id Unique identifier.
+     * @param account Unique identifier within an instance.
+     * @param avatarURL [URL] that leads to the avatar image.
+     * @param name Name to be displayed.
+     * @param bio Describes who the owner is and/or provides information regarding this
+     *   [SampleEditableProfile].
+     * @param followerCount Amount of followers.
+     * @param followingCount Amount of following.
+     * @param url [URL] that leads to the webpage of the instance through which this
+     *   [SampleEditableProfile] can be accessed.
+     */
+    fun createInstance(
+      id: String,
+      account: Account,
+      avatarURL: URL,
+      name: String,
+      bio: StyledString,
+      followerCount: Int,
+      followingCount: Int,
+      url: URL
+    ): SampleEditableProfile {
+      return object : SampleEditableProfile() {
+        override val id = id
+        override val account = account
+        override var avatarURL = avatarURL
+        override var name = name
+        override var bio = bio
+        override val followerCount = followerCount
+        override val followingCount = followingCount
+        override val url = url
+      }
     }
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/editable/SampleEditor.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/editable/SampleEditor.kt
@@ -5,37 +5,30 @@ import com.jeanbarrossilva.orca.core.sample.feed.profile.SampleProfileProvider
 import com.jeanbarrossilva.orca.std.styledstring.StyledString
 import java.net.URL
 
-/** [Editor] that edits [SampleEditableProfile]s. **/
+/** [Editor] that edits [SampleEditableProfile]s. */
 internal class SampleEditor(private val id: String) : Editor {
-    override suspend fun setAvatarURL(avatarURL: URL) {
-        edit {
-            this.avatarURL = avatarURL
-        }
-    }
+  override suspend fun setAvatarURL(avatarURL: URL) {
+    edit { this.avatarURL = avatarURL }
+  }
 
-    override suspend fun setName(name: String) {
-        edit {
-            this.name = name
-        }
-    }
+  override suspend fun setName(name: String) {
+    edit { this.name = name }
+  }
 
-    override suspend fun setBio(bio: StyledString) {
-        edit {
-            this.bio = bio
-        }
-    }
+  override suspend fun setBio(bio: StyledString) {
+    edit { this.bio = bio }
+  }
 
-    /**
-     * Applies the [edit] to the [SampleEditableProfile] whose [ID][SampleEditableProfile.id]
-     * matches [id].
-     *
-     * @param edit Editing to be made to the matching [SampleEditableProfile].
-     **/
-    private inline fun edit(crossinline edit: SampleEditableProfile.() -> Unit) {
-        SampleProfileProvider.profilesFlow.value = SampleProfileProvider
-            .profilesFlow
-            .value
-            .filterIsInstance<SampleEditableProfile>()
-            .replacingOnceBy({ apply(edit) }) { it.id == id }
-    }
+  /**
+   * Applies the [edit] to the [SampleEditableProfile] whose [ID][SampleEditableProfile.id] matches
+   * [id].
+   *
+   * @param edit Editing to be made to the matching [SampleEditableProfile].
+   */
+  private inline fun edit(crossinline edit: SampleEditableProfile.() -> Unit) {
+    SampleProfileProvider.profilesFlow.value =
+      SampleProfileProvider.profilesFlow.value
+        .filterIsInstance<SampleEditableProfile>()
+        .replacingOnceBy({ apply(edit) }) { it.id == id }
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/followable/FollowableProfile.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/followable/FollowableProfile.extensions.kt
@@ -5,8 +5,9 @@ import com.jeanbarrossilva.orca.core.feed.profile.type.followable.Follow
 import com.jeanbarrossilva.orca.core.feed.profile.type.followable.FollowableProfile
 import com.jeanbarrossilva.orca.core.sample.feed.profile.sample
 
-/** [FollowableProfile] that's returned by [sample]'s getter. **/
-private val sampleFollowableProfile: FollowableProfile<*> = SampleFollowableProfile(
+/** [FollowableProfile] that's returned by [sample]'s getter. */
+private val sampleFollowableProfile: FollowableProfile<*> =
+  SampleFollowableProfile(
     Profile.sample.id,
     Profile.sample.account,
     Profile.sample.avatarURL,
@@ -16,8 +17,8 @@ private val sampleFollowableProfile: FollowableProfile<*> = SampleFollowableProf
     Profile.sample.followerCount,
     Profile.sample.followingCount,
     Profile.sample.url
-)
+  )
 
-/** A sample [FollowableProfile]. **/
+/** A sample [FollowableProfile]. */
 val FollowableProfile.Companion.sample
-    get() = sampleFollowableProfile
+  get() = sampleFollowableProfile

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/followable/SampleFollowableProfile.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/followable/SampleFollowableProfile.kt
@@ -12,19 +12,19 @@ import java.net.URL
  * [SampleProfile] that's also followable.
  *
  * @see FollowableProfile
- **/
+ */
 internal data class SampleFollowableProfile<T : Follow>(
-    override val id: String,
-    override val account: Account,
-    override val avatarURL: URL,
-    override val name: String,
-    override val bio: StyledString,
-    override val follow: T,
-    override val followerCount: Int,
-    override val followingCount: Int,
-    override val url: URL
+  override val id: String,
+  override val account: Account,
+  override val avatarURL: URL,
+  override val name: String,
+  override val bio: StyledString,
+  override val follow: T,
+  override val followerCount: Int,
+  override val followingCount: Int,
+  override val url: URL
 ) : SampleProfile, FollowableProfile<T>() {
-    override suspend fun onChangeFollowTo(follow: T) {
-        SampleProfileWriter.updateFollow(id, follow)
-    }
+  override suspend fun onChangeFollowTo(follow: T) {
+    SampleProfileWriter.updateFollow(id, follow)
+  }
 }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/instance/Instance.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/instance/Instance.extensions.kt
@@ -13,8 +13,9 @@ import com.jeanbarrossilva.orca.core.sample.feed.profile.search.SampleProfileSea
 import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.SampleTootProvider
 import com.jeanbarrossilva.orca.core.sample.instance.domain.sample
 
-/** [Instance] returned by [sample]. **/
-private val sampleInstance = object : Instance<Authenticator>() {
+/** [Instance] returned by [sample]. */
+private val sampleInstance =
+  object : Instance<Authenticator>() {
     override val domain = Domain.sample
     override val authenticator: Authenticator = SampleAuthenticator
     override val authenticationLock = AuthenticationLock(authenticator, ActorProvider.sample)
@@ -22,8 +23,8 @@ private val sampleInstance = object : Instance<Authenticator>() {
     override val profileProvider = SampleProfileProvider
     override val profileSearcher = SampleProfileSearcher
     override val tootProvider = SampleTootProvider
-}
+  }
 
-/** Sample [Instance]. **/
+/** Sample [Instance]. */
 val Instance.Companion.sample
-    get() = sampleInstance
+  get() = sampleInstance

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/instance/InstanceProvider.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/instance/InstanceProvider.extensions.kt
@@ -4,13 +4,14 @@ import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.core.instance.InstanceProvider
 import com.jeanbarrossilva.orca.core.instance.SomeInstance
 
-/** [InstanceProvider] returned by [sample]. **/
-private val sampleInstanceProvider = object : InstanceProvider {
+/** [InstanceProvider] returned by [sample]. */
+private val sampleInstanceProvider =
+  object : InstanceProvider {
     override fun provide(): SomeInstance {
-        return Instance.sample
+      return Instance.sample
     }
-}
+  }
 
-/** Sample [InstanceProvider]. **/
+/** Sample [InstanceProvider]. */
 val InstanceProvider.Companion.sample
-    get() = sampleInstanceProvider
+  get() = sampleInstanceProvider

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/instance/domain/Domain.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/instance/domain/Domain.extensions.kt
@@ -2,9 +2,10 @@ package com.jeanbarrossilva.orca.core.sample.instance.domain
 
 import com.jeanbarrossilva.orca.core.instance.domain.Domain
 
-/** [Domain]s returned by [sample]s. **/
+/** [Domain]s returned by [sample]s. */
 @Suppress("SpellCheckingInspection")
-private val sampleDomains = listOf(
+private val sampleDomains =
+  listOf(
     Domain("instance.sample"),
     Domain("kpop.social"),
     Domain("linuxrocks.online"),
@@ -18,12 +19,12 @@ private val sampleDomains = listOf(
     Domain("sciences.social"),
     Domain("techhub.social"),
     Domain("universeodon.com")
-)
+  )
 
-/** Sample [Domain]. **/
+/** Sample [Domain]. */
 val Domain.Companion.sample
-    get() = sampleDomains.first()
+  get() = sampleDomains.first()
 
-/** Sample [Domain]s. **/
+/** Sample [Domain]s. */
 val Domain.Companion.samples
-    get() = sampleDomains
+  get() = sampleDomains

--- a/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/SampleFeedProviderTests.kt
+++ b/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/SampleFeedProviderTests.kt
@@ -11,17 +11,13 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 
 internal class SampleFeedProviderTests {
-    @get:Rule
-    val sampleRule = SampleTestRule()
+  @get:Rule val sampleRule = SampleTestRule()
 
-    @Test
-    fun `GIVEN an empty list of toots WHEN providing it THEN it's provided`() {
-        SampleTootWriter.clear()
-        runTest {
-            assertContentEquals(
-                emptyList(),
-                SampleFeedProvider.provide(Profile.sample.id, 0).first()
-            )
-        }
+  @Test
+  fun `GIVEN an empty list of toots WHEN providing it THEN it's provided`() {
+    SampleTootWriter.clear()
+    runTest {
+      assertContentEquals(emptyList(), SampleFeedProvider.provide(Profile.sample.id, 0).first())
     }
+  }
 }

--- a/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/profile/ProfileExtensionsTests.kt
+++ b/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/profile/ProfileExtensionsTests.kt
@@ -9,13 +9,13 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
 internal class ProfileExtensionsTests {
-    @Test
-    fun `GIVEN a sample profile WHEN getting its toots THEN they are the sample ones`() {
-        runTest {
-            assertContentEquals(
-                Toot.samples.take(SampleProfile.TOOTS_PER_PAGE),
-                Profile.sample.getToots(0).first()
-            )
-        }
+  @Test
+  fun `GIVEN a sample profile WHEN getting its toots THEN they are the sample ones`() {
+    runTest {
+      assertContentEquals(
+        Toot.samples.take(SampleProfile.TOOTS_PER_PAGE),
+        Profile.sample.getToots(0).first()
+      )
     }
+  }
 }

--- a/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/profile/SampleProfileProviderTests.kt
+++ b/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/profile/SampleProfileProviderTests.kt
@@ -10,17 +10,16 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 
 internal class SampleProfileProviderTests {
-    @get:Rule
-    val sampleRule = SampleTestRule()
+  @get:Rule val sampleRule = SampleTestRule()
 
-    @Test
-    fun `GIVEN a profile without toots WHEN providing it and getting them THEN they're obtained`() {
-        SampleTootWriter.clear()
-        runTest {
-            assertContentEquals(
-                emptyList(),
-                SampleProfileProvider.provide(Profile.sample.id).first().getToots(0).first()
-            )
-        }
+  @Test
+  fun `GIVEN a profile without toots WHEN providing it and getting them THEN they're obtained`() {
+    SampleTootWriter.clear()
+    runTest {
+      assertContentEquals(
+        emptyList(),
+        SampleProfileProvider.provide(Profile.sample.id).first().getToots(0).first()
+      )
     }
+  }
 }

--- a/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/profile/SampleProfileTests.kt
+++ b/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/profile/SampleProfileTests.kt
@@ -8,41 +8,30 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 
 internal class SampleProfileTests {
-    @get:Rule
-    val sampleRule = SampleTestRule()
+  @get:Rule val sampleRule = SampleTestRule()
 
-    @Test
-    fun `GIVEN a public unfollowed profile WHEN toggling its follow status THEN it's followed`() {
-        runTest {
-            assertTogglingEquals(Follow.Public.following(), Follow.Public.unfollowed())
-        }
-    }
+  @Test
+  fun `GIVEN a public unfollowed profile WHEN toggling its follow status THEN it's followed`() {
+    runTest { assertTogglingEquals(Follow.Public.following(), Follow.Public.unfollowed()) }
+  }
 
-    @Test
-    fun `GIVEN a public followed profile WHEN toggling its follow status THEN it's not followed`() {
-        runTest {
-            assertTogglingEquals(Follow.Public.unfollowed(), Follow.Public.following())
-        }
-    }
+  @Test
+  fun `GIVEN a public followed profile WHEN toggling its follow status THEN it's not followed`() {
+    runTest { assertTogglingEquals(Follow.Public.unfollowed(), Follow.Public.following()) }
+  }
 
-    @Test
-    fun `GIVEN a private unfollowed profile WHEN toggling its follow status THEN it's requested`() {
-        runTest {
-            assertTogglingEquals(Follow.Private.requested(), Follow.Private.unfollowed())
-        }
-    }
+  @Test
+  fun `GIVEN a private unfollowed profile WHEN toggling its follow status THEN it's requested`() {
+    runTest { assertTogglingEquals(Follow.Private.requested(), Follow.Private.unfollowed()) }
+  }
 
-    @Test
-    fun `GIVEN a private requested profile WHEN toggling its follow status THEN it's unfollowed`() {
-        runTest {
-            assertTogglingEquals(Follow.Private.unfollowed(), Follow.Private.requested())
-        }
-    }
+  @Test
+  fun `GIVEN a private requested profile WHEN toggling its follow status THEN it's unfollowed`() {
+    runTest { assertTogglingEquals(Follow.Private.unfollowed(), Follow.Private.requested()) }
+  }
 
-    @Test
-    fun `GIVEN a private followed profile WHEN toggling its follow status THEN it's unfollowed`() {
-        runTest {
-            assertTogglingEquals(Follow.Private.unfollowed(), Follow.Private.following())
-        }
-    }
+  @Test
+  fun `GIVEN a private followed profile WHEN toggling its follow status THEN it's unfollowed`() {
+    runTest { assertTogglingEquals(Follow.Private.unfollowed(), Follow.Private.following()) }
+  }
 }

--- a/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/SampleTootProviderTests.kt
+++ b/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/SampleTootProviderTests.kt
@@ -7,12 +7,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
 internal class SampleTootProviderTests {
-    @Test
-    fun `GIVEN all toot samples WHEN getting them by their IDs THEN they're returned`() {
-        runTest {
-            Toot.samples.forEach {
-                assertEquals(it, SampleTootProvider.provide(it.id).first())
-            }
-        }
-    }
+  @Test
+  fun `GIVEN all toot samples WHEN getting them by their IDs THEN they're returned`() {
+    runTest { Toot.samples.forEach { assertEquals(it, SampleTootProvider.provide(it.id).first()) } }
+  }
 }

--- a/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/editable/CollectionExtensionsTests.kt
+++ b/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/feed/profile/type/editable/CollectionExtensionsTests.kt
@@ -5,20 +5,18 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertFailsWith
 
 internal class CollectionExtensionsTests {
-    @Test
-    fun `GIVEN a duplicate item WHEN replacing it once THEN it throws`() {
-        assertFailsWith<IllegalStateException> {
-            listOf("Hello", "Hello", "world").replacingOnceBy({ "Goodbye" }) {
-                it == "Hello"
-            }
-        }
+  @Test
+  fun `GIVEN a duplicate item WHEN replacing it once THEN it throws`() {
+    assertFailsWith<IllegalStateException> {
+      listOf("Hello", "Hello", "world").replacingOnceBy({ "Goodbye" }) { it == "Hello" }
     }
+  }
 
-    @Test
-    fun `GIVEN an item WHEN replacing it once THEN it's replaced`() {
-        assertContentEquals(
-            listOf("Hello", "world"),
-            listOf("Goodbye", "world").replacingOnceBy({ "Hello" }) { it == "Goodbye" }
-        )
-    }
+  @Test
+  fun `GIVEN an item WHEN replacing it once THEN it's replaced`() {
+    assertContentEquals(
+      listOf("Hello", "world"),
+      listOf("Goodbye", "world").replacingOnceBy({ "Hello" }) { it == "Goodbye" }
+    )
+  }
 }

--- a/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/test/Asserter.extensions.kt
+++ b/core/sample/src/test/java/com/jeanbarrossilva/orca/core/sample/test/Asserter.extensions.kt
@@ -18,22 +18,21 @@ import kotlinx.coroutines.flow.onEach
  *
  * @param before [Follow] status before the [toggle][SampleFollowableProfile.toggleFollow].
  * @param after [Follow] status after the [toggle][SampleFollowableProfile.toggleFollow].
- **/
+ */
 internal suspend fun <T : Follow> assertTogglingEquals(after: T, before: T) {
-    val matchingAfter = Follow.requireVisibilityMatch(before, after)
-    val profile =
-        @Suppress("UNCHECKED_CAST")
-        (FollowableProfile.sample as SampleFollowableProfile<T>).copy(follow = before)
+  val matchingAfter = Follow.requireVisibilityMatch(before, after)
+  val profile =
+    @Suppress("UNCHECKED_CAST")
+    (FollowableProfile.sample as SampleFollowableProfile<T>).copy(follow = before)
 
-    SampleProfileWriter.insert(profile)
-    assertEquals(
-        matchingAfter,
-        SampleProfileProvider
-            .provide(profile.id)
-            .filterIsInstance<FollowableProfile<T>>()
-            .onEach(FollowableProfile<T>::toggleFollow)
-            .drop(1)
-            .first()
-            .follow
-    )
+  SampleProfileWriter.insert(profile)
+  assertEquals(
+    matchingAfter,
+    SampleProfileProvider.provide(profile.id)
+      .filterIsInstance<FollowableProfile<T>>()
+      .onEach(FollowableProfile<T>::toggleFollow)
+      .drop(1)
+      .first()
+      .follow
+  )
 }

--- a/core/shared-preferences/src/androidTest/java/com/jeanbarrossilva/orca/core/sharedpreferences/actor/SharedPreferencesActorProviderTests.kt
+++ b/core/shared-preferences/src/androidTest/java/com/jeanbarrossilva/orca/core/sharedpreferences/actor/SharedPreferencesActorProviderTests.kt
@@ -7,15 +7,14 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class SharedPreferencesActorProviderTests {
-    @get:Rule
-    val coreRule = SharedPreferencesCoreTestRule()
+  @get:Rule val coreRule = SharedPreferencesCoreTestRule()
 
-    @Test
-    fun remembersActorWhenProvidingItForTheFirstTime() {
-        runTest {
-            val originalActor = coreRule.actorProvider.provide()
-            val rememberedActor = coreRule.actorProvider.provide()
-            assertEquals(originalActor, rememberedActor)
-        }
+  @Test
+  fun remembersActorWhenProvidingItForTheFirstTime() {
+    runTest {
+      val originalActor = coreRule.actorProvider.provide()
+      val rememberedActor = coreRule.actorProvider.provide()
+      assertEquals(originalActor, rememberedActor)
     }
+  }
 }

--- a/core/shared-preferences/src/androidTest/java/com/jeanbarrossilva/orca/core/sharedpreferences/actor/test/SharedPreferencesCoreTestRule.kt
+++ b/core/shared-preferences/src/androidTest/java/com/jeanbarrossilva/orca/core/sharedpreferences/actor/test/SharedPreferencesCoreTestRule.kt
@@ -7,21 +7,22 @@ import com.jeanbarrossilva.orca.core.sharedpreferences.feed.profile.toot.muting.
 import org.junit.rules.ExternalResource
 
 internal class SharedPreferencesCoreTestRule : ExternalResource() {
-    private val context
-        get() = InstrumentationRegistry.getInstrumentation().context
+  private val context
+    get() = InstrumentationRegistry.getInstrumentation().context
 
-    lateinit var actorProvider: SharedPreferencesActorProvider
-        private set
-    lateinit var termMuter: TermMuter
-        private set
+  lateinit var actorProvider: SharedPreferencesActorProvider
+    private set
 
-    override fun before() {
-        actorProvider = SharedPreferencesActorProvider(context)
-        termMuter = SharedPreferencesTermMuter(context)
-    }
+  lateinit var termMuter: TermMuter
+    private set
 
-    override fun after() {
-        actorProvider.reset()
-        SharedPreferencesTermMuter.reset(context)
-    }
+  override fun before() {
+    actorProvider = SharedPreferencesActorProvider(context)
+    termMuter = SharedPreferencesTermMuter(context)
+  }
+
+  override fun after() {
+    actorProvider.reset()
+    SharedPreferencesTermMuter.reset(context)
+  }
 }

--- a/core/shared-preferences/src/androidTest/java/com/jeanbarrossilva/orca/core/sharedpreferences/feed/profile/toot/muting/SharedPreferencesTermMuterTests.kt
+++ b/core/shared-preferences/src/androidTest/java/com/jeanbarrossilva/orca/core/sharedpreferences/feed/profile/toot/muting/SharedPreferencesTermMuterTests.kt
@@ -10,46 +10,42 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class SharedPreferencesTermMuterTests {
-    private val context
-        get() = InstrumentationRegistry.getInstrumentation().context
+  private val context
+    get() = InstrumentationRegistry.getInstrumentation().context
 
-    @get:Rule
-    val coreRule = SharedPreferencesCoreTestRule()
+  @get:Rule val coreRule = SharedPreferencesCoreTestRule()
 
-    @Test
-    fun persistsMutedTerm() {
-        runTest {
-            coreRule.termMuter.mute("🐝")
-            assertEquals(
-                "🐝",
-                SharedPreferencesTermMuter.getPreferences(context).getString("🐝", null)
-            )
-        }
+  @Test
+  fun persistsMutedTerm() {
+    runTest {
+      coreRule.termMuter.mute("🐝")
+      assertEquals("🐝", SharedPreferencesTermMuter.getPreferences(context).getString("🐝", null))
     }
+  }
 
-    @Test
-    fun emitsListWithMutedTerm() {
-        runTest {
-            coreRule.termMuter.mute("☠️")
-            coreRule.termMuter.getTerms().test { assertEquals(listOf("☠️"), awaitItem()) }
-        }
+  @Test
+  fun emitsListWithMutedTerm() {
+    runTest {
+      coreRule.termMuter.mute("☠️")
+      coreRule.termMuter.getTerms().test { assertEquals(listOf("☠️"), awaitItem()) }
     }
+  }
 
-    @Test
-    fun removesUnmutedTerm() {
-        runTest {
-            coreRule.termMuter.mute("👒")
-            coreRule.termMuter.unmute("👒")
-            assertNull(SharedPreferencesTermMuter.getPreferences(context).getString("👒", null))
-        }
+  @Test
+  fun removesUnmutedTerm() {
+    runTest {
+      coreRule.termMuter.mute("👒")
+      coreRule.termMuter.unmute("👒")
+      assertNull(SharedPreferencesTermMuter.getPreferences(context).getString("👒", null))
     }
+  }
 
-    @Test
-    fun emitsListWithoutUnmutedTerm() {
-        runTest {
-            coreRule.termMuter.mute("💀")
-            coreRule.termMuter.unmute("💀")
-            coreRule.termMuter.getTerms().test { assertEquals(emptyList<String>(), awaitItem()) }
-        }
+  @Test
+  fun emitsListWithoutUnmutedTerm() {
+    runTest {
+      coreRule.termMuter.mute("💀")
+      coreRule.termMuter.unmute("💀")
+      coreRule.termMuter.getTerms().test { assertEquals(emptyList<String>(), awaitItem()) }
     }
+  }
 }

--- a/core/shared-preferences/src/main/java/com/jeanbarrossilva/orca/core/sharedpreferences/actor/SharedPreferencesActorProvider.kt
+++ b/core/shared-preferences/src/main/java/com/jeanbarrossilva/orca/core/sharedpreferences/actor/SharedPreferencesActorProvider.kt
@@ -11,30 +11,27 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 class SharedPreferencesActorProvider(context: Context) : ActorProvider() {
-    private val preferences: SharedPreferences =
-        context.getSharedPreferences("shared-preferences-actor-provider", Context.MODE_PRIVATE)
+  private val preferences: SharedPreferences =
+    context.getSharedPreferences("shared-preferences-actor-provider", Context.MODE_PRIVATE)
 
-    override suspend fun remember(actor: Actor) {
-        val mirroredActor = actor.toMirroredActor()
-        val mirroredActorAsJson = Json.encodeToString(mirroredActor)
-        preferences.edit { putString(MIRRORED_ACTOR_KEY, mirroredActorAsJson) }
-    }
+  override suspend fun remember(actor: Actor) {
+    val mirroredActor = actor.toMirroredActor()
+    val mirroredActorAsJson = Json.encodeToString(mirroredActor)
+    preferences.edit { putString(MIRRORED_ACTOR_KEY, mirroredActorAsJson) }
+  }
 
-    override suspend fun retrieve(): Actor {
-        return preferences
-            .getString(MIRRORED_ACTOR_KEY, null)
-            ?.let { Json.decodeFromString<MirroredActor>(it) }
-            ?.toActor()
-            ?: Actor.Unauthenticated
-    }
+  override suspend fun retrieve(): Actor {
+    return preferences
+      .getString(MIRRORED_ACTOR_KEY, null)
+      ?.let { Json.decodeFromString<MirroredActor>(it) }
+      ?.toActor() ?: Actor.Unauthenticated
+  }
 
-    internal fun reset() {
-        preferences.edit {
-            remove(MIRRORED_ACTOR_KEY)
-        }
-    }
+  internal fun reset() {
+    preferences.edit { remove(MIRRORED_ACTOR_KEY) }
+  }
 
-    companion object {
-        private const val MIRRORED_ACTOR_KEY = "mirrored-actor"
-    }
+  companion object {
+    private const val MIRRORED_ACTOR_KEY = "mirrored-actor"
+  }
 }

--- a/core/shared-preferences/src/main/java/com/jeanbarrossilva/orca/core/sharedpreferences/actor/mirror/Actor.extensions.kt
+++ b/core/shared-preferences/src/main/java/com/jeanbarrossilva/orca/core/sharedpreferences/actor/mirror/Actor.extensions.kt
@@ -2,10 +2,10 @@ package com.jeanbarrossilva.orca.core.sharedpreferences.actor.mirror
 
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 
-/** Converts this [Actor] into a [MirroredActor]. **/
+/** Converts this [Actor] into a [MirroredActor]. */
 internal fun Actor.toMirroredActor(): MirroredActor {
-    return when (this) {
-        is Actor.Unauthenticated -> MirroredActor.unauthenticated()
-        is Actor.Authenticated -> MirroredActor.authenticated(id, accessToken)
-    }
+  return when (this) {
+    is Actor.Unauthenticated -> MirroredActor.unauthenticated()
+    is Actor.Authenticated -> MirroredActor.authenticated(id, accessToken)
+  }
 }

--- a/core/shared-preferences/src/main/java/com/jeanbarrossilva/orca/core/sharedpreferences/actor/mirror/MirroredActor.kt
+++ b/core/shared-preferences/src/main/java/com/jeanbarrossilva/orca/core/sharedpreferences/actor/mirror/MirroredActor.kt
@@ -4,61 +4,58 @@ import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class MirroredActor private constructor(
-    private val type: String,
-    val id: String?,
-    val accessToken: String?
-) {
-    init {
-        ensureIntegrity()
+internal class MirroredActor
+private constructor(private val type: String, val id: String?, val accessToken: String?) {
+  init {
+    ensureIntegrity()
+  }
+
+  fun toActor(): Actor {
+    return fold(
+      onUnauthenticated = { Actor.Unauthenticated },
+      onAuthenticated = { Actor.Authenticated(id!!, accessToken!!) }
+    )
+  }
+
+  private fun ensureIntegrity() {
+    fold(
+      onUnauthenticated = ::ensureUnauthenticatedIntegrity,
+      onAuthenticated = ::ensureAuthenticatedIntegrity
+    )
+  }
+
+  private fun <T> fold(onUnauthenticated: () -> T, onAuthenticated: () -> T): T {
+    return when (type) {
+      UNAUTHENTICATED_TYPE -> onUnauthenticated()
+      AUTHENTICATED_TYPE -> onAuthenticated()
+      else -> throw IllegalArgumentException("Unknown \"$type\" mirrored actor type.")
+    }
+  }
+
+  private fun ensureUnauthenticatedIntegrity() {
+    require(id == null) { "$UNAUTHENTICATED_ERROR_MESSAGE_PREFIX an ID." }
+    require(accessToken == null) { "$UNAUTHENTICATED_ERROR_MESSAGE_PREFIX an access token." }
+  }
+
+  private fun ensureAuthenticatedIntegrity() {
+    require(id != null) { "$AUTHENTICATED_ERROR_MESSAGE_PREFIX an ID." }
+    require(accessToken != null) { "$AUTHENTICATED_ERROR_MESSAGE_PREFIX an access token." }
+  }
+
+  companion object {
+    private const val UNAUTHENTICATED_TYPE = "unauthenticated"
+    private const val UNAUTHENTICATED_ERROR_MESSAGE_PREFIX =
+      "Unauthenticated mirrored actor shouldn't have"
+    private const val AUTHENTICATED_TYPE = "authenticated"
+    private const val AUTHENTICATED_ERROR_MESSAGE_PREFIX =
+      "Authenticated mirrored actor should have"
+
+    fun unauthenticated(): MirroredActor {
+      return MirroredActor(UNAUTHENTICATED_TYPE, id = null, accessToken = null)
     }
 
-    fun toActor(): Actor {
-        return fold(
-            onUnauthenticated = { Actor.Unauthenticated },
-            onAuthenticated = { Actor.Authenticated(id!!, accessToken!!) }
-        )
+    fun authenticated(id: String, accessToken: String): MirroredActor {
+      return MirroredActor(AUTHENTICATED_TYPE, id, accessToken)
     }
-
-    private fun ensureIntegrity() {
-        fold(
-            onUnauthenticated = ::ensureUnauthenticatedIntegrity,
-            onAuthenticated = ::ensureAuthenticatedIntegrity
-        )
-    }
-
-    private fun <T> fold(onUnauthenticated: () -> T, onAuthenticated: () -> T): T {
-        return when (type) {
-            UNAUTHENTICATED_TYPE -> onUnauthenticated()
-            AUTHENTICATED_TYPE -> onAuthenticated()
-            else -> throw IllegalArgumentException("Unknown \"$type\" mirrored actor type.")
-        }
-    }
-
-    private fun ensureUnauthenticatedIntegrity() {
-        require(id == null) { "$UNAUTHENTICATED_ERROR_MESSAGE_PREFIX an ID." }
-        require(accessToken == null) { "$UNAUTHENTICATED_ERROR_MESSAGE_PREFIX an access token." }
-    }
-
-    private fun ensureAuthenticatedIntegrity() {
-        require(id != null) { "$AUTHENTICATED_ERROR_MESSAGE_PREFIX an ID." }
-        require(accessToken != null) { "$AUTHENTICATED_ERROR_MESSAGE_PREFIX an access token." }
-    }
-
-    companion object {
-        private const val UNAUTHENTICATED_TYPE = "unauthenticated"
-        private const val UNAUTHENTICATED_ERROR_MESSAGE_PREFIX =
-            "Unauthenticated mirrored actor shouldn't have"
-        private const val AUTHENTICATED_TYPE = "authenticated"
-        private const val AUTHENTICATED_ERROR_MESSAGE_PREFIX =
-            "Authenticated mirrored actor should have"
-
-        fun unauthenticated(): MirroredActor {
-            return MirroredActor(UNAUTHENTICATED_TYPE, id = null, accessToken = null)
-        }
-
-        fun authenticated(id: String, accessToken: String): MirroredActor {
-            return MirroredActor(AUTHENTICATED_TYPE, id, accessToken)
-        }
-    }
+  }
 }

--- a/core/shared-preferences/src/main/java/com/jeanbarrossilva/orca/core/sharedpreferences/feed/profile/toot/muting/SharedPreferencesTermMuter.kt
+++ b/core/shared-preferences/src/main/java/com/jeanbarrossilva/orca/core/sharedpreferences/feed/profile/toot/muting/SharedPreferencesTermMuter.kt
@@ -6,45 +6,45 @@ import androidx.core.content.edit
 import com.jeanbarrossilva.orca.core.feed.profile.toot.muting.TermMuter
 import kotlinx.coroutines.flow.MutableStateFlow
 
-/** Provides and controls configurations of the [SharedPreferences]-specific [TermMuter]. **/
+/** Provides and controls configurations of the [SharedPreferences]-specific [TermMuter]. */
 internal object SharedPreferencesTermMuter {
-    /**
-     * Gets the [SharedPreferences] related to the [SharedPreferences]-specific [TermMuter].
-     *
-     * @param context [Context] through which the [SharedPreferences] will be obtained.
-     **/
-    fun getPreferences(context: Context): SharedPreferences {
-        return context.getSharedPreferences("shared-preferences-term-muter", Context.MODE_PRIVATE)
-    }
+  /**
+   * Gets the [SharedPreferences] related to the [SharedPreferences]-specific [TermMuter].
+   *
+   * @param context [Context] through which the [SharedPreferences] will be obtained.
+   */
+  fun getPreferences(context: Context): SharedPreferences {
+    return context.getSharedPreferences("shared-preferences-term-muter", Context.MODE_PRIVATE)
+  }
 
-    /**
-     * Clears all persisted terms.
-     *
-     * @param context [Context] through which the [SharedPreferences] will be obtained.
-     **/
-    fun reset(context: Context) {
-        getPreferences(context).edit(action = SharedPreferences.Editor::clear)
-    }
+  /**
+   * Clears all persisted terms.
+   *
+   * @param context [Context] through which the [SharedPreferences] will be obtained.
+   */
+  fun reset(context: Context) {
+    getPreferences(context).edit(action = SharedPreferences.Editor::clear)
+  }
 }
 
 /**
  * [TermMuter] that persists muted terms through the [SharedPreferences] API.
  *
  * @param context [Context] through which the [SharedPreferences] will be created.
- **/
+ */
 @Suppress("FunctionName")
 fun SharedPreferencesTermMuter(context: Context): TermMuter {
-    val preferences = SharedPreferencesTermMuter.getPreferences(context)
-    val termsFlow = MutableStateFlow(emptyList<String>())
-    return TermMuter {
-        getTerms { termsFlow }
-        mute {
-            preferences.edit { putString(it, it) }
-            termsFlow.value += it
-        }
-        unmute {
-            preferences.edit { remove(it) }
-            termsFlow.value -= it
-        }
+  val preferences = SharedPreferencesTermMuter.getPreferences(context)
+  val termsFlow = MutableStateFlow(emptyList<String>())
+  return TermMuter {
+    getTerms { termsFlow }
+    mute {
+      preferences.edit { putString(it, it) }
+      termsFlow.value += it
     }
+    unmute {
+      preferences.edit { remove(it) }
+      termsFlow.value -= it
+    }
+  }
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/auth/AuthenticationLock.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/auth/AuthenticationLock.kt
@@ -3,7 +3,7 @@ package com.jeanbarrossilva.orca.core.auth
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.auth.actor.ActorProvider
 
-/** An [AuthenticationLock] with a generic [Authenticator]. **/
+/** An [AuthenticationLock] with a generic [Authenticator]. */
 typealias SomeAuthenticationLock = AuthenticationLock<*>
 
 /**
@@ -12,66 +12,66 @@ typealias SomeAuthenticationLock = AuthenticationLock<*>
  *
  * @param T [Authenticator] to authenticate the [Actor] with.
  * @param authenticator [Authenticator] through which the [Actor] will be requested to be
- * [authenticated][Actor.Authenticated].
+ *   [authenticated][Actor.Authenticated].
  * @param actorProvider [ActorProvider] whose provided [Actor] will be ensured to be
- * [authenticated][Actor.Authenticated].
- **/
+ *   [authenticated][Actor.Authenticated].
+ */
 class AuthenticationLock<T : Authenticator>(
-    private val authenticator: T,
-    private val actorProvider: ActorProvider
+  private val authenticator: T,
+  private val actorProvider: ActorProvider
 ) {
-    /** [IllegalStateException] thrown if authentication fails. **/
-    class FailedAuthenticationException internal constructor() :
-        IllegalStateException("Could not authenticate properly.")
+  /** [IllegalStateException] thrown if authentication fails. */
+  class FailedAuthenticationException internal constructor() :
+    IllegalStateException("Could not authenticate properly.")
 
+  /**
+   * Listens to an unlock.
+   *
+   * @param T Value returned by [onUnlock].
+   */
+  fun interface OnUnlockListener<T> {
     /**
-     * Listens to an unlock.
-     *
-     * @param T Value returned by [onUnlock].
-     **/
-    fun interface OnUnlockListener<T> {
-        /**
-         * Callback called when the [Actor] provided by the [actorProvider] is
-         * [authenticated][Actor.Authenticated].
-         *
-         * @param actor Provided [authenticated][Actor.Authenticated] [Actor].
-         **/
-        suspend fun onUnlock(actor: Actor.Authenticated): T
-    }
-
-    /**
-     * Ensures that the operation in the [listener]'s [onUnlock][OnUnlockListener.onUnlock] callback
-     * is only performed if the [Actor] is [authenticated][Actor.Authenticated]; if it isn't, then
-     * authentication is requested and, if it succeeds, the operation is performed.
-     *
-     * @param T Value returned by the [listener]'s [onUnlock][OnUnlockListener.onUnlock].
-     * @param listener [OnUnlockListener] to be notified if the [Actor] is
-     * [authenticated][Actor.Authenticated].
-     * @return Result of the [listener]'s [onUnlock][OnUnlockListener.onUnlock].
-     * @throws FailedAuthenticationException If authentication fails.
-     **/
-    suspend fun <T> requestUnlock(listener: OnUnlockListener<T>): T {
-        return when (val actor = actorProvider.provide()) {
-            is Actor.Unauthenticated -> authenticateAndNotify(listener)
-            is Actor.Authenticated -> listener.onUnlock(actor)
-        }
-    }
-
-    /**
-     * Authenticates and notifies the [listener] if the resulting [Actor] is
+     * Callback called when the [Actor] provided by the [actorProvider] is
      * [authenticated][Actor.Authenticated].
      *
-     * @param T Value returned by the [listener]'s [onUnlock][OnUnlockListener.onUnlock].
-     * @param listener [OnUnlockListener] to be notified if the [Actor] is
-     * [authenticated][Actor.Authenticated].
-     * @throws FailedAuthenticationException If authentication fails.
-     **/
-    private suspend fun <T> authenticateAndNotify(listener: OnUnlockListener<T>): T {
-        val actor = authenticator.authenticate()
-        return if (actor is Actor.Authenticated) {
-            listener.onUnlock(actor)
-        } else {
-            throw FailedAuthenticationException()
-        }
+     * @param actor Provided [authenticated][Actor.Authenticated] [Actor].
+     */
+    suspend fun onUnlock(actor: Actor.Authenticated): T
+  }
+
+  /**
+   * Ensures that the operation in the [listener]'s [onUnlock][OnUnlockListener.onUnlock] callback
+   * is only performed if the [Actor] is [authenticated][Actor.Authenticated]; if it isn't, then
+   * authentication is requested and, if it succeeds, the operation is performed.
+   *
+   * @param T Value returned by the [listener]'s [onUnlock][OnUnlockListener.onUnlock].
+   * @param listener [OnUnlockListener] to be notified if the [Actor] is
+   *   [authenticated][Actor.Authenticated].
+   * @return Result of the [listener]'s [onUnlock][OnUnlockListener.onUnlock].
+   * @throws FailedAuthenticationException If authentication fails.
+   */
+  suspend fun <T> requestUnlock(listener: OnUnlockListener<T>): T {
+    return when (val actor = actorProvider.provide()) {
+      is Actor.Unauthenticated -> authenticateAndNotify(listener)
+      is Actor.Authenticated -> listener.onUnlock(actor)
     }
+  }
+
+  /**
+   * Authenticates and notifies the [listener] if the resulting [Actor] is
+   * [authenticated][Actor.Authenticated].
+   *
+   * @param T Value returned by the [listener]'s [onUnlock][OnUnlockListener.onUnlock].
+   * @param listener [OnUnlockListener] to be notified if the [Actor] is
+   *   [authenticated][Actor.Authenticated].
+   * @throws FailedAuthenticationException If authentication fails.
+   */
+  private suspend fun <T> authenticateAndNotify(listener: OnUnlockListener<T>): T {
+    val actor = authenticator.authenticate()
+    return if (actor is Actor.Authenticated) {
+      listener.onUnlock(actor)
+    } else {
+      throw FailedAuthenticationException()
+    }
+  }
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/auth/Authenticator.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/auth/Authenticator.kt
@@ -3,29 +3,29 @@ package com.jeanbarrossilva.orca.core.auth
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.auth.actor.ActorProvider
 
-/** Authenticates a user through [authenticate]. **/
+/** Authenticates a user through [authenticate]. */
 abstract class Authenticator {
-    /** [Authorizer] with which the user will be authorized. **/
-    protected abstract val authorizer: Authorizer
+  /** [Authorizer] with which the user will be authorized. */
+  protected abstract val authorizer: Authorizer
 
-    /**
-     * [ActorProvider] to which the [authenticated][Actor.Authenticated] [Actor] will be sent to be
-     * remembered when authentication occurs.
-     **/
-    protected abstract val actorProvider: ActorProvider
+  /**
+   * [ActorProvider] to which the [authenticated][Actor.Authenticated] [Actor] will be sent to be
+   * remembered when authentication occurs.
+   */
+  protected abstract val actorProvider: ActorProvider
 
-    /** Authorizes the user with the [authorizer] and then tries to authenticates them. **/
-    suspend fun authenticate(): Actor {
-        val authorizationCode = authorizer._authorize()
-        val actor = onAuthenticate(authorizationCode)
-        actorProvider._remember(actor)
-        return actor
-    }
+  /** Authorizes the user with the [authorizer] and then tries to authenticates them. */
+  suspend fun authenticate(): Actor {
+    val authorizationCode = authorizer._authorize()
+    val actor = onAuthenticate(authorizationCode)
+    actorProvider._remember(actor)
+    return actor
+  }
 
-    /**
-     * Tries to authenticate the user.
-     *
-     * @param authorizationCode Code that resulted from authorizing the user.
-     **/
-    protected abstract suspend fun onAuthenticate(authorizationCode: String): Actor
+  /**
+   * Tries to authenticate the user.
+   *
+   * @param authorizationCode Code that resulted from authorizing the user.
+   */
+  protected abstract suspend fun onAuthenticate(authorizationCode: String): Actor
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/auth/Authorizer.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/auth/Authorizer.kt
@@ -1,23 +1,23 @@
 package com.jeanbarrossilva.orca.core.auth
 
-/** Authorizes the user through [authorize]. **/
+/** Authorizes the user through [authorize]. */
 abstract class Authorizer {
-    /**
-     * Authorizes the user, allowing the application to perform operations on their behalf.
-     *
-     * @return Resulting authorization code.
-     **/
-    @Suppress("FunctionName")
-    internal suspend fun _authorize(): String {
-        return authorize()
-    }
+  /**
+   * Authorizes the user, allowing the application to perform operations on their behalf.
+   *
+   * @return Resulting authorization code.
+   */
+  @Suppress("FunctionName")
+  internal suspend fun _authorize(): String {
+    return authorize()
+  }
 
-    /**
-     * Authorizes the user, allowing the application to perform operations on their behalf.
-     *
-     * @return Resulting authorization code.
-     **/
-    protected abstract suspend fun authorize(): String
+  /**
+   * Authorizes the user, allowing the application to perform operations on their behalf.
+   *
+   * @return Resulting authorization code.
+   */
+  protected abstract suspend fun authorize(): String
 
-    companion object
+  companion object
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/auth/actor/Actor.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/auth/actor/Actor.kt
@@ -1,17 +1,17 @@
 package com.jeanbarrossilva.orca.core.auth.actor
 
-/** Agent that can perform operations throughout the application. **/
+/** Agent that can perform operations throughout the application. */
 sealed interface Actor {
-    /** Unknown [Actor] that has restricted access. **/
-    object Unauthenticated : Actor
+  /** Unknown [Actor] that has restricted access. */
+  object Unauthenticated : Actor
 
-    /**
-     * [Actor] that's been properly authenticated and can use the application normally.
-     *
-     * @param id Unique identifier within Mastodon.
-     * @param accessToken Access token resulted from the authentication.
-     **/
-    data class Authenticated(val id: String, val accessToken: String) : Actor {
-        companion object
-    }
+  /**
+   * [Actor] that's been properly authenticated and can use the application normally.
+   *
+   * @param id Unique identifier within Mastodon.
+   * @param accessToken Access token resulted from the authentication.
+   */
+  data class Authenticated(val id: String, val accessToken: String) : Actor {
+    companion object
+  }
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/auth/actor/ActorProvider.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/auth/actor/ActorProvider.kt
@@ -1,35 +1,35 @@
 package com.jeanbarrossilva.orca.core.auth.actor
 
-/** Provides an [Actor] through [provide]. **/
+/** Provides an [Actor] through [provide]. */
 abstract class ActorProvider {
-    /** Provides an [Actor]. **/
-    suspend fun provide(): Actor {
-        return retrieve()
-    }
+  /** Provides an [Actor]. */
+  suspend fun provide(): Actor {
+    return retrieve()
+  }
 
-    /**
-     * Remembers the given [actor] so that it can be retrieved later.
-     *
-     * @see retrieve
-     **/
-    @Suppress("FunctionName")
-    internal suspend fun _remember(actor: Actor) {
-        remember(actor)
-    }
+  /**
+   * Remembers the given [actor] so that it can be retrieved later.
+   *
+   * @see retrieve
+   */
+  @Suppress("FunctionName")
+  internal suspend fun _remember(actor: Actor) {
+    remember(actor)
+  }
 
-    /**
-     * Remembers the given [actor] so that it can be retrieved later.
-     *
-     * @see retrieve
-     **/
-    protected abstract suspend fun remember(actor: Actor)
+  /**
+   * Remembers the given [actor] so that it can be retrieved later.
+   *
+   * @see retrieve
+   */
+  protected abstract suspend fun remember(actor: Actor)
 
-    /**
-     * Retrieves a remembered [Actor].
-     *
-     * @see remember
-     **/
-    protected abstract suspend fun retrieve(): Actor
+  /**
+   * Retrieves a remembered [Actor].
+   *
+   * @see remember
+   */
+  protected abstract suspend fun retrieve(): Actor
 
-    companion object
+  companion object
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/FeedProvider.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/FeedProvider.kt
@@ -6,70 +6,70 @@ import kotlinx.coroutines.flow.Flow
 
 /**
  * Provides a user's feed (the [Toot]s shown to them based on who they follow) through [onProvide].
- **/
+ */
 abstract class FeedProvider {
-    /** [TermMuter] by which [Toot]s with muted terms will be filtered out. **/
-    protected abstract val termMuter: TermMuter
+  /** [TermMuter] by which [Toot]s with muted terms will be filtered out. */
+  protected abstract val termMuter: TermMuter
 
-    /**
-     * [IllegalArgumentException] thrown when a user that doesn't exist is requested to be provided.
-     *
-     * @param id ID of the user requested to be provided.
-     **/
-    class NonexistentUserException internal constructor(id: String) :
-        IllegalArgumentException("User identified as \"$id\" doesn't exist.")
+  /**
+   * [IllegalArgumentException] thrown when a user that doesn't exist is requested to be provided.
+   *
+   * @param id ID of the user requested to be provided.
+   */
+  class NonexistentUserException internal constructor(id: String) :
+    IllegalArgumentException("User identified as \"$id\" doesn't exist.")
 
-    /**
-     * Provides the feed of the user identified as [userID].
-     *
-     * @param userID ID of the user whose feed will be provided.
-     * @param page Index of the [Toot]s that compose the feed.
-     * @throws NonexistentUserException If no user with such [userID] exists.
-     * @throws IndexOutOfBoundsException If the page is invalid.
-     * @see ensurePageValidity
-     **/
-    suspend fun provide(userID: String, page: Int): Flow<List<Toot>> {
-        ensureContainsUser(userID)
-        ensurePageValidity(page)
-        return onProvide(userID, page).filterEach { !termMuter.isMuted(it.content) }
+  /**
+   * Provides the feed of the user identified as [userID].
+   *
+   * @param userID ID of the user whose feed will be provided.
+   * @param page Index of the [Toot]s that compose the feed.
+   * @throws NonexistentUserException If no user with such [userID] exists.
+   * @throws IndexOutOfBoundsException If the page is invalid.
+   * @see ensurePageValidity
+   */
+  suspend fun provide(userID: String, page: Int): Flow<List<Toot>> {
+    ensureContainsUser(userID)
+    ensurePageValidity(page)
+    return onProvide(userID, page).filterEach { !termMuter.isMuted(it.content) }
+  }
+
+  /**
+   * Provides the feed of the user identified as [userID].
+   *
+   * @param userID ID of the user whose feed will be provided.
+   * @param page Index of the [Toot]s that compose the feed.
+   */
+  protected abstract suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>>
+
+  /**
+   * Whether a user identified as [userID] exists.
+   *
+   * @param userID ID of the user whose existence will be checked.
+   */
+  protected abstract suspend fun containsUser(userID: String): Boolean
+
+  /**
+   * Ensures that a user identified as [userID] exists.
+   *
+   * @param userID ID of the user whose existence will be ensured.
+   * @throws NonexistentUserException If no user with such [userID] exists.
+   */
+  private suspend fun ensureContainsUser(userID: String) {
+    if (!containsUser(userID)) {
+      throw NonexistentUserException(userID)
     }
+  }
 
-    /**
-     * Provides the feed of the user identified as [userID].
-     *
-     * @param userID ID of the user whose feed will be provided.
-     * @param page Index of the [Toot]s that compose the feed.
-     **/
-    protected abstract suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>>
-
-    /**
-     * Whether a user identified as [userID] exists.
-     *
-     * @param userID ID of the user whose existence will be checked.
-     **/
-    protected abstract suspend fun containsUser(userID: String): Boolean
-
-    /**
-     * Ensures that a user identified as [userID] exists.
-     *
-     * @param userID ID of the user whose existence will be ensured.
-     * @throws NonexistentUserException If no user with such [userID] exists.
-     **/
-    private suspend fun ensureContainsUser(userID: String) {
-        if (!containsUser(userID)) {
-            throw NonexistentUserException(userID)
-        }
+  /**
+   * Ensures that the [page] is valid; that is, if it is a positive [Int].
+   *
+   * @param page Page whose validity will be ensured.
+   * @throws IndexOutOfBoundsException If the page is invalid.
+   */
+  private fun ensurePageValidity(page: Int) {
+    if (page < 0) {
+      throw IndexOutOfBoundsException("Page out of range: $page.")
     }
-
-    /**
-     * Ensures that the [page] is valid; that is, if it is a positive [Int].
-     *
-     * @param page Page whose validity will be ensured.
-     * @throws IndexOutOfBoundsException If the page is invalid.
-     **/
-    private fun ensurePageValidity(page: Int) {
-        if (page < 0) {
-            throw IndexOutOfBoundsException("Page out of range: $page.")
-        }
-    }
+  }
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/Flow.extensions.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/Flow.extensions.kt
@@ -7,11 +7,7 @@ import kotlinx.coroutines.flow.map
  * Filters each element of the [Collection]s emitted to this [Flow].
  *
  * @param predicate Whether the currently iterated element should be in the filtered [List].
- **/
+ */
 internal fun <T> Flow<Collection<T>>.filterEach(predicate: suspend (T) -> Boolean): Flow<List<T>> {
-    return map { elements ->
-        elements.filter { element ->
-            predicate(element)
-        }
-    }
+  return map { elements -> elements.filter { element -> predicate(element) } }
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/Profile.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/Profile.kt
@@ -7,35 +7,35 @@ import java.io.Serializable
 import java.net.URL
 import kotlinx.coroutines.flow.Flow
 
-/** A user's profile. **/
+/** A user's profile. */
 interface Profile : Serializable {
-    /** Unique identifier. **/
-    val id: String
+  /** Unique identifier. */
+  val id: String
 
-    /** Unique identifier within an instance. **/
-    val account: Account
+  /** Unique identifier within an instance. */
+  val account: Account
 
-    /** [URL] that leads to the avatar image. **/
-    val avatarURL: URL
+  /** [URL] that leads to the avatar image. */
+  val avatarURL: URL
 
-    /** Name to be displayed. **/
-    val name: String
+  /** Name to be displayed. */
+  val name: String
 
-    /** Describes who the owner is and/or provides information regarding this [Profile]. **/
-    val bio: StyledString
+  /** Describes who the owner is and/or provides information regarding this [Profile]. */
+  val bio: StyledString
 
-    /** Amount of followers. **/
-    val followerCount: Int
+  /** Amount of followers. */
+  val followerCount: Int
 
-    /** Amount of following. **/
-    val followingCount: Int
+  /** Amount of following. */
+  val followingCount: Int
 
-    /**
-     * [URL] that leads to the webpage of the instance through which this [Profile] can be accessed.
-     **/
-    val url: URL
+  /**
+   * [URL] that leads to the webpage of the instance through which this [Profile] can be accessed.
+   */
+  val url: URL
 
-    suspend fun getToots(page: Int): Flow<List<Toot>>
+  suspend fun getToots(page: Int): Flow<List<Toot>>
 
-    companion object
+  companion object
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/ProfileProvider.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/ProfileProvider.kt
@@ -2,40 +2,40 @@ package com.jeanbarrossilva.orca.core.feed.profile
 
 import kotlinx.coroutines.flow.Flow
 
-/** Provides a [Profile] through [onProvide]. **/
+/** Provides a [Profile] through [onProvide]. */
 abstract class ProfileProvider {
-    /**
-     * [IllegalArgumentException] thrown when a [Profile] that doesn't exist is requested to be
-     * provided.
-     *
-     * @param id ID of the [Profile] requested to be provided.
-     **/
-    class NonexistentProfileException(id: String) :
-        IllegalArgumentException("Profile identified as \"$id\" doesn't exist.")
+  /**
+   * [IllegalArgumentException] thrown when a [Profile] that doesn't exist is requested to be
+   * provided.
+   *
+   * @param id ID of the [Profile] requested to be provided.
+   */
+  class NonexistentProfileException(id: String) :
+    IllegalArgumentException("Profile identified as \"$id\" doesn't exist.")
 
-    /**
-     * Gets the [Profile] identified as [id].
-     *
-     * @param id ID of the [Profile] to be provided.
-     * @throws NonexistentProfileException If no [Profile] with such [ID][Profile.id] exists.
-     * @see Profile.id
-     **/
-    suspend fun provide(id: String): Flow<Profile> {
-        return if (contains(id)) onProvide(id) else throw NonexistentProfileException(id)
-    }
+  /**
+   * Gets the [Profile] identified as [id].
+   *
+   * @param id ID of the [Profile] to be provided.
+   * @throws NonexistentProfileException If no [Profile] with such [ID][Profile.id] exists.
+   * @see Profile.id
+   */
+  suspend fun provide(id: String): Flow<Profile> {
+    return if (contains(id)) onProvide(id) else throw NonexistentProfileException(id)
+  }
 
-    /**
-     * Whether a [Profile] identified as [id] exists.
-     *
-     * @param id ID of the [Profile] whose existence will be checked.
-     **/
-    protected abstract suspend fun contains(id: String): Boolean
+  /**
+   * Whether a [Profile] identified as [id] exists.
+   *
+   * @param id ID of the [Profile] whose existence will be checked.
+   */
+  protected abstract suspend fun contains(id: String): Boolean
 
-    /**
-     * Gets the [Profile] identified as [id].
-     *
-     * @param id ID of the [Profile] to be provided.
-     * @see Profile.id
-     **/
-    protected abstract suspend fun onProvide(id: String): Flow<Profile>
+  /**
+   * Gets the [Profile] identified as [id].
+   *
+   * @param id ID of the [Profile] to be provided.
+   * @see Profile.id
+   */
+  protected abstract suspend fun onProvide(id: String): Flow<Profile>
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/Account.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/Account.kt
@@ -17,104 +17,101 @@ import java.io.Serializable
  * @param domain [Domain] of the server in which this [Account] is.
  * @throws BlankUsernameException If the [username] is blank.
  * @throws IllegalUsernameException If the [username] contains any illegal characters.
- **/
+ */
 data class Account internal constructor(val username: String, val domain: Domain) : Serializable {
-    /** [IllegalArgumentException] thrown if the [username] is blank. **/
-    class BlankUsernameException internal constructor() :
-        IllegalArgumentException("An account cannot have a blank username.")
+  /** [IllegalArgumentException] thrown if the [username] is blank. */
+  class BlankUsernameException internal constructor() :
+    IllegalArgumentException("An account cannot have a blank username.")
+
+  /**
+   * [IllegalArgumentException] thrown if the [username] contains any illegal characters.
+   *
+   * @param illegalCharacters [Char]s that make the [username] illegal.
+   */
+  class IllegalUsernameException internal constructor(illegalCharacters: List<Char>) :
+    IllegalArgumentException("Username cannot contain: $illegalCharacters")
+
+  init {
+    ensureUsernameNonBlankness()
+    ensureUsernameLegality()
+  }
+
+  override fun toString(): String {
+    return username + SEPARATOR + domain
+  }
+
+  /**
+   * Ensures that the [username] is not blank.
+   *
+   * @throws BlankUsernameException If the [username] is blank.
+   */
+  private fun ensureUsernameNonBlankness() {
+    if (username.isBlank()) {
+      throw BlankUsernameException()
+    }
+  }
+
+  /**
+   * Ensures that the [username] is legal.
+   *
+   * @throws IllegalUsernameException If the [username] is illegal.
+   */
+  private fun ensureUsernameLegality() {
+    Domain.doOnIllegality(username) { throw IllegalUsernameException(it) }
+  }
+
+  companion object {
+    /** [Char] that separates the [username] from the [domain]. */
+    private const val SEPARATOR = '@'
 
     /**
-     * [IllegalArgumentException] thrown if the [username] contains any illegal characters.
+     * [IllegalArgumentException] thrown if a blank [String] is given when parsing it into an
+     * [Account].
      *
-     * @param illegalCharacters [Char]s that make the [username] illegal.
-     **/
-    class IllegalUsernameException internal constructor(illegalCharacters: List<Char>) :
-        IllegalArgumentException("Username cannot contain: $illegalCharacters")
+     * @see of
+     */
+    class BlankStringException internal constructor() :
+      IllegalArgumentException("Cannot parse a blank String.")
 
-    init {
-        ensureUsernameNonBlankness()
-        ensureUsernameLegality()
-    }
-
-    override fun toString(): String {
-        return username + SEPARATOR + domain
+    /**
+     * Parses the [string] into an [Account].
+     *
+     * It should be formatted as `"{username}@{domain}"`, with "{username}" and "{domain}" replaced
+     * by the actual data they represent; it can also be given as `"{username}"`, without the
+     * domain, if a [fallbackDomain] is specified.
+     *
+     * Any leading or trailing whitespace in both the [string] and the [fallbackDomain] will be
+     * ignored.
+     *
+     * @param string [String] to be parsed.
+     * @param fallbackDomain [Domain] to fallback to if the [string] only has a username.
+     * @throws BlankStringException If the [string] is blank.
+     * @throws BlankUsernameException If the username is blank.
+     * @throws IllegalUsernameException If the username contains any illegal characters.
+     * @throws Domain.BlankValueException If the domain is not specified in the [string] and the
+     *   [fallbackDomain] is `null`.
+     * @throws Domain.IllegalValueException If the domain contains any of the
+     *   [Domain.illegalCharacters].
+     * @throws Domain.ValueWithoutTopLevelDomainException If the domain doesn't have a top-level
+     *   domain.
+     */
+    fun of(string: String, fallbackDomain: String? = null): Account {
+      val formattedString = string.trim().ifEmpty { throw BlankStringException() }
+      val parts = formattedString.split(SEPARATOR)
+      val username = parts.first()
+      val containsDomain = parts.size > 1
+      val domainValue = if (containsDomain) parts[1].trim() else fallbackDomain?.trim().orEmpty()
+      val domain = Domain(domainValue)
+      return Account(username, domain)
     }
 
     /**
-     * Ensures that the [username] is not blank.
+     * Verifies whether the username is valid.
      *
-     * @throws BlankUsernameException If the [username] is blank.
-     **/
-    private fun ensureUsernameNonBlankness() {
-        if (username.isBlank()) {
-            throw BlankUsernameException()
-        }
+     * @param username Username whose validity will be verified.
+     */
+    fun isUsernameValid(username: String): Boolean {
+      return username.isNotBlank() && username.isLegal
     }
-
-    /**
-     * Ensures that the [username] is legal.
-     *
-     * @throws IllegalUsernameException If the [username] is illegal.
-     **/
-    private fun ensureUsernameLegality() {
-        Domain.doOnIllegality(username) {
-            throw IllegalUsernameException(it)
-        }
-    }
-
-    companion object {
-        /** [Char] that separates the [username] from the [domain]. **/
-        private const val SEPARATOR = '@'
-
-        /**
-         * [IllegalArgumentException] thrown if a blank [String] is given when parsing it into an
-         * [Account].
-         *
-         * @see of
-         **/
-        class BlankStringException internal constructor() :
-            IllegalArgumentException("Cannot parse a blank String.")
-
-        /**
-         * Parses the [string] into an [Account].
-         *
-         * It should be formatted as `"{username}@{domain}"`, with "{username}" and "{domain}"
-         * replaced by the actual data they represent; it can also be given as `"{username}"`,
-         * without the domain, if a [fallbackDomain] is specified.
-         *
-         * Any leading or trailing whitespace in both the [string] and the [fallbackDomain] will be
-         * ignored.
-         *
-         * @param string [String] to be parsed.
-         * @param fallbackDomain [Domain] to fallback to if the [string] only has a username.
-         * @throws BlankStringException If the [string] is blank.
-         * @throws BlankUsernameException If the username is blank.
-         * @throws IllegalUsernameException If the username contains any illegal characters.
-         * @throws Domain.BlankValueException If the domain is not specified in the [string] and the
-         * [fallbackDomain] is `null`.
-         * @throws Domain.IllegalValueException If the domain contains any of the
-         * [Domain.illegalCharacters].
-         * @throws Domain.ValueWithoutTopLevelDomainException If the domain doesn't have a top-level
-         * domain.
-         **/
-        fun of(string: String, fallbackDomain: String? = null): Account {
-            val formattedString = string.trim().ifEmpty { throw BlankStringException() }
-            val parts = formattedString.split(SEPARATOR)
-            val username = parts.first()
-            val containsDomain = parts.size > 1
-            val domainValue =
-                if (containsDomain) parts[1].trim() else fallbackDomain?.trim().orEmpty()
-            val domain = Domain(domainValue)
-            return Account(username, domain)
-        }
-
-        /**
-         * Verifies whether the username is valid.
-         *
-         * @param username Username whose validity will be verified.
-         **/
-        fun isUsernameValid(username: String): Boolean {
-            return username.isNotBlank() && username.isLegal
-        }
-    }
+  }
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/String.extensions.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/String.extensions.kt
@@ -3,11 +3,11 @@ package com.jeanbarrossilva.orca.core.feed.profile.account
 import com.jeanbarrossilva.orca.core.instance.domain.Domain
 
 /**
- * Creates an [Account] with the receiver [String] as the [username][Account.username] and
- * [domain] as the [Account.domain].
+ * Creates an [Account] with the receiver [String] as the [username][Account.username] and [domain]
+ * as the [Account.domain].
  *
  * @param domain Mastodon instance from which the user is.
- **/
+ */
 infix fun String.at(domain: String): Account {
-    return Account(username = this, Domain(domain))
+  return Account(username = this, Domain(domain))
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/search/Profile.extensions.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/search/Profile.extensions.kt
@@ -2,7 +2,7 @@ package com.jeanbarrossilva.orca.core.feed.profile.search
 
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
 
-/** Converts this [Profile] into a [ProfileSearchResult]. **/
+/** Converts this [Profile] into a [ProfileSearchResult]. */
 fun Profile.toProfileSearchResult(): ProfileSearchResult {
-    return ProfileSearchResult(id, account, avatarURL, name, url)
+  return ProfileSearchResult(id, account, avatarURL, name, url)
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/search/ProfileSearchResult.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/search/ProfileSearchResult.kt
@@ -12,13 +12,13 @@ import java.net.URL
  * @param avatarURL [URL] that leads to the avatar image.
  * @param name Name to be displayed.
  * @param url [URL] that leads to the profile.
- **/
+ */
 data class ProfileSearchResult(
-    val id: String,
-    val account: Account,
-    val avatarURL: URL,
-    val name: String,
-    val url: URL
+  val id: String,
+  val account: Account,
+  val avatarURL: URL,
+  val name: String,
+  val url: URL
 ) : Serializable {
-    companion object
+  companion object
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/search/ProfileSearcher.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/search/ProfileSearcher.kt
@@ -9,38 +9,39 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flowOf
 
-/** Searches for profiles through [search]. **/
+/** Searches for profiles through [search]. */
 abstract class ProfileSearcher {
-    /** [MutableStateFlow] to which the query is emitted. **/
-    private val queryFlow = MutableStateFlow("")
+  /** [MutableStateFlow] to which the query is emitted. */
+  private val queryFlow = MutableStateFlow("")
 
-    /** [Flow] with an empty [List] of [ProfileSearchResult]s. **/
-    private val emptyResultsFlow = flowOf(emptyList<ProfileSearchResult>())
+  /** [Flow] with an empty [List] of [ProfileSearchResult]s. */
+  private val emptyResultsFlow = flowOf(emptyList<ProfileSearchResult>())
 
-    /**
-     * [MutableStateFlow] to which [ProfileSearchResult]s based on the query are emitted.
-     *
-     * @see queryFlow
-     **/
-    @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
-    private val resultsFlow = queryFlow.debounce(256.milliseconds).flatMapMerge {
-        if (it.isBlank()) emptyResultsFlow else onSearch(it)
+  /**
+   * [MutableStateFlow] to which [ProfileSearchResult]s based on the query are emitted.
+   *
+   * @see queryFlow
+   */
+  @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+  private val resultsFlow =
+    queryFlow.debounce(256.milliseconds).flatMapMerge {
+      if (it.isBlank()) emptyResultsFlow else onSearch(it)
     }
 
-    /**
-     * Searches for profiles that match the [query].
-     *
-     * @param query Input about the profiles being searched.
-     **/
-    fun search(query: String): Flow<List<ProfileSearchResult>> {
-        queryFlow.value = query.trim()
-        return resultsFlow
-    }
+  /**
+   * Searches for profiles that match the [query].
+   *
+   * @param query Input about the profiles being searched.
+   */
+  fun search(query: String): Flow<List<ProfileSearchResult>> {
+    queryFlow.value = query.trim()
+    return resultsFlow
+  }
 
-    /**
-     * Searches for profiles that match the [query].
-     *
-     * @param query Input about the profiles being searched.
-     **/
-    protected abstract suspend fun onSearch(query: String): Flow<List<ProfileSearchResult>>
+  /**
+   * Searches for profiles that match the [query].
+   *
+   * @param query Input about the profiles being searched.
+   */
+  protected abstract suspend fun onSearch(query: String): Flow<List<ProfileSearchResult>>
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/Author.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/Author.kt
@@ -12,13 +12,13 @@ import java.net.URL
  * @param name Name to be displayed.
  * @param account Unique identifier within an instance.
  * @param profileURL [URL] that leads to this [Author]'s profile.
- **/
+ */
 data class Author(
-    val id: String,
-    val avatarURL: URL,
-    val name: String,
-    val account: Account,
-    val profileURL: URL
+  val id: String,
+  val avatarURL: URL,
+  val name: String,
+  val account: Account,
+  val profileURL: URL
 ) : Serializable {
-    companion object
+  companion object
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/Toot.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/Toot.kt
@@ -8,31 +8,31 @@ import java.io.Serializable
 import java.net.URL
 import java.time.ZonedDateTime
 
-/** Content that's been posted by a user, the [author]. **/
+/** Content that's been posted by a user, the [author]. */
 abstract class Toot : Serializable {
-    /** Unique identifier. **/
-    abstract val id: String
+  /** Unique identifier. */
+  abstract val id: String
 
-    /** [Author] that has authored this [Toot]. **/
-    abstract val author: Author
+  /** [Author] that has authored this [Toot]. */
+  abstract val author: Author
 
-    /** [Content] that's been composed by the [author]. **/
-    abstract val content: Content
+  /** [Content] that's been composed by the [author]. */
+  abstract val content: Content
 
-    /** Zoned moment in time in which this [Toot] was published. **/
-    abstract val publicationDateTime: ZonedDateTime
+  /** Zoned moment in time in which this [Toot] was published. */
+  abstract val publicationDateTime: ZonedDateTime
 
-    /** [Stat] for comments. **/
-    abstract val comment: Stat<Toot>
+  /** [Stat] for comments. */
+  abstract val comment: Stat<Toot>
 
-    /** [Stat] for favorites. **/
-    abstract val favorite: ToggleableStat<Profile>
+  /** [Stat] for favorites. */
+  abstract val favorite: ToggleableStat<Profile>
 
-    /** [Stat] for reblogs. **/
-    abstract val reblog: ToggleableStat<Profile>
+  /** [Stat] for reblogs. */
+  abstract val reblog: ToggleableStat<Profile>
 
-    /** [URL] that leads to this [Toot]. **/
-    abstract val url: URL
+  /** [URL] that leads to this [Toot]. */
+  abstract val url: URL
 
-    companion object
+  companion object
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/TootProvider.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/TootProvider.kt
@@ -2,13 +2,13 @@ package com.jeanbarrossilva.orca.core.feed.profile.toot
 
 import kotlinx.coroutines.flow.Flow
 
-/** Provides [Toot]s. **/
+/** Provides [Toot]s. */
 interface TootProvider {
-    /**
-     * Provides the [Toot] identified as [id].
-     *
-     * @param id ID of the [Toot] to be provided.
-     * @see Toot.id
-     **/
-    suspend fun provide(id: String): Flow<Toot>
+  /**
+   * Provides the [Toot] identified as [id].
+   *
+   * @param id ID of the [Toot] to be provided.
+   * @see Toot.id
+   */
+  suspend fun provide(id: String): Flow<Toot>
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Attachment.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Attachment.kt
@@ -7,5 +7,5 @@ import java.net.URL
  *
  * @param description Description of what's displayed.
  * @param url [URL] that leads to the media.
- **/
+ */
 data class Attachment(val description: String?, val url: URL)

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Content.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Content.kt
@@ -15,84 +15,84 @@ import java.util.Objects
  * @param text Written content.
  * @param attachments [Attachment]s containing the attached media.
  * @param highlight [Highlight] from the [text].
- **/
-class Content private constructor(
-    val text: StyledString,
-    val attachments: List<Attachment>,
-    val highlight: Highlight? = null
+ */
+class Content
+private constructor(
+  val text: StyledString,
+  val attachments: List<Attachment>,
+  val highlight: Highlight? = null
 ) {
+  /**
+   * [IllegalArgumentException] thrown if the text has a [Highlight] while a [Headline] hasn't been
+   * provided.
+   */
+  class UnprovidedHeadlineException :
+    IllegalArgumentException("Text has a highlight but no headline was provided.")
+
+  override fun equals(other: Any?): Boolean {
+    return other is Content && text == other.text && highlight == other.highlight
+  }
+
+  override fun hashCode(): Int {
+    return Objects.hash(text, highlight)
+  }
+
+  override fun toString(): String {
+    return "Content(text=$text, highlight=$highlight)"
+  }
+
+  companion object {
     /**
-     * [IllegalArgumentException] thrown if the text has a [Highlight] while a [Headline] hasn't
-     * been provided.
-     **/
-    class UnprovidedHeadlineException :
-        IllegalArgumentException("Text has a highlight but no headline was provided.")
-
-    override fun equals(other: Any?): Boolean {
-        return other is Content && text == other.text && highlight == other.highlight
-    }
-
-    override fun hashCode(): Int {
-        return Objects.hash(text, highlight)
-    }
-
-    override fun toString(): String {
-        return "Content(text=$text, highlight=$highlight)"
-    }
-
-    companion object {
-        /**
-         * Creates [Content] from the given [text].
-         *
-         * @param text [String] from which [Content] will be created.
-         * @param attachments [Attachment]s containing the attached media.
-         * @param headlineProvider [HeadlineProvider] that provides the [Headline].
-         * @throws UnprovidedHeadlineException If the text has a [Highlight] while a
-         * [HeadlineProvider] hasn't been specified.
-         **/
-        @Throws(UnprovidedHeadlineException::class)
-        fun from(
-            text: StyledString,
-            attachments: List<Attachment> = emptyList(),
-            headlineProvider: HeadlineProvider
-        ): Content {
-            val links = text.styles.filterIsInstance<Link>()
-            val link = links.firstOrNull()
-            val url = link?.indices?.let(text::substring)?.let(::URL)
-            val headline = url?.let { headlineProvider.provide(it) }
-            val highlight = headline?.let { Highlight(it, url) }
-            val formattedText = if (links.size == 1 && text.trim().endsWith("$url")) {
-                "${text.replaceRange(link?.indices ?: IntRange.EMPTY, "")}"
-                    .trimEnd()
-                    .toStyledString()
-            } else {
-                text
-            }
-            return Content(formattedText, attachments, highlight)
+     * Creates [Content] from the given [text].
+     *
+     * @param text [String] from which [Content] will be created.
+     * @param attachments [Attachment]s containing the attached media.
+     * @param headlineProvider [HeadlineProvider] that provides the [Headline].
+     * @throws UnprovidedHeadlineException If the text has a [Highlight] while a [HeadlineProvider]
+     *   hasn't been specified.
+     */
+    @Throws(UnprovidedHeadlineException::class)
+    fun from(
+      text: StyledString,
+      attachments: List<Attachment> = emptyList(),
+      headlineProvider: HeadlineProvider
+    ): Content {
+      val links = text.styles.filterIsInstance<Link>()
+      val link = links.firstOrNull()
+      val url = link?.indices?.let(text::substring)?.let(::URL)
+      val headline = url?.let { headlineProvider.provide(it) }
+      val highlight = headline?.let { Highlight(it, url) }
+      val formattedText =
+        if (links.size == 1 && text.trim().endsWith("$url")) {
+          "${text.replaceRange(link?.indices ?: IntRange.EMPTY, "")}".trimEnd().toStyledString()
+        } else {
+          text
         }
-
-        /**
-         * Ensures the parity of an operation involving the [link] and the [headline], throwing if
-         * the [link] is not `null` and the [headline] is `null`.
-         *
-         * @param link [Link] found in a [StyledString].
-         * @param headline [Headline] with main information about a [Highlight].
-         * @throws UnprovidedHeadlineException If the text has a [Highlight] while the [headline]
-         * hasn't been specified.
-         **/
-
-        /*
-         * There's a case in which the link will exist and a headline won't be provided: when the
-         * URL leads to an in-app resource (such as a toot or a profile). Because these links start
-         * with the instance base URL, a solution for obtaining instance-specific URL resources must
-         * be developed in order for parity between the link and the headline to be properly
-         * ensured.
-         */
-        @Throws(UnprovidedHeadlineException::class)
-        private fun ensureParity(link: Link?, headline: Headline?) {
-            if (link != null && headline == null) {
-                throw UnprovidedHeadlineException()
-            }
-        }
+      return Content(formattedText, attachments, highlight)
     }
+
+    /**
+     * Ensures the parity of an operation involving the [link] and the [headline], throwing if the
+     * [link] is not `null` and the [headline] is `null`.
+     *
+     * @param link [Link] found in a [StyledString].
+     * @param headline [Headline] with main information about a [Highlight].
+     * @throws UnprovidedHeadlineException If the text has a [Highlight] while the [headline] hasn't
+     *   been specified.
+     */
+
+    /*
+     * There's a case in which the link will exist and a headline won't be provided: when the
+     * URL leads to an in-app resource (such as a toot or a profile). Because these links start
+     * with the instance base URL, a solution for obtaining instance-specific URL resources must
+     * be developed in order for parity between the link and the headline to be properly
+     * ensured.
+     */
+    @Throws(UnprovidedHeadlineException::class)
+    private fun ensureParity(link: Link?, headline: Headline?) {
+      if (link != null && headline == null) {
+        throw UnprovidedHeadlineException()
+      }
+    }
+  }
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/highlight/Headline.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/highlight/Headline.kt
@@ -8,7 +8,7 @@ import java.net.URL
  * @param title Title of the external site.
  * @param subtitle Brief description of the content in the external site.
  * @param coverURL [URL] that leads to the image that represents the content.
- **/
+ */
 data class Headline(val title: String, val subtitle: String?, val coverURL: URL) {
-    companion object
+  companion object
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/highlight/HeadlineProvider.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/highlight/HeadlineProvider.kt
@@ -2,12 +2,12 @@ package com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight
 
 import java.net.URL
 
-/** Provides a [Headline] through [provide]. **/
+/** Provides a [Headline] through [provide]. */
 fun interface HeadlineProvider {
-    /**
-     * Provides a [Headline] based on the [url].
-     *
-     * @param url [URL] for which the [Headline] will be provided.
-     **/
-    fun provide(url: URL): Headline?
+  /**
+   * Provides a [Headline] based on the [url].
+   *
+   * @param url [URL] for which the [Headline] will be provided.
+   */
+  fun provide(url: URL): Headline?
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/highlight/Highlight.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/highlight/Highlight.kt
@@ -8,7 +8,7 @@ import java.net.URL
  *
  * @param headline [Headline] with the main information.
  * @param url [URL] that leads to the external site.
- **/
+ */
 data class Highlight(val headline: Headline, val url: URL) {
-    companion object
+  companion object
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/muting/TermMuter.extensions.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/muting/TermMuter.extensions.kt
@@ -4,7 +4,7 @@ package com.jeanbarrossilva.orca.core.feed.profile.toot.muting
  * Mutes and retrieves terms that have been muted.
  *
  * @param build Configuration for the [TermMuter].
- **/
+ */
 fun TermMuter(build: TermMuter.Builder.() -> Unit): TermMuter {
-    return TermMuter.Builder().apply(build).build()
+  return TermMuter.Builder().apply(build).build()
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/muting/TermMuter.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/muting/TermMuter.kt
@@ -9,98 +9,92 @@ import kotlinx.coroutines.flow.first
  * Mutes and retrieves terms that have been muted.
  *
  * An instance of this class can be created via its factory method.
- **/
+ */
 abstract class TermMuter private constructor() {
+  /**
+   * Whether the [content] contains muted terms.
+   *
+   * @param content [Content] whose terms will be verified.
+   */
+  suspend fun isMuted(content: Content): Boolean {
+    val terms = getTerms().first()
+    return terms.any { it in content.text }
+  }
+
+  @TermMuterDsl
+  class Builder internal constructor() {
     /**
-     * Whether the [content] contains muted terms.
+     * Lambda to be invoked when the [Flow] to which the muted terms are emitted is requested to be
+     * returned.
+     */
+    private var onGetTerms = { emptyFlow<List<String>>() }
+
+    /** Lambda to be invoked when a term is requested to be muted. */
+    private var onMute: suspend (term: String) -> Unit = {}
+
+    /** Lambda to be invoked when a term is requested to be unmuted. */
+    private var onUnmute: suspend (term: String) -> Unit = {}
+
+    /**
+     * Defines [getTerms] as the lambda to be invoked when the [Flow] with the terms that have been
+     * muted is requested to be returned.
      *
-     * @param content [Content] whose terms will be verified.
-     **/
-    suspend fun isMuted(content: Content): Boolean {
-        val terms = getTerms().first()
-        return terms.any { it in content.text }
+     * @param getTerms Provides the [Flow] to which the muted terms are emitted.
+     */
+    fun getTerms(getTerms: () -> Flow<List<String>>): Builder {
+      return apply { onGetTerms = getTerms }
     }
 
-    @TermMuterDsl
-    class Builder internal constructor() {
-        /**
-         * Lambda to be invoked when the [Flow] to which the muted terms are emitted is requested to
-         * be returned.
-         **/
-        private var onGetTerms = { emptyFlow<List<String>>() }
-
-        /** Lambda to be invoked when a term is requested to be muted. **/
-        private var onMute: suspend (term: String) -> Unit = { }
-
-        /** Lambda to be invoked when a term is requested to be unmuted. **/
-        private var onUnmute: suspend (term: String) -> Unit = { }
-
-        /**
-         * Defines [getTerms] as the lambda to be invoked when the [Flow] with the terms that have
-         * been muted is requested to be returned.
-         *
-         * @param getTerms Provides the [Flow] to which the muted terms are emitted.
-         **/
-        fun getTerms(getTerms: () -> Flow<List<String>>): Builder {
-            return apply {
-                onGetTerms = getTerms
-            }
-        }
-
-        /**
-         * Defines [mute] as the lambda to be invoked when the a term is requested to be muted.
-         *
-         * @param mute Operation to be performed that mutes the given term.
-         **/
-        fun mute(mute: suspend (term: String) -> Unit): Builder {
-            return apply {
-                onMute = mute
-            }
-        }
-
-        /**
-         * Defines [unmute] as the lambda to be invoked when the a term is requested to be unmuted.
-         *
-         * @param unmute Operation to be performed that unmutes the given term.
-         **/
-        fun unmute(unmute: suspend (term: String) -> Unit): Builder {
-            return apply {
-                onUnmute = unmute
-            }
-        }
-
-        /** Builds the [TermMuter] with the provided configuration. **/
-        internal fun build(): TermMuter {
-            return object : TermMuter() {
-                override fun getTerms(): Flow<List<String>> {
-                    return onGetTerms()
-                }
-
-                override suspend fun mute(term: String) {
-                    onMute(term)
-                }
-
-                override suspend fun unmute(term: String) {
-                    onUnmute(term)
-                }
-            }
-        }
+    /**
+     * Defines [mute] as the lambda to be invoked when the a term is requested to be muted.
+     *
+     * @param mute Operation to be performed that mutes the given term.
+     */
+    fun mute(mute: suspend (term: String) -> Unit): Builder {
+      return apply { onMute = mute }
     }
 
-    /** Gets the [Flow] to which the muted terms are emitted. **/
-    abstract fun getTerms(): Flow<List<String>>
-
     /**
-     * Mutes the given [term].
+     * Defines [unmute] as the lambda to be invoked when the a term is requested to be unmuted.
      *
-     * @param term Term to be muted.
-     **/
-    abstract suspend fun mute(term: String)
+     * @param unmute Operation to be performed that unmutes the given term.
+     */
+    fun unmute(unmute: suspend (term: String) -> Unit): Builder {
+      return apply { onUnmute = unmute }
+    }
 
-    /**
-     * Unmutes the given [term].
-     *
-     * @param term Term to be unmuted.
-     **/
-    abstract suspend fun unmute(term: String)
+    /** Builds the [TermMuter] with the provided configuration. */
+    internal fun build(): TermMuter {
+      return object : TermMuter() {
+        override fun getTerms(): Flow<List<String>> {
+          return onGetTerms()
+        }
+
+        override suspend fun mute(term: String) {
+          onMute(term)
+        }
+
+        override suspend fun unmute(term: String) {
+          onUnmute(term)
+        }
+      }
+    }
+  }
+
+  /** Gets the [Flow] to which the muted terms are emitted. */
+  abstract fun getTerms(): Flow<List<String>>
+
+  /**
+   * Mutes the given [term].
+   *
+   * @param term Term to be muted.
+   */
+  abstract suspend fun mute(term: String)
+
+  /**
+   * Unmutes the given [term].
+   *
+   * @param term Term to be unmuted.
+   */
+  abstract suspend fun unmute(term: String)
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/muting/TermMuterDsl.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/muting/TermMuterDsl.kt
@@ -1,5 +1,4 @@
 package com.jeanbarrossilva.orca.core.feed.profile.toot.muting
 
-/** Denotes that the annotated structure belongs to the [TermMuter] DSL. **/
-@DslMarker
-internal annotation class TermMuterDsl
+/** Denotes that the annotated structure belongs to the [TermMuter] DSL. */
+@DslMarker internal annotation class TermMuterDsl

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/Stat.extensions.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/Stat.extensions.kt
@@ -7,13 +7,9 @@ import kotlinx.coroutines.flow.flowOf
  * [List]s emitted to the result of [get]. Although all core variants should be as precise as
  * possible when defining what the total amount of elements counted by this [Stat] is, there is no
  * precise and efficient way of guaranteeing parity.
- **/
+ */
 fun <T> Stat(): Stat<T> {
-    return Stat(count = 0) {
-        get {
-            flowOf(emptyList())
-        }
-    }
+  return Stat(count = 0) { get { flowOf(emptyList()) } }
 }
 
 /**
@@ -24,7 +20,7 @@ fun <T> Stat(): Stat<T> {
  *
  * @param count Initial amount of elements of the [Stat].
  * @param build Configuration for the [Stat].
- **/
+ */
 fun <T> Stat(count: Int, build: Stat.Builder<T>.() -> Unit): Stat<T> {
-    return Stat.Builder<T>(count).apply(build).build()
+  return Stat.Builder<T>(count).apply(build).build()
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/Stat.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/Stat.kt
@@ -17,56 +17,54 @@ import kotlinx.coroutines.flow.emptyFlow
  *
  * @param count Initial amount of elements.
  * @see get
- **/
+ */
 abstract class Stat<T> internal constructor(count: Int) {
+  /**
+   * [MutableStateFlow] that keeps track of the total amount of elements comprehended by this
+   * [Stat].
+   */
+  internal val countMutableFlow = MutableStateFlow(count)
+
+  /** [StateFlow] to which the amount of elements will be emitted. */
+  val countFlow = countMutableFlow.asStateFlow()
+
+  /** Current amount of elements. */
+  val count
+    get() = countFlow.value
+
+  /**
+   * Allows for a [Stat] to be configured and built.
+   *
+   * @param count Initial amount of elements of the [Stat].
+   */
+  @StatDsl
+  open class Builder<T> internal constructor(protected val count: Int) {
+    /** Lambda that provides the [Flow] to be returned by the built [Stat]'s [onGet] method. */
+    protected var onGet = { _: Int -> emptyFlow<List<T>>() }
+
     /**
-     * [MutableStateFlow] that keeps track of the total amount of elements comprehended by this
-     * [Stat].
-     **/
-    internal val countMutableFlow = MutableStateFlow(count)
-
-    /** [StateFlow] to which the amount of elements will be emitted. **/
-    val countFlow = countMutableFlow.asStateFlow()
-
-    /** Current amount of elements. **/
-    val count
-        get() = countFlow.value
-
-    /**
-     * Allows for a [Stat] to be configured and built.
+     * Defines the [Flow] to be returned when the [Stat]'s [get] method is called.
      *
-     * @param count Initial amount of elements of the [Stat].
-     **/
-    @StatDsl
-    open class Builder<T> internal constructor(protected val count: Int) {
-        /** Lambda that provides the [Flow] to be returned by the built [Stat]'s [onGet] method. **/
-        protected var onGet = { _: Int -> emptyFlow<List<T>>() }
-
-        /**
-         * Defines the [Flow] to be returned when the [Stat]'s [get] method is called.
-         *
-         * @param get Provides the [Flow] to be returned.
-         **/
-        fun get(get: (page: Int) -> Flow<List<T>>): Builder<T> {
-            return apply {
-                onGet = get
-            }
-        }
-
-        /** Builds the [Stat] with the provided configuration. **/
-        internal open fun build(): Stat<T> {
-            return object : Stat<T>(count) {
-                override fun get(page: Int): Flow<List<T>> {
-                    return onGet.invoke(page)
-                }
-            }
-        }
+     * @param get Provides the [Flow] to be returned.
+     */
+    fun get(get: (page: Int) -> Flow<List<T>>): Builder<T> {
+      return apply { onGet = get }
     }
 
-    /**
-     * Gets the [Flow] to which the elements related to this [Stat] will be emitted.
-     *
-     * @param page Page at which the elements to be emitted are.
-     **/
-    abstract fun get(page: Int): Flow<List<T>>
+    /** Builds the [Stat] with the provided configuration. */
+    internal open fun build(): Stat<T> {
+      return object : Stat<T>(count) {
+        override fun get(page: Int): Flow<List<T>> {
+          return onGet.invoke(page)
+        }
+      }
+    }
+  }
+
+  /**
+   * Gets the [Flow] to which the elements related to this [Stat] will be emitted.
+   *
+   * @param page Page at which the elements to be emitted are.
+   */
+  abstract fun get(page: Int): Flow<List<T>>
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/StatDsl.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/StatDsl.kt
@@ -1,6 +1,4 @@
 package com.jeanbarrossilva.orca.core.feed.profile.toot.stat
 
-/** Denotes that the annotated structure belongs to the [Stat] DSL. **/
-@DslMarker
-@Target(AnnotationTarget.CLASS)
-internal annotation class StatDsl
+/** Denotes that the annotated structure belongs to the [Stat] DSL. */
+@DslMarker @Target(AnnotationTarget.CLASS) internal annotation class StatDsl

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/toggleable/ToggleableStat.extensions.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/toggleable/ToggleableStat.extensions.kt
@@ -3,13 +3,9 @@ package com.jeanbarrossilva.orca.core.feed.profile.toot.stat.toggleable
 import com.jeanbarrossilva.orca.core.feed.profile.toot.stat.Stat
 import kotlinx.coroutines.flow.flowOf
 
-/** [Stat] that can have its enable-ability toggled. **/
+/** [Stat] that can have its enable-ability toggled. */
 fun <T> ToggleableStat(): ToggleableStat<T> {
-    return ToggleableStat(count = 0) {
-        get {
-            flowOf(emptyList())
-        }
-    }
+  return ToggleableStat(count = 0) { get { flowOf(emptyList()) } }
 }
 
 /**
@@ -17,7 +13,7 @@ fun <T> ToggleableStat(): ToggleableStat<T> {
  *
  * @param count Initial amount of elements of the [ToggleableStat].
  * @param build Configuration for the [ToggleableStat].
- **/
+ */
 fun <T> ToggleableStat(count: Int, build: ToggleableStat.Builder<T>.() -> Unit): ToggleableStat<T> {
-    return ToggleableStat.Builder<T>(count).apply(build).build()
+  return ToggleableStat.Builder<T>(count).apply(build).build()
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/toggleable/ToggleableStat.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/toggleable/ToggleableStat.kt
@@ -10,80 +10,78 @@ import kotlinx.coroutines.flow.asStateFlow
  * [Stat] that can have its enable-ability toggled.
  *
  * @param count Initial amount of elements.
- **/
+ */
 abstract class ToggleableStat<T> internal constructor(count: Int) : Stat<T>(count) {
-    /** [MutableStateFlow] that gets emitted to whenever this [ToggleableStat] is toggled. **/
-    private val isEnabledMutableFlow = MutableStateFlow(false)
+  /** [MutableStateFlow] that gets emitted to whenever this [ToggleableStat] is toggled. */
+  private val isEnabledMutableFlow = MutableStateFlow(false)
 
-    /** [StateFlow] to which the current enable-ability state will be emitted. **/
-    val isEnabledFlow = isEnabledMutableFlow.asStateFlow()
+  /** [StateFlow] to which the current enable-ability state will be emitted. */
+  val isEnabledFlow = isEnabledMutableFlow.asStateFlow()
 
-    /** Whether this [ToggleableStat] is currently enabled. **/
-    val isEnabled
-        get() = isEnabledFlow.value
+  /** Whether this [ToggleableStat] is currently enabled. */
+  val isEnabled
+    get() = isEnabledFlow.value
 
-    /**
-     * Allows for a [ToggleableStat] to be configured and built.
-     *
-     * @param count Initial amount of elements of the [ToggleableStat].
-     **/
-    class Builder<T> internal constructor(count: Int) : Stat.Builder<T>(count) {
-        /** Lambda to be invoked when the [ToggleableStat]'s [setEnabled] method is called. **/
-        private var onSetEnabled: suspend (isEnabled: Boolean) -> Unit = { }
-
-        /**
-         * Defines what will be done when the [ToggleableStat]'s [setEnabled] is called.
-         *
-         * @param setEnabled Callback to be run.
-         **/
-        fun setEnabled(setEnabled: suspend (isEnabled: Boolean) -> Unit): Builder<T> {
-            return apply {
-                onSetEnabled = setEnabled
-            }
-        }
-
-        override fun build(): ToggleableStat<T> {
-            return object : ToggleableStat<T>(count) {
-                override fun get(page: Int): Flow<List<T>> {
-                    return onGet.invoke(page)
-                }
-
-                override suspend fun setEnabled(isEnabled: Boolean) {
-                    onSetEnabled(isEnabled)
-                }
-            }
-        }
-    }
-
-    /** Toggles whether this [ToggleableStat] is enabled. **/
-    suspend fun toggle() {
-        setEnabled(!isEnabled)
-        isEnabledMutableFlow.value = !isEnabled
-        countMutableFlow.value = if (isEnabled) countFlow.value.inc() else countFlow.value.dec()
-    }
-
-    /** Enables this [ToggleableStat]. **/
-    suspend fun enable() {
-        if (!isEnabled) {
-            setEnabled(true)
-            isEnabledMutableFlow.value = true
-            countMutableFlow.value++
-        }
-    }
-
-    /** Disables this [ToggleableStat]. **/
-    suspend fun disable() {
-        if (isEnabled) {
-            setEnabled(false)
-            isEnabledMutableFlow.value = false
-            countMutableFlow.value--
-        }
-    }
+  /**
+   * Allows for a [ToggleableStat] to be configured and built.
+   *
+   * @param count Initial amount of elements of the [ToggleableStat].
+   */
+  class Builder<T> internal constructor(count: Int) : Stat.Builder<T>(count) {
+    /** Lambda to be invoked when the [ToggleableStat]'s [setEnabled] method is called. */
+    private var onSetEnabled: suspend (isEnabled: Boolean) -> Unit = {}
 
     /**
-     * Defines whether this [ToggleableStat] is enabled.
+     * Defines what will be done when the [ToggleableStat]'s [setEnabled] is called.
      *
-     * @param isEnabled Whether it's being enabled or disabled.
-     **/
-    protected abstract suspend fun setEnabled(isEnabled: Boolean)
+     * @param setEnabled Callback to be run.
+     */
+    fun setEnabled(setEnabled: suspend (isEnabled: Boolean) -> Unit): Builder<T> {
+      return apply { onSetEnabled = setEnabled }
+    }
+
+    override fun build(): ToggleableStat<T> {
+      return object : ToggleableStat<T>(count) {
+        override fun get(page: Int): Flow<List<T>> {
+          return onGet.invoke(page)
+        }
+
+        override suspend fun setEnabled(isEnabled: Boolean) {
+          onSetEnabled(isEnabled)
+        }
+      }
+    }
+  }
+
+  /** Toggles whether this [ToggleableStat] is enabled. */
+  suspend fun toggle() {
+    setEnabled(!isEnabled)
+    isEnabledMutableFlow.value = !isEnabled
+    countMutableFlow.value = if (isEnabled) countFlow.value.inc() else countFlow.value.dec()
+  }
+
+  /** Enables this [ToggleableStat]. */
+  suspend fun enable() {
+    if (!isEnabled) {
+      setEnabled(true)
+      isEnabledMutableFlow.value = true
+      countMutableFlow.value++
+    }
+  }
+
+  /** Disables this [ToggleableStat]. */
+  suspend fun disable() {
+    if (isEnabled) {
+      setEnabled(false)
+      isEnabledMutableFlow.value = false
+      countMutableFlow.value--
+    }
+  }
+
+  /**
+   * Defines whether this [ToggleableStat] is enabled.
+   *
+   * @param isEnabled Whether it's being enabled or disabled.
+   */
+  protected abstract suspend fun setEnabled(isEnabled: Boolean)
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/type/editable/EditableProfile.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/type/editable/EditableProfile.kt
@@ -2,10 +2,10 @@ package com.jeanbarrossilva.orca.core.feed.profile.type.editable
 
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
 
-/** [Profile] that can be edited through its [editor]. **/
+/** [Profile] that can be edited through its [editor]. */
 abstract class EditableProfile : Profile {
-    /** [Editor] through which this [EditableProfile] can be edited. **/
-    abstract val editor: Editor
+  /** [Editor] through which this [EditableProfile] can be edited. */
+  abstract val editor: Editor
 
-    companion object
+  companion object
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/type/editable/Editor.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/type/editable/Editor.kt
@@ -3,40 +3,38 @@ package com.jeanbarrossilva.orca.core.feed.profile.type.editable
 import com.jeanbarrossilva.orca.std.styledstring.StyledString
 import java.net.URL
 
-/** Edits an [EditableProfile]. **/
+/** Edits an [EditableProfile]. */
 interface Editor {
-    /**
-     * Sets [avatarURL] as the [EditableProfile]'s [avatarURL][EditableProfile.avatarURL].
-     *
-     * @param avatarURL Avatar [URL] to be set to the [EditableProfile]..
-     **/
-    suspend fun setAvatarURL(avatarURL: URL)
+  /**
+   * Sets [avatarURL] as the [EditableProfile]'s [avatarURL][EditableProfile.avatarURL].
+   *
+   * @param avatarURL Avatar [URL] to be set to the [EditableProfile]..
+   */
+  suspend fun setAvatarURL(avatarURL: URL)
 
-    /**
-     * Sets [name] as the [EditableProfile]'s [name][EditableProfile.name].
-     *
-     * @param name Name to be set to the [EditableProfile].
-     **/
-    suspend fun setName(name: String)
+  /**
+   * Sets [name] as the [EditableProfile]'s [name][EditableProfile.name].
+   *
+   * @param name Name to be set to the [EditableProfile].
+   */
+  suspend fun setName(name: String)
 
-    /**
-     * Sets [bio] as the [EditableProfile]'s [bio][EditableProfile.bio].
-     *
-     * @param bio Bio to be set to the [EditableProfile].
-     **/
-    suspend fun setBio(bio: StyledString)
+  /**
+   * Sets [bio] as the [EditableProfile]'s [bio][EditableProfile.bio].
+   *
+   * @param bio Bio to be set to the [EditableProfile].
+   */
+  suspend fun setBio(bio: StyledString)
 
-    companion object {
-        /** No-op, empty [Editor]. **/
-        val empty = object : Editor {
-            override suspend fun setAvatarURL(avatarURL: URL) {
-            }
+  companion object {
+    /** No-op, empty [Editor]. */
+    val empty =
+      object : Editor {
+        override suspend fun setAvatarURL(avatarURL: URL) {}
 
-            override suspend fun setName(name: String) {
-            }
+        override suspend fun setName(name: String) {}
 
-            override suspend fun setBio(bio: StyledString) {
-            }
-        }
-    }
+        override suspend fun setBio(bio: StyledString) {}
+      }
+  }
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/type/followable/Follow.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/type/followable/Follow.kt
@@ -2,200 +2,201 @@ package com.jeanbarrossilva.orca.core.feed.profile.type.followable
 
 import java.io.Serializable
 
-/** Status that indicates in which "following" state a user is related to another. **/
+/** Status that indicates in which "following" state a user is related to another. */
 abstract class Follow private constructor() : Serializable {
-    /** Name that describes the visibility for which this [Follow] status is intended. **/
-    protected abstract val visibilityName: String
+  /** Name that describes the visibility for which this [Follow] status is intended. */
+  protected abstract val visibilityName: String
 
-    /** Public [Follow] status. **/
-    abstract class Public private constructor() : Follow() {
-        override val visibilityName = "public"
-
-        companion object {
-            /**
-             * [Follow] status in which a user doesn't receive any updates related to the other's
-             * activity.
-             **/
-            fun unfollowed(): Public {
-                return object : Public() {
-                    override fun toString(): String {
-                        return "Follow.Public.unfollowed"
-                    }
-
-                    override fun toggled(): Follow {
-                        return following()
-                    }
-
-                    override fun next(): Follow {
-                        return following()
-                    }
-                }
-            }
-
-            /** [Follow] status in which a user has subscribed to receive updates from another. **/
-            fun following(): Public {
-                return object : Public() {
-                    override fun toString(): String {
-                        return "Follow.Public.following"
-                    }
-
-                    override fun toggled(): Follow {
-                        return unfollowed()
-                    }
-
-                    override fun next(): Follow? {
-                        return null
-                    }
-                }
-            }
-        }
-    }
-
-    /** Private [Follow] status. **/
-    abstract class Private private constructor() : Follow() {
-        override val visibilityName = "private"
-
-        companion object {
-            /**
-             * [Follow] status in which a user doesn't receive any updates related to the other's
-             * activity.
-             **/
-            fun unfollowed(): Private {
-                return object : Private() {
-                    override fun toString(): String {
-                        return "Follow.Private.unfollowed"
-                    }
-
-                    override fun toggled(): Follow {
-                        return requested()
-                    }
-
-                    override fun next(): Follow {
-                        return requested()
-                    }
-                }
-            }
-
-            /**
-             * [Follow] status in which a user has requested to follow another and is waiting for it to
-             * be accepted or denied.
-             **/
-            fun requested(): Private {
-                return object : Private() {
-                    override fun toString(): String {
-                        return "Follow.Private.requested"
-                    }
-
-                    override fun toggled(): Follow {
-                        return unfollowed()
-                    }
-
-                    override fun next(): Follow {
-                        return following()
-                    }
-                }
-            }
-
-            /** [Follow] status in which a user has subscribed to receive updates from another. **/
-            fun following(): Private {
-                return object : Private() {
-                    override fun toString(): String {
-                        return "Follow.Private.following"
-                    }
-
-                    override fun toggled(): Follow {
-                        return unfollowed()
-                    }
-
-                    override fun next(): Follow? {
-                        return null
-                    }
-                }
-            }
-        }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        return toString() == other?.toString()
-    }
-
-    override fun hashCode(): Int {
-        return toString().hashCode()
-    }
-
-    /** Provides the [Follow] status that's contrary to this one. **/
-    internal abstract fun toggled(): Follow
-
-    /** Provides the [Follow] status that succeeds this one. **/
-    internal abstract fun next(): Follow?
+  /** Public [Follow] status. */
+  abstract class Public private constructor() : Follow() {
+    override val visibilityName = "public"
 
     companion object {
-        /**
-         * [IllegalArgumentException] thrown if a blank [String] is given when parsing it into a
-         * [Follow].
-         *
-         * @see of
-         **/
-        class BlankStringException internal constructor() :
-            IllegalArgumentException("Cannot parse a blank String.")
+      /**
+       * [Follow] status in which a user doesn't receive any updates related to the other's
+       * activity.
+       */
+      fun unfollowed(): Public {
+        return object : Public() {
+          override fun toString(): String {
+            return "Follow.Public.unfollowed"
+          }
 
-        /**
-         * [IllegalArgumentException] thrown if the given [String] is not a valid [Follow]
-         * representation.
-         *
-         * @param string [Follow] representation that's invalid.
-         **/
-        class InvalidFollowString internal constructor(string: String) : IllegalArgumentException(
-            "\"$string\" does not match any of the available Follow String representations."
-        )
+          override fun toggled(): Follow {
+            return following()
+          }
 
-        /**
-         * Parses the [string] into a [Follow].
-         *
-         * [string] must be the result of calling [toString] on one of the existing [Follow]s
-         * (e. g., `Follow.of("${Follow.Public.unfollowed()}")` returns [Public.unfollowed]). Any
-         * leading or trailing whitespace it may contain will be ignored.
-         *
-         * @param string [String] to be parsed into a [Follow].
-         * @return [Follow] whose result of [toString] equals to the [string] (minus surrounding
-         * whitespaces).
-         * @throws BlankStringException If the [string] is blank.
-         * @throws InvalidFollowString If the [string] is not a valid [Follow] representation.
-         **/
-        fun of(string: String): Follow {
-            val formattedString = string.trim()
-            formattedString.ifBlank { throw BlankStringException() }
-            return when (formattedString) {
-                Public.unfollowed().toString() -> Public.unfollowed()
-                Public.following().toString() -> Public.following()
-                Private.unfollowed().toString() -> Private.unfollowed()
-                Private.requested().toString() -> Private.requested()
-                Private.following().toString() -> Private.following()
-                else -> throw InvalidFollowString(formattedString)
-            }
+          override fun next(): Follow {
+            return following()
+          }
         }
+      }
 
-        /**
-         * Requires both statuses to have the same visibility: either [public][Follow.Public] or
-         * [private][Follow.Private].
-         *
-         * @param expected Status that indicates which visibility [actual]'s should match.
-         * @param actual Status whose visibility should match [expected]'s.
-         * @return [actual] as [T].
-         * @throws IllegalArgumentException If [expected] and [actual] have different visibilities.
-         * @see visibilityName
-         **/
-        fun <T : Follow> requireVisibilityMatch(expected: T, actual: Follow): T {
-            val isCohesive = actual.visibilityName == expected.visibilityName
-            return if (isCohesive) {
-                @Suppress("UNCHECKED_CAST")
-                actual as T
-            } else {
-                throw IllegalArgumentException(
-                    "$actual is a ${actual.visibilityName} status instead of a " +
-                        "${expected.visibilityName} one."
-                )
-            }
+      /** [Follow] status in which a user has subscribed to receive updates from another. */
+      fun following(): Public {
+        return object : Public() {
+          override fun toString(): String {
+            return "Follow.Public.following"
+          }
+
+          override fun toggled(): Follow {
+            return unfollowed()
+          }
+
+          override fun next(): Follow? {
+            return null
+          }
         }
+      }
     }
+  }
+
+  /** Private [Follow] status. */
+  abstract class Private private constructor() : Follow() {
+    override val visibilityName = "private"
+
+    companion object {
+      /**
+       * [Follow] status in which a user doesn't receive any updates related to the other's
+       * activity.
+       */
+      fun unfollowed(): Private {
+        return object : Private() {
+          override fun toString(): String {
+            return "Follow.Private.unfollowed"
+          }
+
+          override fun toggled(): Follow {
+            return requested()
+          }
+
+          override fun next(): Follow {
+            return requested()
+          }
+        }
+      }
+
+      /**
+       * [Follow] status in which a user has requested to follow another and is waiting for it to be
+       * accepted or denied.
+       */
+      fun requested(): Private {
+        return object : Private() {
+          override fun toString(): String {
+            return "Follow.Private.requested"
+          }
+
+          override fun toggled(): Follow {
+            return unfollowed()
+          }
+
+          override fun next(): Follow {
+            return following()
+          }
+        }
+      }
+
+      /** [Follow] status in which a user has subscribed to receive updates from another. */
+      fun following(): Private {
+        return object : Private() {
+          override fun toString(): String {
+            return "Follow.Private.following"
+          }
+
+          override fun toggled(): Follow {
+            return unfollowed()
+          }
+
+          override fun next(): Follow? {
+            return null
+          }
+        }
+      }
+    }
+  }
+
+  override fun equals(other: Any?): Boolean {
+    return toString() == other?.toString()
+  }
+
+  override fun hashCode(): Int {
+    return toString().hashCode()
+  }
+
+  /** Provides the [Follow] status that's contrary to this one. */
+  internal abstract fun toggled(): Follow
+
+  /** Provides the [Follow] status that succeeds this one. */
+  internal abstract fun next(): Follow?
+
+  companion object {
+    /**
+     * [IllegalArgumentException] thrown if a blank [String] is given when parsing it into a
+     * [Follow].
+     *
+     * @see of
+     */
+    class BlankStringException internal constructor() :
+      IllegalArgumentException("Cannot parse a blank String.")
+
+    /**
+     * [IllegalArgumentException] thrown if the given [String] is not a valid [Follow]
+     * representation.
+     *
+     * @param string [Follow] representation that's invalid.
+     */
+    class InvalidFollowString internal constructor(string: String) :
+      IllegalArgumentException(
+        "\"$string\" does not match any of the available Follow String representations."
+      )
+
+    /**
+     * Parses the [string] into a [Follow].
+     *
+     * [string] must be the result of calling [toString] on one of the existing [Follow]s (e. g.,
+     * `Follow.of("${Follow.Public.unfollowed()}")` returns [Public.unfollowed]). Any leading or
+     * trailing whitespace it may contain will be ignored.
+     *
+     * @param string [String] to be parsed into a [Follow].
+     * @return [Follow] whose result of [toString] equals to the [string] (minus surrounding
+     *   whitespaces).
+     * @throws BlankStringException If the [string] is blank.
+     * @throws InvalidFollowString If the [string] is not a valid [Follow] representation.
+     */
+    fun of(string: String): Follow {
+      val formattedString = string.trim()
+      formattedString.ifBlank { throw BlankStringException() }
+      return when (formattedString) {
+        Public.unfollowed().toString() -> Public.unfollowed()
+        Public.following().toString() -> Public.following()
+        Private.unfollowed().toString() -> Private.unfollowed()
+        Private.requested().toString() -> Private.requested()
+        Private.following().toString() -> Private.following()
+        else -> throw InvalidFollowString(formattedString)
+      }
+    }
+
+    /**
+     * Requires both statuses to have the same visibility: either [public][Follow.Public] or
+     * [private][Follow.Private].
+     *
+     * @param expected Status that indicates which visibility [actual]'s should match.
+     * @param actual Status whose visibility should match [expected]'s.
+     * @return [actual] as [T].
+     * @throws IllegalArgumentException If [expected] and [actual] have different visibilities.
+     * @see visibilityName
+     */
+    fun <T : Follow> requireVisibilityMatch(expected: T, actual: Follow): T {
+      val isCohesive = actual.visibilityName == expected.visibilityName
+      return if (isCohesive) {
+        @Suppress("UNCHECKED_CAST")
+        actual as T
+      } else {
+        throw IllegalArgumentException(
+          "$actual is a ${actual.visibilityName} status instead of a " +
+            "${expected.visibilityName} one."
+        )
+      }
+    }
+  }
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/type/followable/FollowableProfile.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/type/followable/FollowableProfile.kt
@@ -2,24 +2,24 @@ package com.jeanbarrossilva.orca.core.feed.profile.type.followable
 
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
 
-/** [Profile] whose [follow] status can be toggled. **/
+/** [Profile] whose [follow] status can be toggled. */
 abstract class FollowableProfile<T : Follow> : Profile {
-    /** Current [Follow] status. **/
-    abstract val follow: T
+  /** Current [Follow] status. */
+  abstract val follow: T
 
-    /** Toggles the [follow] status. **/
-    suspend fun toggleFollow() {
-        val toggledFollow = follow.toggled()
-        val matchingToggledFollow = Follow.requireVisibilityMatch(follow, toggledFollow)
-        onChangeFollowTo(matchingToggledFollow)
-    }
+  /** Toggles the [follow] status. */
+  suspend fun toggleFollow() {
+    val toggledFollow = follow.toggled()
+    val matchingToggledFollow = Follow.requireVisibilityMatch(follow, toggledFollow)
+    onChangeFollowTo(matchingToggledFollow)
+  }
 
-    /**
-     * Callback run whenever the [Follow] status is changed to [follow].
-     *
-     * @param follow Changed [Follow] status.
-     **/
-    protected abstract suspend fun onChangeFollowTo(follow: T)
+  /**
+   * Callback run whenever the [Follow] status is changed to [follow].
+   *
+   * @param follow Changed [Follow] status.
+   */
+  protected abstract suspend fun onChangeFollowTo(follow: T)
 
-    companion object
+  companion object
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/instance/Instance.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/instance/Instance.kt
@@ -10,38 +10,38 @@ import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
 import com.jeanbarrossilva.orca.core.feed.profile.toot.TootProvider
 import com.jeanbarrossilva.orca.core.instance.domain.Domain
 
-/** An [Instance] with a generic [Authenticator]. **/
+/** An [Instance] with a generic [Authenticator]. */
 typealias SomeInstance = Instance<*>
 
 /**
  * Site at which the user is, from which all operations can be performed.
  *
  * @param T [Authenticator] to authenticate the user with.
- **/
+ */
 abstract class Instance<T : Authenticator> {
-    /** Unique identifier of the server. **/
-    abstract val domain: Domain
+  /** Unique identifier of the server. */
+  abstract val domain: Domain
 
-    /** [Instance]-specific [Authenticator] through which authentication can be done. **/
-    abstract val authenticator: T
+  /** [Instance]-specific [Authenticator] through which authentication can be done. */
+  abstract val authenticator: T
 
-    /**
-     * [Instance]-specific [AuthenticationLock] by which features can be locked or unlocked by an
-     * authentication "wall".
-     **/
-    abstract val authenticationLock: AuthenticationLock<T>
+  /**
+   * [Instance]-specific [AuthenticationLock] by which features can be locked or unlocked by an
+   * authentication "wall".
+   */
+  abstract val authenticationLock: AuthenticationLock<T>
 
-    /** [Instance]-specific [FeedProvider] that provides the [Toot]s in the timeline. **/
-    abstract val feedProvider: FeedProvider
+  /** [Instance]-specific [FeedProvider] that provides the [Toot]s in the timeline. */
+  abstract val feedProvider: FeedProvider
 
-    /** [Instance]-specific [ProfileProvider] for providing [Profile]s. **/
-    abstract val profileProvider: ProfileProvider
+  /** [Instance]-specific [ProfileProvider] for providing [Profile]s. */
+  abstract val profileProvider: ProfileProvider
 
-    /** [Instance]-specific [ProfileSearcher] by which search for [Profile]s can be made. **/
-    abstract val profileSearcher: ProfileSearcher
+  /** [Instance]-specific [ProfileSearcher] by which search for [Profile]s can be made. */
+  abstract val profileSearcher: ProfileSearcher
 
-    /** [Instance]-specific [TootProvider] that provides [Toot]s. **/
-    abstract val tootProvider: TootProvider
+  /** [Instance]-specific [TootProvider] that provides [Toot]s. */
+  abstract val tootProvider: TootProvider
 
-    companion object
+  companion object
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/instance/InstanceProvider.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/instance/InstanceProvider.kt
@@ -1,9 +1,9 @@
 package com.jeanbarrossilva.orca.core.instance
 
-/** Provides an [Instance] through [provide]. **/
+/** Provides an [Instance] through [provide]. */
 interface InstanceProvider {
-    /** Provides an [Instance]. **/
-    fun provide(): SomeInstance
+  /** Provides an [Instance]. */
+  fun provide(): SomeInstance
 
-    companion object
+  companion object
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/instance/domain/Domain.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/instance/domain/Domain.kt
@@ -4,107 +4,104 @@ package com.jeanbarrossilva.orca.core.instance.domain
  * An instance's unique identifier.
  *
  * @param value [String] that represents this [Domain].
- **/
+ */
 @JvmInline
 value class Domain(private val value: String) {
-    /** [IllegalArgumentException] thrown if the [value] is blank. **/
-    class BlankValueException internal constructor() :
-        IllegalArgumentException("Domain cannot be empty.")
+  /** [IllegalArgumentException] thrown if the [value] is blank. */
+  class BlankValueException internal constructor() :
+    IllegalArgumentException("Domain cannot be empty.")
+
+  /**
+   * [IllegalArgumentException] thrown if the [value] contains any of the [illegalCharacters].
+   *
+   * @param illegalCharacters [Char]s that make the [value] illegal.
+   */
+  class IllegalValueException internal constructor(illegalCharacters: List<Char>) :
+    IllegalArgumentException("Value cannot contain: $illegalCharacters.")
+
+  /**
+   * [IllegalArgumentException] thrown if the [value] doesn't have a top-level domain.
+   *
+   * @param value Domain that lacks a top-level domain.
+   */
+  class ValueWithoutTopLevelDomainException internal constructor(value: String) :
+    IllegalArgumentException("\"$value\" doesn't have a top-level domain.")
+
+  init {
+    ensureNonBlankness()
+    ensureLegality()
+    ensureTopLevelDomainPresence()
+  }
+
+  override fun toString(): String {
+    return value
+  }
+
+  /**
+   * Ensures that the [value] is not blank.
+   *
+   * @throws BlankValueException If the [value] is blank.
+   */
+  private fun ensureNonBlankness() {
+    if (value.isBlank()) {
+      throw BlankValueException()
+    }
+  }
+
+  /**
+   * Ensures that the [value] is legal.
+   *
+   * @throws IllegalValueException If the [value] is illegal.
+   */
+  private fun ensureLegality() {
+    doOnIllegality(value) { throw IllegalValueException(it) }
+  }
+
+  /**
+   * Ensures that the [value] has a top-level domain.
+   *
+   * @throws ValueWithoutTopLevelDomainException If the [value] doesn't have a top-level domain.
+   */
+  private fun ensureTopLevelDomainPresence() {
+    if (!containsTopLevelDomain(value)) {
+      throw ValueWithoutTopLevelDomainException(value)
+    }
+  }
+
+  companion object {
+    /** [Char]s that the [value] shouldn't contain. */
+    internal val illegalCharacters = arrayOf(' ', '@')
 
     /**
-     * [IllegalArgumentException] thrown if the [value] contains any of the
-     * [illegalCharacters].
+     * Verifies whether the [value] is valid.
      *
-     * @param illegalCharacters [Char]s that make the [value] illegal.
-     **/
-    class IllegalValueException internal constructor(illegalCharacters: List<Char>) :
-        IllegalArgumentException("Value cannot contain: $illegalCharacters.")
-
-    /**
-     * [IllegalArgumentException] thrown if the [value] doesn't have a top-level domain.
-     *
-     * @param value Domain that lacks a top-level domain.
-     **/
-    class ValueWithoutTopLevelDomainException internal constructor(value: String) :
-        IllegalArgumentException("\"$value\" doesn't have a top-level domain.")
-
-    init {
-        ensureNonBlankness()
-        ensureLegality()
-        ensureTopLevelDomainPresence()
-    }
-
-    override fun toString(): String {
-        return value
+     * @param value [String] whose validity will be verified.
+     */
+    fun isValid(value: String): Boolean {
+      return value.isNotBlank() && value.isLegal && containsTopLevelDomain(value)
     }
 
     /**
-     * Ensures that the [value] is not blank.
+     * Runs the [action] if the [value] contains any of the [illegalCharacters].
      *
-     * @throws BlankValueException If the [value] is blank.
-     **/
-    private fun ensureNonBlankness() {
-        if (value.isBlank()) {
-            throw BlankValueException()
-        }
+     * @param value [String] to check against.
+     * @param action Callback called if the [value] is considered to be illegal.
+     */
+    internal fun doOnIllegality(value: String, action: (illegal: List<Char>) -> Unit) {
+      val illegal = illegalCharacters.filter { it in value }
+      val isIllegal = illegal.any { it in value }
+      if (isIllegal) {
+        action(illegal)
+      }
     }
 
     /**
-     * Ensures that the [value] is legal.
+     * Whether the [value] contains a top-level domain.
      *
-     * @throws IllegalValueException If the [value] is illegal.
-     **/
-    private fun ensureLegality() {
-        doOnIllegality(value) {
-            throw IllegalValueException(it)
-        }
+     * @param value [String] whose top-level domain's presence will be checked.
+     */
+    private fun containsTopLevelDomain(value: String): Boolean {
+      return value.split('.').getOrNull(1)?.isNotBlank() ?: false
     }
-
-    /**
-     * Ensures that the [value] has a top-level domain.
-     *
-     * @throws ValueWithoutTopLevelDomainException If the [value] doesn't have a top-level domain.
-     **/
-    private fun ensureTopLevelDomainPresence() {
-        if (!containsTopLevelDomain(value)) {
-            throw ValueWithoutTopLevelDomainException(value)
-        }
-    }
-
-    companion object {
-        /** [Char]s that the [value] shouldn't contain. **/
-        internal val illegalCharacters = arrayOf(' ', '@')
-
-        /**
-         * Verifies whether the [value] is valid.
-         *
-         * @param value [String] whose validity will be verified.
-         **/
-        fun isValid(value: String): Boolean {
-            return value.isNotBlank() && value.isLegal && containsTopLevelDomain(value)
-        }
-
-        /**
-         * Runs the [action] if the [value] contains any of the [illegalCharacters].
-         *
-         * @param value [String] to check against.
-         * @param action Callback called if the [value] is considered to be illegal.
-         **/
-        internal fun doOnIllegality(value: String, action: (illegal: List<Char>) -> Unit) {
-            val illegal = illegalCharacters.filter { it in value }
-            val isIllegal = illegal.any { it in value }
-            if (isIllegal) {
-                action(illegal)
-            }
-        }
-
-        /**
-         * Whether the [value] contains a top-level domain.
-         *
-         * @param value [String] whose top-level domain's presence will be checked.
-         **/
-        private fun containsTopLevelDomain(value: String): Boolean {
-            return value.split('.').getOrNull(1)?.isNotBlank() ?: false
-        }
-    }
+  }
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/instance/domain/String.extensions.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/instance/domain/String.extensions.kt
@@ -1,5 +1,5 @@
 package com.jeanbarrossilva.orca.core.instance.domain
 
-/** Whether this [String] contains no illegal characters. **/
+/** Whether this [String] contains no illegal characters. */
 internal val String.isLegal
-    get() = Domain.illegalCharacters.none { it in this }
+  get() = Domain.illegalCharacters.none { it in this }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/auth/AuthenticationLockTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/auth/AuthenticationLockTests.kt
@@ -8,28 +8,25 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 
 internal class AuthenticationLockTests {
-    @Test
-    fun `GIVEN an unauthenticated actor WHEN unlocking THEN it's authenticated`() {
-        var hasBeenAuthenticated = false
-        val authenticator = TestAuthenticator { hasBeenAuthenticated = true }
-        runTest {
-            TestAuthenticationLock(authenticator = authenticator).requestUnlock {
-            }
-        }
-        assertTrue(hasBeenAuthenticated)
-    }
+  @Test
+  fun `GIVEN an unauthenticated actor WHEN unlocking THEN it's authenticated`() {
+    var hasBeenAuthenticated = false
+    val authenticator = TestAuthenticator { hasBeenAuthenticated = true }
+    runTest { TestAuthenticationLock(authenticator = authenticator).requestUnlock {} }
+    assertTrue(hasBeenAuthenticated)
+  }
 
-    @Test
-    fun `GIVEN an authenticated actor WHEN unlocking THEN the listener is notified`() {
-        val actorProvider = TestActorProvider()
-        val authenticator = TestAuthenticator(actorProvider = actorProvider)
-        var hasListenerBeenNotified = false
-        runTest {
-            authenticator.authenticate()
-            TestAuthenticationLock(actorProvider, authenticator).requestUnlock {
-                hasListenerBeenNotified = true
-            }
-        }
-        assertTrue(hasListenerBeenNotified)
+  @Test
+  fun `GIVEN an authenticated actor WHEN unlocking THEN the listener is notified`() {
+    val actorProvider = TestActorProvider()
+    val authenticator = TestAuthenticator(actorProvider = actorProvider)
+    var hasListenerBeenNotified = false
+    runTest {
+      authenticator.authenticate()
+      TestAuthenticationLock(actorProvider, authenticator).requestUnlock {
+        hasListenerBeenNotified = true
+      }
     }
+    assertTrue(hasListenerBeenNotified)
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/auth/AuthenticatorTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/auth/AuthenticatorTests.kt
@@ -10,29 +10,27 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 
 internal class AuthenticatorTests {
-    @Test
-    fun `GIVEN an authentication WHEN verifying if the actor is authorized THEN it is`() {
-        var isAuthorized = false
-        val authorizer = TestAuthorizer { isAuthorized = true }
-        runTest { TestAuthenticator(authorizer).authenticate() }
-        assertTrue(isAuthorized)
-    }
+  @Test
+  fun `GIVEN an authentication WHEN verifying if the actor is authorized THEN it is`() {
+    var isAuthorized = false
+    val authorizer = TestAuthorizer { isAuthorized = true }
+    runTest { TestAuthenticator(authorizer).authenticate() }
+    assertTrue(isAuthorized)
+  }
 
-    @Test
-    fun `GIVEN an authentication WHEN comparing the authorization code provided by the authorizer and the one the authenticator receives THEN they're the same`() { // ktlint-disable max-line-length
-        lateinit var providedAuthorizationCode: String
-        val authorizer = TestAuthorizer()
-        val authenticator = TestAuthenticator { providedAuthorizationCode = it }
-        runTest { authenticator.authenticate() }
-        assertEquals(TestAuthorizer.AUTHORIZATION_CODE, providedAuthorizationCode)
-    }
+  @Test
+  fun `GIVEN an authentication WHEN comparing the authorization code provided by the authorizer and the one the authenticator receives THEN they're the same`() {
+    lateinit var providedAuthorizationCode: String
+    val authorizer = TestAuthorizer()
+    val authenticator = TestAuthenticator { providedAuthorizationCode = it }
+    runTest { authenticator.authenticate() }
+    assertEquals(TestAuthorizer.AUTHORIZATION_CODE, providedAuthorizationCode)
+  }
 
-    @Test
-    fun `GIVEN an authentication WHEN getting the resulting actor THEN it's authenticated`() {
-        val authorizer = TestAuthorizer()
-        val authenticator = TestAuthenticator()
-        runTest {
-            assertIs<Actor.Authenticated>(authenticator.authenticate())
-        }
-    }
+  @Test
+  fun `GIVEN an authentication WHEN getting the resulting actor THEN it's authenticated`() {
+    val authorizer = TestAuthorizer()
+    val authenticator = TestAuthenticator()
+    runTest { assertIs<Actor.Authenticated>(authenticator.authenticate()) }
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/auth/actor/ActorProviderTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/auth/actor/ActorProviderTests.kt
@@ -7,13 +7,13 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 internal class ActorProviderTests {
-    @Test
-    fun `GIVEN a provider WHEN authenticating THEN it provides the resulting actor`() {
-        val actorProvider = TestActorProvider()
-        val authenticator = TestAuthenticator(actorProvider = actorProvider)
-        runTest {
-            val actor = authenticator.authenticate()
-            assertEquals(actor, actorProvider.provide())
-        }
+  @Test
+  fun `GIVEN a provider WHEN authenticating THEN it provides the resulting actor`() {
+    val actorProvider = TestActorProvider()
+    val authenticator = TestAuthenticator(actorProvider = actorProvider)
+    runTest {
+      val actor = authenticator.authenticate()
+      assertEquals(actor, actorProvider.provide())
     }
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/FeedProviderTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/FeedProviderTests.kt
@@ -4,94 +4,92 @@ import app.cash.turbine.test
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
 import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.muting.SampleTermMuter
 import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.samples
-import kotlin.test.Test
-import kotlin.test.assertContentEquals
-import kotlin.test.assertFailsWith
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
 
 internal class FeedProviderTests {
-    @Test
-    fun `GIVEN a nonexistent user's ID WHEN requesting a feed to be provided with it THEN it throws`() { // ktlint-disable max-line-length
-        val provider = object : FeedProvider() {
-            override val termMuter = SampleTermMuter()
+  @Test
+  fun `GIVEN a nonexistent user's ID WHEN requesting a feed to be provided with it THEN it throws`() {
+    val provider =
+      object : FeedProvider() {
+        override val termMuter = SampleTermMuter()
 
-            override suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>> {
-                return emptyFlow()
-            }
+        override suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>> {
+          return emptyFlow()
+        }
 
-            override suspend fun containsUser(userID: String): Boolean {
-                return false
-            }
+        override suspend fun containsUser(userID: String): Boolean {
+          return false
         }
-        assertFailsWith<FeedProvider.NonexistentUserException> {
-            runTest {
-                provider.provide(userID = "🫨", page = 0)
-            }
-        }
+      }
+    assertFailsWith<FeedProvider.NonexistentUserException> {
+      runTest { provider.provide(userID = "🫨", page = 0) }
     }
+  }
 
-    @Test
-    fun `GIVEN a negative page WHEN requesting a feed to be provided with it THEN it throws`() {
-        val provider = object : FeedProvider() {
-            override val termMuter = SampleTermMuter()
+  @Test
+  fun `GIVEN a negative page WHEN requesting a feed to be provided with it THEN it throws`() {
+    val provider =
+      object : FeedProvider() {
+        override val termMuter = SampleTermMuter()
 
-            override suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>> {
-                return emptyFlow()
-            }
-
-            override suspend fun containsUser(userID: String): Boolean {
-                return true
-            }
+        override suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>> {
+          return emptyFlow()
         }
-        assertFailsWith<IndexOutOfBoundsException> {
-            runTest {
-                provider.provide(userID = "🥲", page = -1)
-            }
+
+        override suspend fun containsUser(userID: String): Boolean {
+          return true
         }
+      }
+    assertFailsWith<IndexOutOfBoundsException> {
+      runTest { provider.provide(userID = "🥲", page = -1) }
     }
+  }
 
-    @Test
-    fun `GIVEN a user ID WHEN requesting a feed to be provided with it THEN it's provided`() {
-        val provider = object : FeedProvider() {
-            override val termMuter = SampleTermMuter()
+  @Test
+  fun `GIVEN a user ID WHEN requesting a feed to be provided with it THEN it's provided`() {
+    val provider =
+      object : FeedProvider() {
+        override val termMuter = SampleTermMuter()
 
-            override suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>> {
-                return flowOf(Toot.samples)
-            }
-
-            override suspend fun containsUser(userID: String): Boolean {
-                return true
-            }
+        override suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>> {
+          return flowOf(Toot.samples)
         }
-        runTest {
-            assertContentEquals(Toot.samples, provider.provide(userID = "🥸", page = 0).first())
+
+        override suspend fun containsUser(userID: String): Boolean {
+          return true
         }
+      }
+    runTest { assertContentEquals(Toot.samples, provider.provide(userID = "🥸", page = 0).first()) }
+  }
+
+  @Test
+  fun `GIVEN some muted terms WHEN providing a feed THEN toots with these terms are filtered out`() {
+    val termMuter = SampleTermMuter()
+    val provider =
+      object : FeedProvider() {
+        override val termMuter = termMuter
+
+        override suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>> {
+          return flowOf(Toot.samples.take(1))
+        }
+
+        override suspend fun containsUser(userID: String): Boolean {
+          return true
+        }
+      }
+    runTest {
+      Toot.samples.first().content.text.split(' ').take(2).forEach { termMuter.mute(it) }
+      provider.provide(userID = "😶‍🌫️", page = 0).test {
+        assertContentEquals(emptyList(), awaitItem())
+        awaitComplete()
+      }
     }
-
-    @Test
-    fun `GIVEN some muted terms WHEN providing a feed THEN toots with these terms are filtered out`() { // ktlint-disable max-line-length
-        val termMuter = SampleTermMuter()
-        val provider = object : FeedProvider() {
-            override val termMuter = termMuter
-
-            override suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>> {
-                return flowOf(Toot.samples.take(1))
-            }
-
-            override suspend fun containsUser(userID: String): Boolean {
-                return true
-            }
-        }
-        runTest {
-            Toot.samples.first().content.text.split(' ').take(2).forEach { termMuter.mute(it) }
-            provider.provide(userID = "😶‍🌫️", page = 0).test {
-                assertContentEquals(emptyList(), awaitItem())
-                awaitComplete()
-            }
-        }
-    }
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/FlowExtensionsTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/FlowExtensionsTests.kt
@@ -7,13 +7,15 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 
 internal class FlowExtensionsTests {
-    @Test
-    fun filtersEach() {
-        runTest {
-            flowOf(listOf(0, 1, 2)).filterEach { it % 2 == 0 }.test {
-                assertEquals(listOf(0, 2), awaitItem())
-                awaitComplete()
-            }
+  @Test
+  fun filtersEach() {
+    runTest {
+      flowOf(listOf(0, 1, 2))
+        .filterEach { it % 2 == 0 }
+        .test {
+          assertEquals(listOf(0, 2), awaitItem())
+          awaitComplete()
         }
     }
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/ProfileProviderTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/ProfileProviderTests.kt
@@ -11,37 +11,35 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 
 internal class ProfileProviderTests {
-    @Test
-    fun `GIVEN a nonexistent profile WHEN requesting it to be provided THEN it throws`() {
-        val provider = object : ProfileProvider() {
-            override suspend fun contains(id: String): Boolean {
-                return false
-            }
+  @Test
+  fun `GIVEN a nonexistent profile WHEN requesting it to be provided THEN it throws`() {
+    val provider =
+      object : ProfileProvider() {
+        override suspend fun contains(id: String): Boolean {
+          return false
+        }
 
-            override suspend fun onProvide(id: String): Flow<Profile> {
-                return emptyFlow()
-            }
+        override suspend fun onProvide(id: String): Flow<Profile> {
+          return emptyFlow()
         }
-        assertFailsWith<ProfileProvider.NonexistentProfileException> {
-            runTest {
-                provider.provide("🫥")
-            }
-        }
+      }
+    assertFailsWith<ProfileProvider.NonexistentProfileException> {
+      runTest { provider.provide("🫥") }
     }
+  }
 
-    @Test
-    fun `GIVEN a profile WHEN requesting it to be provided THEN it's provided`() {
-        val provider = object : ProfileProvider() {
-            override suspend fun contains(id: String): Boolean {
-                return true
-            }
+  @Test
+  fun `GIVEN a profile WHEN requesting it to be provided THEN it's provided`() {
+    val provider =
+      object : ProfileProvider() {
+        override suspend fun contains(id: String): Boolean {
+          return true
+        }
 
-            override suspend fun onProvide(id: String): Flow<Profile> {
-                return flowOf(Profile.sample)
-            }
+        override suspend fun onProvide(id: String): Flow<Profile> {
+          return flowOf(Profile.sample)
         }
-        runTest {
-            assertEquals(Profile.sample, provider.provide(Profile.sample.id).first())
-        }
-    }
+      }
+    runTest { assertEquals(Profile.sample, provider.provide(Profile.sample.id).first()) }
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/AccountTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/AccountTests.kt
@@ -7,75 +7,60 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 
 internal class AccountTests {
-    @Test
-    fun `GIVEN a blank string WHEN parsing it THEN it throws`() {
-        assertFailsWith<Account.Companion.BlankStringException> {
-            Account.of(" ")
-        }
-    }
+  @Test
+  fun `GIVEN a blank string WHEN parsing it THEN it throws`() {
+    assertFailsWith<Account.Companion.BlankStringException> { Account.of(" ") }
+  }
 
-    @Test
-    fun `GIVEN a blank string with a fallback domain WHEN parsing it THEN it throws`() {
-        assertFailsWith<Account.Companion.BlankStringException> {
-            Account.of(" ", "appleseed.com")
-        }
-    }
+  @Test
+  fun `GIVEN a blank string with a fallback domain WHEN parsing it THEN it throws`() {
+    assertFailsWith<Account.Companion.BlankStringException> { Account.of(" ", "appleseed.com") }
+  }
 
-    @Test
-    fun `GIVEN a string containing a username with illegal characters WHEN parsing it THEN it throws`() { // ktlint-disable max-line-length
-        assertFailsWith<Account.IllegalUsernameException> {
-            Account.of("john @appleseed.com")
-        }
-    }
+  @Test
+  fun `GIVEN a string containing a username with illegal characters WHEN parsing it THEN it throws`() {
+    assertFailsWith<Account.IllegalUsernameException> { Account.of("john @appleseed.com") }
+  }
 
-    @Test
-    fun `GIVEN a string containing only a username without the separator without a fallback domain WHEN parsing it THEN it throws`() { // ktlint-disable max-line-length
-        assertFailsWith<Domain.BlankValueException> {
-            Account.of("john")
-        }
-    }
+  @Test
+  fun `GIVEN a string containing only a username without the separator without a fallback domain WHEN parsing it THEN it throws`() {
+    assertFailsWith<Domain.BlankValueException> { Account.of("john") }
+  }
 
-    @Test
-    fun `GIVEN a string containing only a username with the separator without a fallback domain WHEN parsing it THEN it throws`() { // ktlint-disable max-line-length
-        assertFailsWith<Domain.BlankValueException> {
-            Account.of("john@")
-        }
-    }
+  @Test
+  fun `GIVEN a string containing only a username with the separator without a fallback domain WHEN parsing it THEN it throws`() {
+    assertFailsWith<Domain.BlankValueException> { Account.of("john@") }
+  }
 
-    @Test
-    fun `GIVEN a string containing a valid username and an domain with illegal characters WHEN parsing it THEN it throws`() { // ktlint-disable max-line-length
-        assertFailsWith<Domain.IllegalValueException> {
-            Account.of("john@apple seed.com")
-        }
-    }
+  @Test
+  fun `GIVEN a string containing a valid username and an domain with illegal characters WHEN parsing it THEN it throws`() {
+    assertFailsWith<Domain.IllegalValueException> { Account.of("john@apple seed.com") }
+  }
 
-    @Test
-    fun `GIVEN a string containing a valid username without an domain with a fallback one with illegal characters WHEN parsing it THEN it throws`() { // ktlint-disable max-line-length
-        assertFailsWith<Domain.IllegalValueException> {
-            Account.of("john", fallbackDomain = "apple seed.com")
-        }
+  @Test
+  fun `GIVEN a string containing a valid username without an domain with a fallback one with illegal characters WHEN parsing it THEN it throws`() {
+    assertFailsWith<Domain.IllegalValueException> {
+      Account.of("john", fallbackDomain = "apple seed.com")
     }
+  }
 
-    @Test
-    fun `GIVEN a string containing a valid username and a valid domain WHEN parsing it THEN it creates an account`() { // ktlint-disable max-line-length
-        assertEquals("john" at "appleseed.com", Account.of("john@appleseed.com"))
-    }
+  @Test
+  fun `GIVEN a string containing a valid username and a valid domain WHEN parsing it THEN it creates an account`() {
+    assertEquals("john" at "appleseed.com", Account.of("john@appleseed.com"))
+  }
 
-    @Test
-    fun `GIVEN a string containing only a username with a valid fallback domain WHEN parsing it THEN it creates an account`() { // ktlint-disable max-line-length
-        assertEquals(
-            "john" at "appleseed.com",
-            Account.of("john", fallbackDomain = "appleseed.com")
-        )
-    }
+  @Test
+  fun `GIVEN a string containing only a username with a valid fallback domain WHEN parsing it THEN it creates an account`() {
+    assertEquals("john" at "appleseed.com", Account.of("john", fallbackDomain = "appleseed.com"))
+  }
 
-    @Test
-    fun `GIVEN a blank username WHEN verifying if it's valid THEN it isn't`() {
-        assertFalse(Account.isUsernameValid(" "))
-    }
+  @Test
+  fun `GIVEN a blank username WHEN verifying if it's valid THEN it isn't`() {
+    assertFalse(Account.isUsernameValid(" "))
+  }
 
-    @Test
-    fun `GIVEN a username with an illegal character WHEN verifying if it's valid THEN it isn't`() {
-        assertFalse(Account.isUsernameValid("john@"))
-    }
+  @Test
+  fun `GIVEN a username with an illegal character WHEN verifying if it's valid THEN it isn't`() {
+    assertFalse(Account.isUsernameValid("john@"))
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/DomainTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/DomainTests.kt
@@ -5,24 +5,18 @@ import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 internal class DomainTests {
-    @Test
-    fun `GIVEN a blank domain WHEN ensuring its integrity THEN it throws`() {
-        assertFailsWith<Domain.BlankValueException> {
-            Domain(" ")
-        }
-    }
+  @Test
+  fun `GIVEN a blank domain WHEN ensuring its integrity THEN it throws`() {
+    assertFailsWith<Domain.BlankValueException> { Domain(" ") }
+  }
 
-    @Test
-    fun `GIVEN an domain with an illegal character WHEN ensuring its integrity THEN it throws`() {
-        assertFailsWith<Domain.IllegalValueException> {
-            Domain("@appleseed.com")
-        }
-    }
+  @Test
+  fun `GIVEN an domain with an illegal character WHEN ensuring its integrity THEN it throws`() {
+    assertFailsWith<Domain.IllegalValueException> { Domain("@appleseed.com") }
+  }
 
-    @Test
-    fun `GIVEN an domain without a TLD WHEN ensuring its integrity THEN it throws`() {
-        assertFailsWith<Domain.ValueWithoutTopLevelDomainException> {
-            Domain("appleseed.")
-        }
-    }
+  @Test
+  fun `GIVEN an domain without a TLD WHEN ensuring its integrity THEN it throws`() {
+    assertFailsWith<Domain.ValueWithoutTopLevelDomainException> { Domain("appleseed.") }
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/StringExtensionsTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/StringExtensionsTests.kt
@@ -5,43 +5,33 @@ import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 internal class StringExtensionsTests {
-    @Test
-    fun `GIVEN a blank username WHEN creating an account with it THEN it throws`() {
-        assertFailsWith<Account.BlankUsernameException> {
-            " " at "appleseed.com"
-        }
-    }
+  @Test
+  fun `GIVEN a blank username WHEN creating an account with it THEN it throws`() {
+    assertFailsWith<Account.BlankUsernameException> { " " at "appleseed.com" }
+  }
 
-    @Test
-    fun `GIVEN a username with an illegal character WHEN creating an account with it THEN it throws`() { // ktlint-disable max-line-length
-        assertFailsWith<Account.IllegalUsernameException> {
-            "john@" at "appleseed.com"
-        }
-    }
+  @Test
+  fun `GIVEN a username with an illegal character WHEN creating an account with it THEN it throws`() {
+    assertFailsWith<Account.IllegalUsernameException> { "john@" at "appleseed.com" }
+  }
 
-    @Test
-    fun `GIVEN a blank domain WHEN creating an account with it THEN it throws`() {
-        assertFailsWith<Domain.BlankValueException> {
-            "john" at " "
-        }
-    }
+  @Test
+  fun `GIVEN a blank domain WHEN creating an account with it THEN it throws`() {
+    assertFailsWith<Domain.BlankValueException> { "john" at " " }
+  }
 
-    @Test
-    fun `GIVEN an domain with an illegal character WHEN creating an account with it THEN it throws`() { // ktlint-disable max-line-length
-        assertFailsWith<Domain.IllegalValueException> {
-            "john" at "@appleseed.com"
-        }
-    }
+  @Test
+  fun `GIVEN an domain with an illegal character WHEN creating an account with it THEN it throws`() {
+    assertFailsWith<Domain.IllegalValueException> { "john" at "@appleseed.com" }
+  }
 
-    @Test
-    fun `GIVEN an domain without a TLD WHEN creating an account with it THEN it throws`() {
-        assertFailsWith<Domain.ValueWithoutTopLevelDomainException> {
-            "john" at "appleseed."
-        }
-    }
+  @Test
+  fun `GIVEN an domain without a TLD WHEN creating an account with it THEN it throws`() {
+    assertFailsWith<Domain.ValueWithoutTopLevelDomainException> { "john" at "appleseed." }
+  }
 
-    @Test
-    fun `GIVEN a valid username and a valid domain WHEN creating an account with them THEN it's created`() { // ktlint-disable max-line-length
-        "john" at "appleseed.com"
-    }
+  @Test
+  fun `GIVEN a valid username and a valid domain WHEN creating an account with them THEN it's created`() {
+    "john" at "appleseed.com"
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/search/ProfileExtensionsTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/search/ProfileExtensionsTests.kt
@@ -7,8 +7,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 internal class ProfileExtensionsTests {
-    @Test
-    fun `GIVEN a profile WHEN converting it into a search result THEN it's converted`() {
-        assertEquals(ProfileSearchResult.sample, Profile.sample.toProfileSearchResult())
-    }
+  @Test
+  fun `GIVEN a profile WHEN converting it into a search result THEN it's converted`() {
+    assertEquals(ProfileSearchResult.sample, Profile.sample.toProfileSearchResult())
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/search/ProfileSearcherTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/search/ProfileSearcherTests.kt
@@ -9,15 +9,14 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 
 internal class ProfileSearcherTests {
-    @Test
-    fun `GIVEN a blank query WHEN searching THEN it returns no results`() {
-        val searcher = object : ProfileSearcher() {
-            override suspend fun onSearch(query: String): Flow<List<ProfileSearchResult>> {
-                return flowOf(ProfileSearchResult.samples)
-            }
+  @Test
+  fun `GIVEN a blank query WHEN searching THEN it returns no results`() {
+    val searcher =
+      object : ProfileSearcher() {
+        override suspend fun onSearch(query: String): Flow<List<ProfileSearchResult>> {
+          return flowOf(ProfileSearchResult.samples)
         }
-        runTest {
-            assertContentEquals(emptyList(), searcher.search(" ").first())
-        }
-    }
+      }
+    runTest { assertContentEquals(emptyList(), searcher.search(" ").first()) }
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/TootTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/TootTests.kt
@@ -7,43 +7,43 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 
 internal class TootTests {
-    @Test
-    fun `GIVEN an unliked toot WHEN liking it THEN it's liked`() {
-        val toot = TestToot()
-        runTest {
-            toot.favorite.disable()
-            toot.favorite.enable()
-            assertTrue(toot.favorite.isEnabled)
-        }
+  @Test
+  fun `GIVEN an unliked toot WHEN liking it THEN it's liked`() {
+    val toot = TestToot()
+    runTest {
+      toot.favorite.disable()
+      toot.favorite.enable()
+      assertTrue(toot.favorite.isEnabled)
     }
+  }
 
-    @Test
-    fun `GIVEN a liked toot WHEN unliking it THEN it isn't liked`() {
-        val toot = TestToot()
-        runTest {
-            toot.favorite.enable()
-            toot.favorite.disable()
-            assertFalse(toot.favorite.isEnabled)
-        }
+  @Test
+  fun `GIVEN a liked toot WHEN unliking it THEN it isn't liked`() {
+    val toot = TestToot()
+    runTest {
+      toot.favorite.enable()
+      toot.favorite.disable()
+      assertFalse(toot.favorite.isEnabled)
     }
+  }
 
-    @Test
-    fun `GIVEN a non-reblogged toot WHEN reblogging it THEN it's reblogged`() {
-        val toot = TestToot()
-        runTest {
-            toot.reblog.disable()
-            toot.reblog.enable()
-            assertTrue(toot.reblog.isEnabled)
-        }
+  @Test
+  fun `GIVEN a non-reblogged toot WHEN reblogging it THEN it's reblogged`() {
+    val toot = TestToot()
+    runTest {
+      toot.reblog.disable()
+      toot.reblog.enable()
+      assertTrue(toot.reblog.isEnabled)
     }
+  }
 
-    @Test
-    fun `GIVEN a reblogged toot WHEN un-reblogging it THEN it isn't reblogged`() {
-        val toot = TestToot()
-        runTest {
-            toot.reblog.enable()
-            toot.reblog.disable()
-            assertFalse(toot.reblog.isEnabled)
-        }
+  @Test
+  fun `GIVEN a reblogged toot WHEN un-reblogging it THEN it isn't reblogged`() {
+    val toot = TestToot()
+    runTest {
+      toot.reblog.enable()
+      toot.reblog.disable()
+      assertFalse(toot.reblog.isEnabled)
     }
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/ContentTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/ContentTests.kt
@@ -11,35 +11,30 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 internal class ContentTests {
-    @Ignore("Depends on the implementation of instance-specific URL resources.")
-    @Test
-    fun `GIVEN a text with a URL without providing a headline WHEN creating content from it THEN it throws`() { // ktlint-disable max-line-length
-        assertFailsWith<Content.UnprovidedHeadlineException> {
-            Content.from(buildStyledString { +Highlight.sample.url.toString() }) {
-                null
-            }
+  @Ignore("Depends on the implementation of instance-specific URL resources.")
+  @Test
+  fun `GIVEN a text with a URL without providing a headline WHEN creating content from it THEN it throws`() {
+    assertFailsWith<Content.UnprovidedHeadlineException> {
+      Content.from(buildStyledString { +Highlight.sample.url.toString() }) { null }
+    }
+  }
+
+  @Test
+  fun `GIVEN a text with a single trailing URL WHEN creating content from it THEN it's removed`() {
+    assertEquals(
+      StyledString("🥸"),
+      Content.from(buildStyledString { +"🥸 ${Highlight.sample.url}" }) { Headline.sample }.text
+    )
+  }
+
+  @Test
+  fun `GIVEN a text with two trailing URLs WHEN creating content from it THEN they're kept`() {
+    assertEquals(
+      buildStyledString { +"🫨 ${Highlight.sample.url} ${Highlight.sample.url}" },
+      Content.from(buildStyledString { +"🫨 ${Highlight.sample.url} ${Highlight.sample.url}" }) {
+          Headline.sample
         }
-    }
-
-    @Test
-    fun `GIVEN a text with a single trailing URL WHEN creating content from it THEN it's removed`() { // ktlint-disable max-line-length
-        assertEquals(
-            StyledString("🥸"),
-            Content
-                .from(buildStyledString { +"🥸 ${Highlight.sample.url}" }) { Headline.sample }
-                .text
-        )
-    }
-
-    @Test
-    fun `GIVEN a text with two trailing URLs WHEN creating content from it THEN they're kept`() {
-        assertEquals(
-            buildStyledString { +"🫨 ${Highlight.sample.url} ${Highlight.sample.url}" },
-            Content
-                .from(buildStyledString { +"🫨 ${Highlight.sample.url} ${Highlight.sample.url}" }) {
-                    Headline.sample
-                }
-                .text
-        )
-    }
+        .text
+    )
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/StatExtensionsTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/StatExtensionsTests.kt
@@ -9,36 +9,27 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 
 internal class StatExtensionsTests {
-    @Test
-    fun buildsEmptyStat() {
-        val stat = Stat<Int>()
-        assertEquals(0, stat.count)
-        runTest {
-            stat.get(0).test {
-                assertTrue(awaitItem().isEmpty())
-                awaitComplete()
-            }
-        }
+  @Test
+  fun buildsEmptyStat() {
+    val stat = Stat<Int>()
+    assertEquals(0, stat.count)
+    runTest {
+      stat.get(0).test {
+        assertTrue(awaitItem().isEmpty())
+        awaitComplete()
+      }
     }
+  }
 
-    @Test
-    fun buildsStatWithConfiguredCount() {
-        assertEquals(0, Stat<Int>(count = 0) { }.count)
-    }
+  @Test
+  fun buildsStatWithConfiguredCount() {
+    assertEquals(0, Stat<Int>(count = 0) {}.count)
+  }
 
-    @Test
-    fun buildsStatWithConfiguredGet() {
-        runTest {
-            assertEquals(
-                listOf(0, 1),
-                Stat(count = 2) {
-                    get {
-                        flowOf(listOf(0, 1))
-                    }
-                }
-                    .get(0)
-                    .first()
-            )
-        }
+  @Test
+  fun buildsStatWithConfiguredGet() {
+    runTest {
+      assertEquals(listOf(0, 1), Stat(count = 2) { get { flowOf(listOf(0, 1)) } }.get(0).first())
     }
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/toggleable/ToggleableStatExtensionsTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/stat/toggleable/ToggleableStatExtensionsTests.kt
@@ -5,20 +5,16 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 
 internal class ToggleableStatExtensionsTests {
-    @Test
-    fun buildsToggleableStatWithConfiguredSetEnabled() {
-        var isEnabled = false
-        runTest {
-            ToggleableStat<Int>(count = 1) {
-                setEnabled {
-                    isEnabled = it
-                }
-            }
-                .apply {
-                    disable()
-                    enable()
-                }
+  @Test
+  fun buildsToggleableStatWithConfiguredSetEnabled() {
+    var isEnabled = false
+    runTest {
+      ToggleableStat<Int>(count = 1) { setEnabled { isEnabled = it } }
+        .apply {
+          disable()
+          enable()
         }
-        assertTrue(isEnabled)
     }
+    assertTrue(isEnabled)
+  }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/test/TestToot.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/test/TestToot.kt
@@ -10,14 +10,14 @@ import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.sample
 import java.net.URL
 import java.time.ZonedDateTime
 
-/** Local [Toot] that defaults its properties' values to [Toot.Companion.sample]'s. **/
+/** Local [Toot] that defaults its properties' values to [Toot.Companion.sample]'s. */
 internal class TestToot(
-    override val id: String = Toot.sample.id,
-    override val author: Author = Toot.sample.author,
-    override val content: Content = Toot.sample.content,
-    override val publicationDateTime: ZonedDateTime = Toot.sample.publicationDateTime,
-    override val comment: Stat<Toot> = Toot.sample.comment,
-    override val favorite: ToggleableStat<Profile> = Toot.sample.favorite,
-    override val reblog: ToggleableStat<Profile> = Toot.sample.reblog,
-    override val url: URL = Toot.sample.url
+  override val id: String = Toot.sample.id,
+  override val author: Author = Toot.sample.author,
+  override val content: Content = Toot.sample.content,
+  override val publicationDateTime: ZonedDateTime = Toot.sample.publicationDateTime,
+  override val comment: Stat<Toot> = Toot.sample.comment,
+  override val favorite: ToggleableStat<Profile> = Toot.sample.favorite,
+  override val reblog: ToggleableStat<Profile> = Toot.sample.reblog,
+  override val url: URL = Toot.sample.url
 ) : Toot()

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/type/followable/FollowTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/type/followable/FollowTests.kt
@@ -5,74 +5,70 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 internal class FollowTests {
-    @Test
-    fun `GIVEN a blank string WHEN parsing it into a follow status THEN it throws`() {
-        assertFailsWith<Follow.Companion.BlankStringException> {
-            Follow.of(" ")
-        }
-    }
+  @Test
+  fun `GIVEN a blank string WHEN parsing it into a follow status THEN it throws`() {
+    assertFailsWith<Follow.Companion.BlankStringException> { Follow.of(" ") }
+  }
 
-    @Test
-    fun `GIVEN an invalid string WHEN parsing it into a follow status THEN it throws`() {
-        assertFailsWith<Follow.Companion.InvalidFollowString> {
-            Follow.of("🥸")
-        }
-    }
+  @Test
+  fun `GIVEN an invalid string WHEN parsing it into a follow status THEN it throws`() {
+    assertFailsWith<Follow.Companion.InvalidFollowString> { Follow.of("🥸") }
+  }
 
-    @Test
-    fun `GIVEN a public unfollowed status string WHEN parsing it THEN it returns the status`() {
-        assertEquals(Follow.Public.unfollowed(), Follow.of("${Follow.Public.unfollowed()}"))
-    }
+  @Test
+  fun `GIVEN a public unfollowed status string WHEN parsing it THEN it returns the status`() {
+    assertEquals(Follow.Public.unfollowed(), Follow.of("${Follow.Public.unfollowed()}"))
+  }
 
-    @Test
-    fun `GIVEN a public following status string WHEN parsing it THEN it returns the status`() {
-        assertEquals(Follow.Public.following(), Follow.of("${Follow.Public.following()}"))
-    }
+  @Test
+  fun `GIVEN a public following status string WHEN parsing it THEN it returns the status`() {
+    assertEquals(Follow.Public.following(), Follow.of("${Follow.Public.following()}"))
+  }
 
-    @Test
-    fun `GIVEN a private unfollowed status string WHEN parsing it THEN it returns the status`() {
-        assertEquals(Follow.Private.unfollowed(), Follow.of("${Follow.Private.unfollowed()}"))
-    }
+  @Test
+  fun `GIVEN a private unfollowed status string WHEN parsing it THEN it returns the status`() {
+    assertEquals(Follow.Private.unfollowed(), Follow.of("${Follow.Private.unfollowed()}"))
+  }
 
-    @Test
-    fun `GIVEN a private requested status string WHEN parsing it THEN it returns the status`() {
-        assertEquals(Follow.Private.requested(), Follow.of("${Follow.Private.requested()}"))
-    }
+  @Test
+  fun `GIVEN a private requested status string WHEN parsing it THEN it returns the status`() {
+    assertEquals(Follow.Private.requested(), Follow.of("${Follow.Private.requested()}"))
+  }
 
-    @Test
-    fun `GIVEN a private following status string WHEN parsing it THEN it returns the status`() {
-        assertEquals(Follow.Private.following(), Follow.of("${Follow.Private.following()}"))
-    }
+  @Test
+  fun `GIVEN a private following status string WHEN parsing it THEN it returns the status`() {
+    assertEquals(Follow.Private.following(), Follow.of("${Follow.Private.following()}"))
+  }
 
-    @Test
-    fun `GIVEN a public unfollowed status WHEN toggling it THEN it's followed`() {
-        assertEquals(Follow.Public.following(), Follow.Public.unfollowed().toggled())
-    }
+  @Test
+  fun `GIVEN a public unfollowed status WHEN toggling it THEN it's followed`() {
+    assertEquals(Follow.Public.following(), Follow.Public.unfollowed().toggled())
+  }
 
-    @Test
-    fun `GIVEN a public followed status WHEN toggling it THEN it's unfollowed`() {
-        assertEquals(Follow.Public.unfollowed(), Follow.Public.following().toggled())
-    }
+  @Test
+  fun `GIVEN a public followed status WHEN toggling it THEN it's unfollowed`() {
+    assertEquals(Follow.Public.unfollowed(), Follow.Public.following().toggled())
+  }
 
-    @Test
-    fun `GIVEN a private unfollowed status WHEN toggling it THEN it's requested`() {
-        assertEquals(Follow.Private.requested(), Follow.Private.unfollowed().toggled())
-    }
+  @Test
+  fun `GIVEN a private unfollowed status WHEN toggling it THEN it's requested`() {
+    assertEquals(Follow.Private.requested(), Follow.Private.unfollowed().toggled())
+  }
 
-    @Test
-    fun `GIVEN a private requested status WHEN toggling it THEN it's unfollowed`() {
-        assertEquals(Follow.Private.unfollowed(), Follow.Private.requested().toggled())
-    }
+  @Test
+  fun `GIVEN a private requested status WHEN toggling it THEN it's unfollowed`() {
+    assertEquals(Follow.Private.unfollowed(), Follow.Private.requested().toggled())
+  }
 
-    @Test
-    fun `GIVEN a cohesive status WHEN requiring it to be cohesive THEN it is`() {
-        Follow.requireVisibilityMatch(Follow.Public.unfollowed(), Follow.Public.following())
-    }
+  @Test
+  fun `GIVEN a cohesive status WHEN requiring it to be cohesive THEN it is`() {
+    Follow.requireVisibilityMatch(Follow.Public.unfollowed(), Follow.Public.following())
+  }
 
-    @Test
-    fun `GIVEN a non-cohesive status WHEN requiring it to be cohesive THEN it throws`() {
-        assertFailsWith<IllegalArgumentException> {
-            Follow.requireVisibilityMatch(Follow.Public.unfollowed(), Follow.Private.unfollowed())
-        }
+  @Test
+  fun `GIVEN a non-cohesive status WHEN requiring it to be cohesive THEN it throws`() {
+    assertFailsWith<IllegalArgumentException> {
+      Follow.requireVisibilityMatch(Follow.Public.unfollowed(), Follow.Private.unfollowed())
     }
+  }
 }

--- a/feature/composer/build.gradle.kts
+++ b/feature/composer/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     buildFeatures.compose = true
-    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.get()
     defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 }
 

--- a/feature/composer/src/androidTest/java/com/jeanbarrossilva/orca/feature/composer/ComposerActivityTests.kt
+++ b/feature/composer/src/androidTest/java/com/jeanbarrossilva/orca/feature/composer/ComposerActivityTests.kt
@@ -24,38 +24,41 @@ import org.junit.Test
 
 @OptIn(ExperimentalTestApi::class)
 internal class ComposerActivityTests {
-    @get:Rule
-    val composeRule = createAndroidComposeRule<ComposerActivity>()
+  @get:Rule val composeRule = createAndroidComposeRule<ComposerActivity>()
 
-    @Test
-    fun stylesSelectedComposition() {
-        composeRule.onField().performTextInput("Hello, world!")
-        composeRule.onField().performTextInputSelection(TextRange(0, 5))
-        composeRule.onToolbar().onChildren().filterToOne(isBoldFormat()).performClick()
-        composeRule.onField().assertTextEquals(
-            buildAnnotatedString {
-                withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Hello") }
-                append(", world!")
-            }
-        )
-    }
+  @Test
+  fun stylesSelectedComposition() {
+    composeRule.onField().performTextInput("Hello, world!")
+    composeRule.onField().performTextInputSelection(TextRange(0, 5))
+    composeRule.onToolbar().onChildren().filterToOne(isBoldFormat()).performClick()
+    composeRule
+      .onField()
+      .assertTextEquals(
+        buildAnnotatedString {
+          withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Hello") }
+          append(", world!")
+        }
+      )
+  }
 
-    @Ignore(
-        "androidx.compose.ui:ui-text:1.5.0 has a bug that prevents stylization from being kept " +
-            "across selection changes."
-    )
-    @Test
-    fun keepsStylizationWhenUnselectingStylizedComposition() {
-        composeRule.onField().performTextInput("Hello, world!")
-        composeRule.onField().performTextInputSelection(TextRange(7, 12))
-        composeRule.onToolbar().onChildren().filterToOne(isItalicFormat()).performClick()
-        repeat(64) { composeRule.onField().performTextInputSelection(TextRange((0..12).random())) }
-        composeRule.onField().assertTextEquals(
-            buildAnnotatedString {
-                append("Hello, ")
-                withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append("world") }
-                append('!')
-            }
-        )
-    }
+  @Ignore(
+    "androidx.compose.ui:ui-text:1.5.0 has a bug that prevents stylization from being kept " +
+      "across selection changes."
+  )
+  @Test
+  fun keepsStylizationWhenUnselectingStylizedComposition() {
+    composeRule.onField().performTextInput("Hello, world!")
+    composeRule.onField().performTextInputSelection(TextRange(7, 12))
+    composeRule.onToolbar().onChildren().filterToOne(isItalicFormat()).performClick()
+    repeat(64) { composeRule.onField().performTextInputSelection(TextRange((0..12).random())) }
+    composeRule
+      .onField()
+      .assertTextEquals(
+        buildAnnotatedString {
+          append("Hello, ")
+          withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append("world") }
+          append('!')
+        }
+      )
+  }
 }

--- a/feature/composer/src/androidTest/java/com/jeanbarrossilva/orca/feature/composer/test/ComposeTestRule.extensions.kt
+++ b/feature/composer/src/androidTest/java/com/jeanbarrossilva/orca/feature/composer/test/ComposeTestRule.extensions.kt
@@ -8,12 +8,12 @@ import com.jeanbarrossilva.orca.feature.composer.Composer
 import com.jeanbarrossilva.orca.feature.composer.ui.COMPOSER_TOOLBAR
 import com.jeanbarrossilva.orca.feature.composer.ui.Toolbar
 
-/** [SemanticsNodeInteraction] of a [Composer]'s field. **/
+/** [SemanticsNodeInteraction] of a [Composer]'s field. */
 internal fun ComposeTestRule.onField(): SemanticsNodeInteraction {
-    return onNodeWithTag(COMPOSER_FIELD)
+  return onNodeWithTag(COMPOSER_FIELD)
 }
 
-/** [SemanticsNodeInteraction] of a [Toolbar]. **/
+/** [SemanticsNodeInteraction] of a [Toolbar]. */
 internal fun ComposeTestRule.onToolbar(): SemanticsNodeInteraction {
-    return onNodeWithTag(COMPOSER_TOOLBAR)
+  return onNodeWithTag(COMPOSER_TOOLBAR)
 }

--- a/feature/composer/src/androidTest/java/com/jeanbarrossilva/orca/feature/composer/test/SemanticsMatcher.extensions.kt
+++ b/feature/composer/src/androidTest/java/com/jeanbarrossilva/orca/feature/composer/test/SemanticsMatcher.extensions.kt
@@ -15,46 +15,46 @@ import com.jeanbarrossilva.orca.feature.composer.ui.Toolbar
  * non-editable.
  *
  * @param values [AnnotatedString]s that the [SemanticsNode] is expected to have.
- **/
+ */
 internal fun hasTextExactly(vararg values: AnnotatedString): SemanticsMatcher {
-    val expected = values.toList()
-    return SemanticsMatcher(
-        "${SemanticsProperties.Text.name} + ${SemanticsProperties.EditableText.name} = $expected"
-    ) { node ->
-        with(node.config) {
-            getOrNull(SemanticsProperties.Text)
-                .orEmpty()
-                .plus(getOrNull(SemanticsProperties.EditableText))
-                .filterNotNull()
-                .let { texts -> texts.containsAll(expected) && expected.containsAll(texts) }
-        }
+  val expected = values.toList()
+  return SemanticsMatcher(
+    "${SemanticsProperties.Text.name} + ${SemanticsProperties.EditableText.name} = $expected"
+  ) { node ->
+    with(node.config) {
+      getOrNull(SemanticsProperties.Text)
+        .orEmpty()
+        .plus(getOrNull(SemanticsProperties.EditableText))
+        .filterNotNull()
+        .let { texts -> texts.containsAll(expected) && expected.containsAll(texts) }
     }
+  }
 }
 
 /**
  * [SemanticsMatcher] that indicates whether the [SemanticsNode] is of a [Toolbar]'s bold format.
- **/
+ */
 internal fun isBoldFormat(): SemanticsMatcher {
-    return SemanticsMatcher("is bold format") {
-        it.config.getOrNull(SemanticsProperties.TestTag) == COMPOSER_TOOLBAR_BOLD_FORMAT
-    }
+  return SemanticsMatcher("is bold format") {
+    it.config.getOrNull(SemanticsProperties.TestTag) == COMPOSER_TOOLBAR_BOLD_FORMAT
+  }
 }
 
 /**
  * [SemanticsMatcher] that indicates whether the [SemanticsNode] is of a [Toolbar]'s italic format.
- **/
+ */
 internal fun isItalicFormat(): SemanticsMatcher {
-    return SemanticsMatcher("is italic format") {
-        it.config.getOrNull(SemanticsProperties.TestTag) == COMPOSER_TOOLBAR_ITALIC_FORMAT
-    }
+  return SemanticsMatcher("is italic format") {
+    it.config.getOrNull(SemanticsProperties.TestTag) == COMPOSER_TOOLBAR_ITALIC_FORMAT
+  }
 }
 
 /**
  * [SemanticsMatcher] that indicates whether the [SemanticsNode] if of a [Toolbar]'s underline
  * format.
- **/
+ */
 internal fun isUnderlineFormat(): SemanticsMatcher {
-    return SemanticsMatcher("is underline format") {
-        it.config.getOrNull(SemanticsProperties.TestTag) == COMPOSER_TOOLBAR_UNDERLINE_FORMAT
-    }
+  return SemanticsMatcher("is underline format") {
+    it.config.getOrNull(SemanticsProperties.TestTag) == COMPOSER_TOOLBAR_UNDERLINE_FORMAT
+  }
 }

--- a/feature/composer/src/androidTest/java/com/jeanbarrossilva/orca/feature/composer/test/SemanticsNodeInteraction.extensions.kt
+++ b/feature/composer/src/androidTest/java/com/jeanbarrossilva/orca/feature/composer/test/SemanticsNodeInteraction.extensions.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.text.AnnotatedString
  * Asserts that the [SemanticsNode] has exactly the given text [values].
  *
  * @param values Texts that the [SemanticsNode] is expected to have.
- **/
+ */
 internal fun SemanticsNodeInteraction.assertTextEquals(vararg values: AnnotatedString) {
-    assert(hasTextExactly(*values))
+  assert(hasTextExactly(*values))
 }

--- a/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/AnnotatedString.extensions.kt
+++ b/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/AnnotatedString.extensions.kt
@@ -8,15 +8,14 @@ import com.jeanbarrossilva.orca.core.sample.feed.profile.type.editable.replacing
  * Gets the [SpanStyle] annotations applied within the specified [range].
  *
  * @param range [IntRange] representing the index from (inclusively) and to which (exclusively)
- * where the [SpanStyle] annotations to be obtained are.
- **/
-internal fun AnnotatedString.getSpanStylesWithin(range: IntRange):
-    List<AnnotatedString.Range<SpanStyle>> {
-    return spanStyles.filter { annotation ->
-        (annotation.start..annotation.end).any { index ->
-            index in range
-        }
-    }
+ *   where the [SpanStyle] annotations to be obtained are.
+ */
+internal fun AnnotatedString.getSpanStylesWithin(
+  range: IntRange
+): List<AnnotatedString.Range<SpanStyle>> {
+  return spanStyles.filter { annotation ->
+    (annotation.start..annotation.end).any { index -> index in range }
+  }
 }
 
 /**
@@ -25,18 +24,17 @@ internal fun AnnotatedString.getSpanStylesWithin(range: IntRange):
  * created and passed into [replacement] as if it was a preexisting one.
  *
  * @param range [IntRange] representing the index from (inclusively) and to which (exclusively)
- * where the [SpanStyle]s to be replaced are.
+ *   where the [SpanStyle]s to be replaced are.
  * @param replacement Returns the [SpanStyle] to replace the current given one that's within the
- * [range].
- **/
+ *   [range].
+ */
 internal fun AnnotatedString.replacingSpanStylesWithin(
-    range: IntRange,
-    replacement: SpanStyle.() -> SpanStyle
+  range: IntRange,
+  replacement: SpanStyle.() -> SpanStyle
 ): AnnotatedString {
-    val replacedSpanStyles = spanStyles
-        .replacingBy({ copy(item = item.replacement()) }) { it in getSpanStylesWithin(range) }
-        .ifEmpty {
-            listOf(AnnotatedString.Range(SpanStyle().replacement(), range.first, range.last))
-        }
-    return AnnotatedString(text, replacedSpanStyles, paragraphStyles)
+  val replacedSpanStyles =
+    spanStyles
+      .replacingBy({ copy(item = item.replacement()) }) { it in getSpanStylesWithin(range) }
+      .ifEmpty { listOf(AnnotatedString.Range(SpanStyle().replacement(), range.first, range.last)) }
+  return AnnotatedString(text, replacedSpanStyles, paragraphStyles)
 }

--- a/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/ComposerActivity.kt
+++ b/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/ComposerActivity.kt
@@ -7,16 +7,16 @@ import com.jeanbarrossilva.orca.platform.ui.core.composable.ComposableActivity
 import com.jeanbarrossilva.orca.platform.ui.core.on
 
 class ComposerActivity internal constructor() : ComposableActivity() {
-    private val viewModel by viewModels<ComposerViewModel>()
+  private val viewModel by viewModels<ComposerViewModel>()
 
-    @Composable
-    override fun Content() {
-        Composer(viewModel, onBackwardsNavigation = ::finish)
-    }
+  @Composable
+  override fun Content() {
+    Composer(viewModel, onBackwardsNavigation = ::finish)
+  }
 
-    companion object {
-        fun start(context: Context) {
-            context.on<ComposerActivity>().asNewTask().start()
-        }
+  companion object {
+    fun start(context: Context) {
+      context.on<ComposerActivity>().asNewTask().start()
     }
+  }
 }

--- a/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/ComposerViewModel.kt
@@ -6,14 +6,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 internal class ComposerViewModel : ViewModel() {
-    private val textFieldValueMutableFlow = MutableStateFlow(TextFieldValue())
+  private val textFieldValueMutableFlow = MutableStateFlow(TextFieldValue())
 
-    val textFieldValueFlow = textFieldValueMutableFlow.asStateFlow()
+  val textFieldValueFlow = textFieldValueMutableFlow.asStateFlow()
 
-    fun setTextFieldValue(textFieldValue: TextFieldValue) {
-        textFieldValueMutableFlow.value = textFieldValue
-    }
+  fun setTextFieldValue(textFieldValue: TextFieldValue) {
+    textFieldValueMutableFlow.value = textFieldValue
+  }
 
-    fun compose() {
-    }
+  fun compose() {}
 }

--- a/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/TextFieldValue.extensions.kt
+++ b/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/TextFieldValue.extensions.kt
@@ -6,54 +6,57 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextDecoration
 
-/** Whether the selected portion of the [text][TextFieldValue.text] is bold. **/
+/** Whether the selected portion of the [text][TextFieldValue.text] is bold. */
 internal val TextFieldValue.isSelectionBold
-    get() = annotatedString.getSpanStylesWithin(selection.start..selection.end).any {
-        it.item.fontWeight == FontWeight.Bold
+  get() =
+    annotatedString.getSpanStylesWithin(selection.start..selection.end).any {
+      it.item.fontWeight == FontWeight.Bold
     }
 
-/** Whether the selected portion of the [text][TextFieldValue.text] is italicized. **/
+/** Whether the selected portion of the [text][TextFieldValue.text] is italicized. */
 internal val TextFieldValue.isSelectionItalicized
-    get() = annotatedString.getSpanStylesWithin(selection.start..selection.end).any {
-        it.item.fontStyle == FontStyle.Italic
+  get() =
+    annotatedString.getSpanStylesWithin(selection.start..selection.end).any {
+      it.item.fontStyle == FontStyle.Italic
     }
 
-/** Whether the selected portion of the [text][TextFieldValue.text] is underlined. **/
+/** Whether the selected portion of the [text][TextFieldValue.text] is underlined. */
 internal val TextFieldValue.isSelectionUnderlined
-    get() = annotatedString.getSpanStylesWithin(selection.start..selection.end).any {
-        it.item.textDecoration == TextDecoration.Underline
+  get() =
+    annotatedString.getSpanStylesWithin(selection.start..selection.end).any {
+      it.item.textDecoration == TextDecoration.Underline
     }
 
 /**
  * Creates a [TextFieldValue] that's identical to this one, except for having the selected portion
  * of its [text][TextFieldValue.text] styled as bold if [isBold] is `true` or normally if it isn't.
- **/
+ */
 internal fun TextFieldValue.withBoldSelection(isBold: Boolean): TextFieldValue {
-    return replacingSelectedAnnotatedStringSpanStyles {
-        copy(fontWeight = if (isBold) FontWeight.Bold else null)
-    }
+  return replacingSelectedAnnotatedStringSpanStyles {
+    copy(fontWeight = if (isBold) FontWeight.Bold else null)
+  }
 }
 
 /**
  * Creates a [TextFieldValue] that's identical to this one, except for having the selection portion
  * of its [text][TextFieldValue.text] styled as italic if [isItalic] is `true` or normally if it
  * isn't.
- **/
+ */
 internal fun TextFieldValue.withItalicizedSelection(isItalic: Boolean): TextFieldValue {
-    return replacingSelectedAnnotatedStringSpanStyles {
-        copy(fontStyle = if (isItalic) FontStyle.Italic else null)
-    }
+  return replacingSelectedAnnotatedStringSpanStyles {
+    copy(fontStyle = if (isItalic) FontStyle.Italic else null)
+  }
 }
 
 /**
  * Creates a [TextFieldValue] that's identical to this one, except for having the selection portion
  * of its [text][TextFieldValue.text] decorated with an underline if [isUnderlined] is `true` or
  * undecorated if it isn't.
- **/
+ */
 internal fun TextFieldValue.withUnderlinedSelection(isUnderlined: Boolean): TextFieldValue {
-    return replacingSelectedAnnotatedStringSpanStyles {
-        copy(textDecoration = if (isUnderlined) TextDecoration.Underline else null)
-    }
+  return replacingSelectedAnnotatedStringSpanStyles {
+    copy(textDecoration = if (isUnderlined) TextDecoration.Underline else null)
+  }
 }
 
 /**
@@ -61,15 +64,13 @@ internal fun TextFieldValue.withUnderlinedSelection(isUnderlined: Boolean): Text
  * selected portion of the [text][TextFieldValue.text] by the result of [replacement].
  *
  * @param replacement Returns the [SpanStyle] to replace the current given one that's been applied
- * to the selected [text][TextFieldValue.text].
- **/
+ *   to the selected [text][TextFieldValue.text].
+ */
 private fun TextFieldValue.replacingSelectedAnnotatedStringSpanStyles(
-    replacement: SpanStyle.() -> SpanStyle
+  replacement: SpanStyle.() -> SpanStyle
 ): TextFieldValue {
-    return copy(
-        annotatedString = annotatedString.replacingSpanStylesWithin(
-            selection.start..selection.end,
-            replacement
-        )
-    )
+  return copy(
+    annotatedString =
+      annotatedString.replacingSpanStylesWithin(selection.start..selection.end, replacement)
+  )
 }

--- a/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/ui/Toolbar.FormatIconButton.kt
+++ b/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/ui/Toolbar.FormatIconButton.kt
@@ -25,63 +25,60 @@ import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
 
 @Composable
 internal fun FormatIconButton(
-    isEnabled: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit
+  isEnabled: Boolean,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit
 ) {
-    val role = Role.Switch
-    val contentColor by animateColorAsState(
-        if (isEnabled) OrcaTheme.colors.primary.container else LocalContentColor.current,
-        label = "ContentColor"
+  val role = Role.Switch
+  val contentColor by
+    animateColorAsState(
+      if (isEnabled) OrcaTheme.colors.primary.container else LocalContentColor.current,
+      label = "ContentColor"
     )
 
-    Box(
-        modifier
-            .clip(OrcaTheme.shapes.small)
-            .clickable(role = role, onClick = onClick)
-            .padding(4.dp)
-            .size(24.dp)
-            .semantics {
-                this.role = role
-                toggleableState = if (isEnabled) ToggleableState.On else ToggleableState.Off
-            },
-        Alignment.Center
-    ) {
-        CompositionLocalProvider(LocalContentColor provides contentColor, content = content)
-    }
+  Box(
+    modifier
+      .clip(OrcaTheme.shapes.small)
+      .clickable(role = role, onClick = onClick)
+      .padding(4.dp)
+      .size(24.dp)
+      .semantics {
+        this.role = role
+        toggleableState = if (isEnabled) ToggleableState.On else ToggleableState.Off
+      },
+    Alignment.Center
+  ) {
+    CompositionLocalProvider(LocalContentColor provides contentColor, content = content)
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun DisabledFormatIconButtonPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            FormatIconButton(isEnabled = false)
-        }
-    }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) { FormatIconButton(isEnabled = false) }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun EnabledFormatIconButtonPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            FormatIconButton(isEnabled = true)
-        }
-    }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) { FormatIconButton(isEnabled = true) }
+  }
 }
 
 @Composable
 private fun FormatIconButton(isEnabled: Boolean, modifier: Modifier = Modifier) {
-    FormatIconButton(isEnabled, onClick = { }, modifier) {
-        Icon(
-            if (isEnabled) {
-                OrcaTheme.iconography.compose.filled
-            } else {
-                OrcaTheme.iconography.compose.outlined
-            },
-            contentDescription = "Compose"
-        )
-    }
+  FormatIconButton(isEnabled, onClick = {}, modifier) {
+    Icon(
+      if (isEnabled) {
+        OrcaTheme.iconography.compose.filled
+      } else {
+        OrcaTheme.iconography.compose.outlined
+      },
+      contentDescription = "Compose"
+    )
+  }
 }

--- a/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/ui/Toolbar.kt
+++ b/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/ui/Toolbar.kt
@@ -29,73 +29,73 @@ internal const val COMPOSER_TOOLBAR_UNDERLINE_FORMAT = "composer-toolbar-underli
 
 @Composable
 internal fun Toolbar(
-    isBold: Boolean,
-    onBoldToggle: (isBold: Boolean) -> Unit,
-    isItalicized: Boolean,
-    onItalicToggle: (isItalicized: Boolean) -> Unit,
-    isUnderlined: Boolean,
-    onUnderlineToggle: (isUnderlined: Boolean) -> Unit,
-    modifier: Modifier = Modifier
+  isBold: Boolean,
+  onBoldToggle: (isBold: Boolean) -> Unit,
+  isItalicized: Boolean,
+  onItalicToggle: (isItalicized: Boolean) -> Unit,
+  isUnderlined: Boolean,
+  onUnderlineToggle: (isUnderlined: Boolean) -> Unit,
+  modifier: Modifier = Modifier
 ) {
-    val shape = OrcaTheme.shapes.large
-    val spacing = OrcaTheme.spacings.small
+  val shape = OrcaTheme.shapes.large
+  val spacing = OrcaTheme.spacings.small
 
-    CompositionLocalProvider(LocalContentColor provides OrcaTheme.colors.surface.content) {
-        LazyRow(
-            modifier
-                .shadow(4.dp, shape)
-                .clip(shape)
-                .background(OrcaTheme.colors.surface.container)
-                .height(56.dp)
-                .testTag(COMPOSER_TOOLBAR),
-            horizontalArrangement = Arrangement.spacedBy(spacing),
-            verticalAlignment = Alignment.CenterVertically,
-            contentPadding = PaddingValues(horizontal = spacing)
+  CompositionLocalProvider(LocalContentColor provides OrcaTheme.colors.surface.content) {
+    LazyRow(
+      modifier
+        .shadow(4.dp, shape)
+        .clip(shape)
+        .background(OrcaTheme.colors.surface.container)
+        .height(56.dp)
+        .testTag(COMPOSER_TOOLBAR),
+      horizontalArrangement = Arrangement.spacedBy(spacing),
+      verticalAlignment = Alignment.CenterVertically,
+      contentPadding = PaddingValues(horizontal = spacing)
+    ) {
+      item {
+        FormatIconButton(
+          isEnabled = isBold,
+          onClick = { onBoldToggle(!isBold) },
+          Modifier.testTag(COMPOSER_TOOLBAR_BOLD_FORMAT)
         ) {
-            item {
-                FormatIconButton(
-                    isEnabled = isBold,
-                    onClick = { onBoldToggle(!isBold) },
-                    Modifier.testTag(COMPOSER_TOOLBAR_BOLD_FORMAT)
-                ) {
-                    Icon(Icons.Rounded.FormatBold, contentDescription = "Bold")
-                }
-            }
-
-            item {
-                FormatIconButton(
-                    isEnabled = isItalicized,
-                    onClick = { onItalicToggle(!isItalicized) },
-                    Modifier.testTag(COMPOSER_TOOLBAR_ITALIC_FORMAT)
-                ) {
-                    Icon(Icons.Rounded.FormatItalic, contentDescription = "Italic")
-                }
-            }
-
-            item {
-                FormatIconButton(
-                    isEnabled = isUnderlined,
-                    onClick = { onUnderlineToggle(!isUnderlined) },
-                    Modifier.testTag(COMPOSER_TOOLBAR_UNDERLINE_FORMAT)
-                ) {
-                    Icon(Icons.Rounded.FormatUnderlined, contentDescription = "Underline")
-                }
-            }
+          Icon(Icons.Rounded.FormatBold, contentDescription = "Bold")
         }
+      }
+
+      item {
+        FormatIconButton(
+          isEnabled = isItalicized,
+          onClick = { onItalicToggle(!isItalicized) },
+          Modifier.testTag(COMPOSER_TOOLBAR_ITALIC_FORMAT)
+        ) {
+          Icon(Icons.Rounded.FormatItalic, contentDescription = "Italic")
+        }
+      }
+
+      item {
+        FormatIconButton(
+          isEnabled = isUnderlined,
+          onClick = { onUnderlineToggle(!isUnderlined) },
+          Modifier.testTag(COMPOSER_TOOLBAR_UNDERLINE_FORMAT)
+        ) {
+          Icon(Icons.Rounded.FormatUnderlined, contentDescription = "Underline")
+        }
+      }
     }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun ToolbarPreview() {
-    OrcaTheme {
-        Toolbar(
-            isBold = true,
-            onBoldToggle = { },
-            isItalicized = false,
-            onItalicToggle = { },
-            isUnderlined = false,
-            onUnderlineToggle = { }
-        )
-    }
+  OrcaTheme {
+    Toolbar(
+      isBold = true,
+      onBoldToggle = {},
+      isItalicized = false,
+      onItalicToggle = {},
+      isUnderlined = false,
+      onUnderlineToggle = {}
+    )
+  }
 }

--- a/feature/composer/src/test/java/com/jeanbarrossilva/orca/feature/composer/AnnotatedStringExtensionsTests.kt
+++ b/feature/composer/src/test/java/com/jeanbarrossilva/orca/feature/composer/AnnotatedStringExtensionsTests.kt
@@ -11,45 +11,44 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class AnnotatedStringExtensionsTests {
-    @Test
-    fun `GIVEN an AnnotatedString with an un-styled portion WHEN getting its span styles THEN it's an empty list`() { // ktlint-disable max-line-length
-        assertEquals(
-            emptyList<AnnotatedString.Range<SpanStyle>>(),
-            buildAnnotatedString {
-                append("Hello, ")
-                withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) {
-                    append("world")
-                }
-            }
-                .getSpanStylesWithin(0..5)
-        )
-    }
+  @Test
+  fun `GIVEN an AnnotatedString with an un-styled portion WHEN getting its span styles THEN it's an empty list`() {
+    assertEquals(
+      emptyList<AnnotatedString.Range<SpanStyle>>(),
+      buildAnnotatedString {
+          append("Hello, ")
+          withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) { append("world") }
+        }
+        .getSpanStylesWithin(0..5)
+    )
+  }
 
-    @Test
-    fun `GIVEN an AnnotatedString with a portion of it styled WHEN getting its span styles THEN it's equivalent to its styling`() { // ktlint-disable max-line-length
-        assertEquals(
-            listOf(
-                AnnotatedString.Range(SpanStyle(fontWeight = FontWeight.Bold), start = 0, end = 5),
-                AnnotatedString.Range(SpanStyle(Color.Blue), start = 12, end = 13)
-            ),
-            buildAnnotatedString {
-                withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Hello") }
-                append(", world")
-                withStyle(SpanStyle(Color.Blue)) { append('!') }
-            }
-                .getSpanStylesWithin(0..13)
-        )
-    }
+  @Test
+  fun `GIVEN an AnnotatedString with a portion of it styled WHEN getting its span styles THEN it's equivalent to its styling`() {
+    assertEquals(
+      listOf(
+        AnnotatedString.Range(SpanStyle(fontWeight = FontWeight.Bold), start = 0, end = 5),
+        AnnotatedString.Range(SpanStyle(Color.Blue), start = 12, end = 13)
+      ),
+      buildAnnotatedString {
+          withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Hello") }
+          append(", world")
+          withStyle(SpanStyle(Color.Blue)) { append('!') }
+        }
+        .getSpanStylesWithin(0..13)
+    )
+  }
 
-    @Test
-    fun `GIVEN an AnnotatedString without span styles WHEN replacing the ones within a range THEN the replacement is added`() { // ktlint-disable max-line-length
-        assertEquals(
-            buildAnnotatedString {
-                withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Hello") }
-                append(", world!")
-            },
-            AnnotatedString("Hello, world!")
-                .replacingSpanStylesWithin(0..5) { copy(fontWeight = FontWeight.Bold) }
-        )
-    }
+  @Test
+  fun `GIVEN an AnnotatedString without span styles WHEN replacing the ones within a range THEN the replacement is added`() {
+    assertEquals(
+      buildAnnotatedString {
+        withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Hello") }
+        append(", world!")
+      },
+      AnnotatedString("Hello, world!").replacingSpanStylesWithin(0..5) {
+        copy(fontWeight = FontWeight.Bold)
+      }
+    )
+  }
 }

--- a/feature/composer/src/test/java/com/jeanbarrossilva/orca/feature/composer/TextFieldValueExtensionsTests.kt
+++ b/feature/composer/src/test/java/com/jeanbarrossilva/orca/feature/composer/TextFieldValueExtensionsTests.kt
@@ -12,53 +12,53 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class TextFieldValueExtensionsTests {
-    @Test
-    fun `GIVEN a value with a bold portion WHEN selecting it and checking if it's bold THEN it is`() { // ktlint-disable max-line-length
-        assertTrue(
-            TextFieldValue(
-                buildAnnotatedString {
-                    withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Hello") }
-                    append(", world!")
-                },
-                selection = TextRange(0, 5)
-            )
-                .isSelectionBold
+  @Test
+  fun `GIVEN a value with a bold portion WHEN selecting it and checking if it's bold THEN it is`() {
+    assertTrue(
+      TextFieldValue(
+          buildAnnotatedString {
+            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Hello") }
+            append(", world!")
+          },
+          selection = TextRange(0, 5)
         )
-    }
+        .isSelectionBold
+    )
+  }
 
-    @Test
-    fun `GIVEN a value without a bold portion WHEN selecting and toggling it THEN it is bold`() {
-        assertEquals(
-            TextFieldValue(
-                buildAnnotatedString {
-                    withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Hello") }
-                    append(", world!")
-                },
-                selection = TextRange(0, 5)
-            ),
-            TextFieldValue(AnnotatedString("Hello, world!"), selection = TextRange(0, 5))
-                .withBoldSelection(true)
-        )
-    }
+  @Test
+  fun `GIVEN a value without a bold portion WHEN selecting and toggling it THEN it is bold`() {
+    assertEquals(
+      TextFieldValue(
+        buildAnnotatedString {
+          withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Hello") }
+          append(", world!")
+        },
+        selection = TextRange(0, 5)
+      ),
+      TextFieldValue(AnnotatedString("Hello, world!"), selection = TextRange(0, 5))
+        .withBoldSelection(true)
+    )
+  }
 
-    @Test
-    fun `GIVEN a value with a bold portion WHEN selecting and toggling it THEN it isn't bold`() {
-        assertEquals(
-            TextFieldValue(
-                buildAnnotatedString {
-                    withStyle(SpanStyle()) { append("Hello") }
-                    append(", world!")
-                },
-                selection = TextRange(0, 5)
-            ),
-            TextFieldValue(
-                buildAnnotatedString {
-                    withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Hello") }
-                    append(", world!")
-                },
-                selection = TextRange(0, 5)
-            )
-                .withBoldSelection(false)
+  @Test
+  fun `GIVEN a value with a bold portion WHEN selecting and toggling it THEN it isn't bold`() {
+    assertEquals(
+      TextFieldValue(
+        buildAnnotatedString {
+          withStyle(SpanStyle()) { append("Hello") }
+          append(", world!")
+        },
+        selection = TextRange(0, 5)
+      ),
+      TextFieldValue(
+          buildAnnotatedString {
+            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Hello") }
+            append(", world!")
+          },
+          selection = TextRange(0, 5)
         )
-    }
+        .withBoldSelection(false)
+    )
+  }
 }

--- a/feature/feed/build.gradle.kts
+++ b/feature/feed/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     buildFeatures.compose = true
-    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.get()
     defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 }
 

--- a/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/FeedFragmentTests.kt
+++ b/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/FeedFragmentTests.kt
@@ -22,31 +22,28 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class FeedFragmentTests {
-    @get:Rule
-    val injectorRule = InjectorTestRule { register<FeedModule>(TestFeedModule) }
+  @get:Rule val injectorRule = InjectorTestRule { register<FeedModule>(TestFeedModule) }
 
-    @get:Rule
-    val time4JRule = Time4JTestRule()
+  @get:Rule val time4JRule = Time4JTestRule()
 
-    @get:Rule
-    val composeRule = createEmptyComposeRule()
+  @get:Rule val composeRule = createEmptyComposeRule()
 
-    @Test
-    fun favoritesToot() {
-        runTest {
-            val toot = Profile.sample.getToots(page = 0).first().first()
-            if (toot.favorite.isEnabled) {
-                toot.favorite.toggle()
-            }
-        }
-        launchActivity<FeedActivity>(FeedActivity.getIntent(Profile.sample.id)).use {
-            composeRule
-                .onTootPreviews()
-                .onFirst()
-                .onChildren()
-                .filterToOne(hasTestTag(TOOT_PREVIEW_FAVORITE_STAT_TAG))
-                .performClick()
-                .assertIsSelected()
-        }
+  @Test
+  fun favoritesToot() {
+    runTest {
+      val toot = Profile.sample.getToots(page = 0).first().first()
+      if (toot.favorite.isEnabled) {
+        toot.favorite.toggle()
+      }
     }
+    launchActivity<FeedActivity>(FeedActivity.getIntent(Profile.sample.id)).use {
+      composeRule
+        .onTootPreviews()
+        .onFirst()
+        .onChildren()
+        .filterToOne(hasTestTag(TOOT_PREVIEW_FAVORITE_STAT_TAG))
+        .performClick()
+        .assertIsSelected()
+    }
+  }
 }

--- a/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/FeedTests.kt
+++ b/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/FeedTests.kt
@@ -18,29 +18,27 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class FeedTests {
-    @get:Rule
-    val time4JRule = Time4JTestRule()
+  @get:Rule val time4JRule = Time4JTestRule()
 
-    @get:Rule
-    val composeRule = createComposeRule()
+  @get:Rule val composeRule = createComposeRule()
 
-    @Test
-    fun runsCallbackWhenClickingTootFavoriteStat() {
-        var hasCallbackBeenRun = false
-        composeRule.setContent {
-            OrcaTheme {
-                Feed(
-                    TootPreview.samples.toSerializableList().toListLoadable(),
-                    onFavorite = { hasCallbackBeenRun = true }
-                )
-            }
-        }
-        composeRule
-            .onTootPreviews()
-            .onFirst()
-            .onChildren()
-            .filterToOne(hasTestTag(TOOT_PREVIEW_FAVORITE_STAT_TAG))
-            .performClick()
-        assertTrue(hasCallbackBeenRun)
+  @Test
+  fun runsCallbackWhenClickingTootFavoriteStat() {
+    var hasCallbackBeenRun = false
+    composeRule.setContent {
+      OrcaTheme {
+        Feed(
+          TootPreview.samples.toSerializableList().toListLoadable(),
+          onFavorite = { hasCallbackBeenRun = true }
+        )
+      }
     }
+    composeRule
+      .onTootPreviews()
+      .onFirst()
+      .onChildren()
+      .filterToOne(hasTestTag(TOOT_PREVIEW_FAVORITE_STAT_TAG))
+      .performClick()
+    assertTrue(hasCallbackBeenRun)
+  }
 }

--- a/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/FeedActivity.kt
+++ b/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/FeedActivity.kt
@@ -8,16 +8,16 @@ import com.jeanbarrossilva.orca.platform.ui.core.Intent
 import com.jeanbarrossilva.orca.platform.ui.test.core.SingleFragmentActivity
 
 internal class FeedActivity : SingleFragmentActivity() {
-    override val route = "feed"
+  override val route = "feed"
 
-    override fun NavGraphBuilder.add() {
-        fragment<FeedFragment>()
-    }
+  override fun NavGraphBuilder.add() {
+    fragment<FeedFragment>()
+  }
 
-    companion object {
-        fun getIntent(userID: String): Intent {
-            val context = InstrumentationRegistry.getInstrumentation().context
-            return Intent<FeedActivity>(context, FeedFragment.USER_ID_KEY to userID)
-        }
+  companion object {
+    fun getIntent(userID: String): Intent {
+      val context = InstrumentationRegistry.getInstrumentation().context
+      return Intent<FeedActivity>(context, FeedFragment.USER_ID_KEY to userID)
     }
+  }
 }

--- a/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/TestFeedBoundary.kt
+++ b/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/TestFeedBoundary.kt
@@ -4,15 +4,11 @@ import com.jeanbarrossilva.orca.feature.feed.FeedBoundary
 import java.net.URL
 
 internal class TestFeedBoundary : FeedBoundary {
-    override fun navigateToSearch() {
-    }
+  override fun navigateToSearch() {}
 
-    override fun navigateTo(url: URL) {
-    }
+  override fun navigateTo(url: URL) {}
 
-    override fun navigateToTootDetails(id: String) {
-    }
+  override fun navigateToTootDetails(id: String) {}
 
-    override fun navigateToComposer() {
-    }
+  override fun navigateToComposer() {}
 }

--- a/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/TestFeedModule.kt
+++ b/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/TestFeedModule.kt
@@ -5,9 +5,10 @@ import com.jeanbarrossilva.orca.core.sample.instance.sample
 import com.jeanbarrossilva.orca.feature.feed.FeedModule
 import com.jeanbarrossilva.orca.platform.theme.reactivity.OnBottomAreaAvailabilityChangeListener
 
-internal object TestFeedModule : FeedModule(
+internal object TestFeedModule :
+  FeedModule(
     { Instance.sample.feedProvider },
     { Instance.sample.tootProvider },
     { TestFeedBoundary() },
     { OnBottomAreaAvailabilityChangeListener.empty }
-)
+  )

--- a/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/Feed.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/Feed.kt
@@ -33,135 +33,128 @@ const val FEED_FLOATING_ACTION_BUTTON_TAG = "feed-floating-action-button"
 
 @Composable
 internal fun Feed(
-    viewModel: FeedViewModel,
-    boundary: FeedBoundary,
-    onBottomAreaAvailabilityChangeListener: OnBottomAreaAvailabilityChangeListener,
-    modifier: Modifier = Modifier
+  viewModel: FeedViewModel,
+  boundary: FeedBoundary,
+  onBottomAreaAvailabilityChangeListener: OnBottomAreaAvailabilityChangeListener,
+  modifier: Modifier = Modifier
 ) {
-    val tootPreviewsLoadable by viewModel.tootPreviewsLoadableFlow.collectAsState()
-    val bottomAreaAvailabilityNestedScrollConnection =
-        rememberBottomAreaAvailabilityNestedScrollConnection(onBottomAreaAvailabilityChangeListener)
+  val tootPreviewsLoadable by viewModel.tootPreviewsLoadableFlow.collectAsState()
+  val bottomAreaAvailabilityNestedScrollConnection =
+    rememberBottomAreaAvailabilityNestedScrollConnection(onBottomAreaAvailabilityChangeListener)
 
-    Feed(
-        tootPreviewsLoadable,
-        onSearch = boundary::navigateToSearch,
-        onHighlightClick = boundary::navigateTo,
-        onFavorite = viewModel::favorite,
-        onReblog = viewModel::reblog,
-        onShare = viewModel::share,
-        onTootClick = boundary::navigateToTootDetails,
-        onNext = viewModel::loadTootsAt,
-        onComposition = boundary::navigateToComposer,
-        bottomAreaAvailabilityNestedScrollConnection,
-        modifier
-    )
+  Feed(
+    tootPreviewsLoadable,
+    onSearch = boundary::navigateToSearch,
+    onHighlightClick = boundary::navigateTo,
+    onFavorite = viewModel::favorite,
+    onReblog = viewModel::reblog,
+    onShare = viewModel::share,
+    onTootClick = boundary::navigateToTootDetails,
+    onNext = viewModel::loadTootsAt,
+    onComposition = boundary::navigateToComposer,
+    bottomAreaAvailabilityNestedScrollConnection,
+    modifier
+  )
 }
 
 @Composable
 internal fun Feed(
-    tootPreviewsLoadable: ListLoadable<TootPreview>,
-    modifier: Modifier = Modifier,
-    onFavorite: (tootID: String) -> Unit = { }
+  tootPreviewsLoadable: ListLoadable<TootPreview>,
+  modifier: Modifier = Modifier,
+  onFavorite: (tootID: String) -> Unit = {}
 ) {
-    Feed(
-        tootPreviewsLoadable,
-        onSearch = { },
-        onHighlightClick = { },
-        onFavorite,
-        onReblog = { },
-        onShare = { },
-        onTootClick = { },
-        onNext = { },
-        onComposition = { },
-        BottomAreaAvailabilityNestedScrollConnection.empty,
-        modifier
-    )
+  Feed(
+    tootPreviewsLoadable,
+    onSearch = {},
+    onHighlightClick = {},
+    onFavorite,
+    onReblog = {},
+    onShare = {},
+    onTootClick = {},
+    onNext = {},
+    onComposition = {},
+    BottomAreaAvailabilityNestedScrollConnection.empty,
+    modifier
+  )
 }
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 private fun Feed(
-    tootPreviewsLoadable: ListLoadable<TootPreview>,
-    onSearch: () -> Unit,
-    onHighlightClick: (URL) -> Unit,
-    onFavorite: (tootID: String) -> Unit,
-    onReblog: (tootID: String) -> Unit,
-    onShare: (URL) -> Unit,
-    onTootClick: (tootID: String) -> Unit,
-    onNext: (index: Int) -> Unit,
-    onComposition: () -> Unit,
-    bottomAreaAvailabilityNestedScrollConnection: BottomAreaAvailabilityNestedScrollConnection,
-    modifier: Modifier = Modifier
+  tootPreviewsLoadable: ListLoadable<TootPreview>,
+  onSearch: () -> Unit,
+  onHighlightClick: (URL) -> Unit,
+  onFavorite: (tootID: String) -> Unit,
+  onReblog: (tootID: String) -> Unit,
+  onShare: (URL) -> Unit,
+  onTootClick: (tootID: String) -> Unit,
+  onNext: (index: Int) -> Unit,
+  onComposition: () -> Unit,
+  bottomAreaAvailabilityNestedScrollConnection: BottomAreaAvailabilityNestedScrollConnection,
+  modifier: Modifier = Modifier
 ) {
-    val topAppBarScrollBehavior = TopAppBarDefaults.scrollBehavior
+  val topAppBarScrollBehavior = TopAppBarDefaults.scrollBehavior
 
-    Scaffold(
-        modifier,
-        topAppBar = {
-            @OptIn(ExperimentalMaterial3Api::class)
-            TopAppBar(
-                title = { AutoSizeText(stringResource(R.string.feed)) },
-                actions = {
-                    HoverableIconButton(onClick = onSearch) {
-                        Icon(
-                            OrcaTheme.iconography.search,
-                            contentDescription = stringResource(R.string.feed_search)
-                        )
-                    }
-                },
-                scrollBehavior = topAppBarScrollBehavior
+  Scaffold(
+    modifier,
+    topAppBar = {
+      @OptIn(ExperimentalMaterial3Api::class)
+      TopAppBar(
+        title = { AutoSizeText(stringResource(R.string.feed)) },
+        actions = {
+          HoverableIconButton(onClick = onSearch) {
+            Icon(
+              OrcaTheme.iconography.search,
+              contentDescription = stringResource(R.string.feed_search)
             )
+          }
         },
-        floatingActionButton = {
-            if (tootPreviewsLoadable.isLoaded) {
-                FloatingActionButton(
-                    onClick = onComposition,
-                    Modifier.testTag(FEED_FLOATING_ACTION_BUTTON_TAG)
-                ) {
-                    Icon(
-                        OrcaTheme.iconography.compose.filled,
-                        contentDescription = stringResource(R.string.feed_compose)
-                    )
-                }
-            }
+        scrollBehavior = topAppBarScrollBehavior
+      )
+    },
+    floatingActionButton = {
+      if (tootPreviewsLoadable.isLoaded) {
+        FloatingActionButton(
+          onClick = onComposition,
+          Modifier.testTag(FEED_FLOATING_ACTION_BUTTON_TAG)
+        ) {
+          Icon(
+            OrcaTheme.iconography.compose.filled,
+            contentDescription = stringResource(R.string.feed_compose)
+          )
         }
-    ) {
-        Timeline(
-            tootPreviewsLoadable,
-            onHighlightClick,
-            onFavorite,
-            onReblog,
-            onShare,
-            onTootClick,
-            onNext,
-            Modifier
-                .nestedScroll(bottomAreaAvailabilityNestedScrollConnection)
-                .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
-            contentPadding = it + OrcaTheme.overlays.fab
-        )
+      }
     }
+  ) {
+    Timeline(
+      tootPreviewsLoadable,
+      onHighlightClick,
+      onFavorite,
+      onReblog,
+      onShare,
+      onTootClick,
+      onNext,
+      Modifier.nestedScroll(bottomAreaAvailabilityNestedScrollConnection)
+        .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
+      contentPadding = it + OrcaTheme.overlays.fab
+    )
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadingFeedPreview() {
-    OrcaTheme {
-        Feed(ListLoadable.Loading())
-    }
+  OrcaTheme { Feed(ListLoadable.Loading()) }
 }
 
 @Composable
 @MultiThemePreview
 private fun EmptyFeedPreview() {
-    OrcaTheme {
-        Feed(ListLoadable.Empty())
-    }
+  OrcaTheme { Feed(ListLoadable.Empty()) }
 }
 
 @Composable
 @MultiThemePreview
 private fun PopulatedFeedPreview() {
-    OrcaTheme {
-        Feed(TootPreview.samples.toSerializableList().toListLoadable())
-    }
+  OrcaTheme { Feed(TootPreview.samples.toSerializableList().toListLoadable()) }
 }

--- a/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedBoundary.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedBoundary.kt
@@ -3,11 +3,11 @@ package com.jeanbarrossilva.orca.feature.feed
 import java.net.URL
 
 interface FeedBoundary {
-    fun navigateToSearch()
+  fun navigateToSearch()
 
-    fun navigateTo(url: URL)
+  fun navigateTo(url: URL)
 
-    fun navigateToTootDetails(id: String)
+  fun navigateToTootDetails(id: String)
 
-    fun navigateToComposer()
+  fun navigateToComposer()
 }

--- a/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedFragment.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedFragment.kt
@@ -11,35 +11,32 @@ import com.jeanbarrossilva.orca.platform.ui.core.context.ContextProvider
 import com.jeanbarrossilva.orca.std.injector.Injector
 
 class FeedFragment internal constructor() : ComposableFragment(), ContextProvider {
-    private val module by lazy { Injector.from<FeedModule>() }
-    private val userID by argument<String>(USER_ID_KEY)
-    private val viewModel by viewModels<FeedViewModel> {
-        FeedViewModel.createFactory(
-            contextProvider = this,
-            module.feedProvider(),
-            module.tootProvider(),
-            userID
-        )
+  private val module by lazy { Injector.from<FeedModule>() }
+  private val userID by argument<String>(USER_ID_KEY)
+  private val viewModel by
+    viewModels<FeedViewModel> {
+      FeedViewModel.createFactory(
+        contextProvider = this,
+        module.feedProvider(),
+        module.tootProvider(),
+        userID
+      )
     }
 
-    constructor(userID: String) : this() {
-        arguments = bundleOf(USER_ID_KEY to userID)
-    }
+  constructor(userID: String) : this() {
+    arguments = bundleOf(USER_ID_KEY to userID)
+  }
 
-    @Composable
-    override fun Content() {
-        Feed(
-            viewModel,
-            boundary = module.get(),
-            onBottomAreaAvailabilityChangeListener = module.get()
-        )
-    }
+  @Composable
+  override fun Content() {
+    Feed(viewModel, boundary = module.get(), onBottomAreaAvailabilityChangeListener = module.get())
+  }
 
-    override fun provide(): Context {
-        return requireContext()
-    }
+  override fun provide(): Context {
+    return requireContext()
+  }
 
-    companion object {
-        internal const val USER_ID_KEY = "user-id"
-    }
+  companion object {
+    internal const val USER_ID_KEY = "user-id"
+  }
 }

--- a/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedModule.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedModule.kt
@@ -7,9 +7,10 @@ import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
 
 open class FeedModule(
-    @Inject internal val feedProvider: Module.() -> FeedProvider,
-    @Inject internal val tootProvider: Module.() -> TootProvider,
-    @Inject internal val boundary: Module.() -> FeedBoundary,
-    @Inject internal val onBottomAreaAvailabilityChangeListener:
+  @Inject internal val feedProvider: Module.() -> FeedProvider,
+  @Inject internal val tootProvider: Module.() -> TootProvider,
+  @Inject internal val boundary: Module.() -> FeedBoundary,
+  @Inject
+  internal val onBottomAreaAvailabilityChangeListener:
     Module.() -> OnBottomAreaAvailabilityChangeListener
 ) : Module()

--- a/feature/profile-details/build.gradle.kts
+++ b/feature/profile-details/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     buildFeatures.compose = true
-    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.get()
     defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     namespace = namespaceFor("feature.profiledetails")
 }

--- a/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsFragmentTests.kt
+++ b/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsFragmentTests.kt
@@ -20,30 +20,31 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 
 internal class ProfileDetailsFragmentTests {
-    private val injectorRule =
-        InjectorTestRule { register<ProfileDetailsModule>(TestProfileDetailsModule) }
-    private val sampleRule = SampleTestRule()
-    private val time4JRule = Time4JTestRule()
-    private val composeRule = createEmptyComposeRule()
+  private val injectorRule = InjectorTestRule {
+    register<ProfileDetailsModule>(TestProfileDetailsModule)
+  }
+  private val sampleRule = SampleTestRule()
+  private val time4JRule = Time4JTestRule()
+  private val composeRule = createEmptyComposeRule()
 
-    @get:Rule
-    val ruleChain: RuleChain = RuleChain
-        .outerRule(injectorRule)
-        .around(sampleRule)
-        .around(time4JRule)
-        .around(composeRule)
+  @get:Rule
+  val ruleChain: RuleChain =
+    RuleChain.outerRule(injectorRule).around(sampleRule).around(time4JRule).around(composeRule)
 
-    @Test
-    fun unfollowsFollowedProfileWhenClickingActionButton() { // ktlint-disable max-line-length
-        SampleProfileWriter.insert(FollowableProfile.sample)
-        launchActivity<ProfileDetailsActivity>(
-            ProfileDetailsActivity
-                .getIntent(BackwardsNavigationState.Unavailable, FollowableProfile.sample.id)
-        ).use {
-            composeRule
-                .onNodeWithTag(ProfileDetails.Followable.MAIN_ACTION_BUTTON_TAG)
-                .performClick()
-                .assertTextEquals(ProfileDetails.Followable.Status.UNFOLLOWED.label)
-        }
-    }
+  @Test
+  fun unfollowsFollowedProfileWhenClickingActionButton() {
+    SampleProfileWriter.insert(FollowableProfile.sample)
+    launchActivity<ProfileDetailsActivity>(
+        ProfileDetailsActivity.getIntent(
+          BackwardsNavigationState.Unavailable,
+          FollowableProfile.sample.id
+        )
+      )
+      .use {
+        composeRule
+          .onNodeWithTag(ProfileDetails.Followable.MAIN_ACTION_BUTTON_TAG)
+          .performClick()
+          .assertTextEquals(ProfileDetails.Followable.Status.UNFOLLOWED.label)
+      }
+  }
 }

--- a/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsTests.kt
+++ b/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsTests.kt
@@ -17,30 +17,24 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class ProfileDetailsTests {
-    @get:Rule
-    val composeRule = createComposeRule()
+  @get:Rule val composeRule = createComposeRule()
 
-    @Test
-    fun showsUsernameWhenScrollingPastHeader() {
-        val screenHeightInPx = InstrumentationRegistry
-            .getInstrumentation()
-            .context
-            .resources
-            .displayMetrics
-            .heightPixels
-        composeRule.setContent {
-            OrcaTheme {
-                ProfileDetails(
-                    Loadable.Loaded(ProfileDetails.sample),
-                    tootPreviewsLoadable = List(size = screenHeightInPx) {
-                        TootPreview.sample.copy(id = "${UUID.randomUUID()}")
-                    }
-                        .toSerializableList()
-                        .toListLoadable()
-                )
-            }
-        }
-        composeRule.onTimeline().performScrollToIndex(1)
-        composeRule.onNodeWithTag(TIMELINE_TAG).assertIsDisplayed()
+  @Test
+  fun showsUsernameWhenScrollingPastHeader() {
+    val screenHeightInPx =
+      InstrumentationRegistry.getInstrumentation().context.resources.displayMetrics.heightPixels
+    composeRule.setContent {
+      OrcaTheme {
+        ProfileDetails(
+          Loadable.Loaded(ProfileDetails.sample),
+          tootPreviewsLoadable =
+            List(size = screenHeightInPx) { TootPreview.sample.copy(id = "${UUID.randomUUID()}") }
+              .toSerializableList()
+              .toListLoadable()
+        )
+      }
     }
+    composeRule.onTimeline().performScrollToIndex(1)
+    composeRule.onNodeWithTag(TIMELINE_TAG).assertIsDisplayed()
+  }
 }

--- a/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/test/ProfileDetailsActivity.kt
+++ b/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/test/ProfileDetailsActivity.kt
@@ -9,23 +9,20 @@ import com.jeanbarrossilva.orca.platform.ui.core.Intent
 import com.jeanbarrossilva.orca.platform.ui.test.core.SingleFragmentActivity
 
 internal class ProfileDetailsActivity : SingleFragmentActivity() {
-    override val route = "profile-details"
+  override val route = "profile-details"
 
-    override fun NavGraphBuilder.add() {
-        fragment<ProfileDetailsFragment>()
-    }
+  override fun NavGraphBuilder.add() {
+    fragment<ProfileDetailsFragment>()
+  }
 
-    companion object {
-        fun getIntent(
-            backwardsNavigationState: BackwardsNavigationState,
-            id: String
-        ): Intent {
-            val context = InstrumentationRegistry.getInstrumentation().context
-            return Intent<ProfileDetailsActivity>(
-                context,
-                ProfileDetailsFragment.BACKWARDS_NAVIGATION_STATE_KEY to backwardsNavigationState,
-                ProfileDetailsFragment.ID_KEY to id
-            )
-        }
+  companion object {
+    fun getIntent(backwardsNavigationState: BackwardsNavigationState, id: String): Intent {
+      val context = InstrumentationRegistry.getInstrumentation().context
+      return Intent<ProfileDetailsActivity>(
+        context,
+        ProfileDetailsFragment.BACKWARDS_NAVIGATION_STATE_KEY to backwardsNavigationState,
+        ProfileDetailsFragment.ID_KEY to id
+      )
     }
+  }
 }

--- a/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/test/TestProfileDetailsBoundary.kt
+++ b/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/test/TestProfileDetailsBoundary.kt
@@ -4,9 +4,7 @@ import com.jeanbarrossilva.orca.feature.profiledetails.ProfileDetailsBoundary
 import java.net.URL
 
 internal class TestProfileDetailsBoundary : ProfileDetailsBoundary {
-    override fun navigateTo(url: URL) {
-    }
+  override fun navigateTo(url: URL) {}
 
-    override fun navigateToTootDetails(id: String) {
-    }
+  override fun navigateToTootDetails(id: String) {}
 }

--- a/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/test/TestProfileDetailsModule.kt
+++ b/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/test/TestProfileDetailsModule.kt
@@ -5,9 +5,10 @@ import com.jeanbarrossilva.orca.core.sample.instance.sample
 import com.jeanbarrossilva.orca.feature.ProfileDetailsModule
 import com.jeanbarrossilva.orca.platform.theme.reactivity.OnBottomAreaAvailabilityChangeListener
 
-internal object TestProfileDetailsModule : ProfileDetailsModule(
+internal object TestProfileDetailsModule :
+  ProfileDetailsModule(
     { Instance.sample.profileProvider },
     { Instance.sample.tootProvider },
     { TestProfileDetailsBoundary() },
     { OnBottomAreaAvailabilityChangeListener.empty }
-)
+  )

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/ProfileDetailsModule.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/ProfileDetailsModule.kt
@@ -8,9 +8,10 @@ import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
 
 abstract class ProfileDetailsModule(
-    @Inject internal val profileProvider: Module.() -> ProfileProvider,
-    @Inject internal val tootProvider: Module.() -> TootProvider,
-    @Inject internal val boundary: Module.() -> ProfileDetailsBoundary,
-    @Inject internal val onBottomAreaAvailabilityChangeListener:
+  @Inject internal val profileProvider: Module.() -> ProfileProvider,
+  @Inject internal val tootProvider: Module.() -> TootProvider,
+  @Inject internal val boundary: Module.() -> ProfileDetailsBoundary,
+  @Inject
+  internal val onBottomAreaAvailabilityChangeListener:
     Module.() -> OnBottomAreaAvailabilityChangeListener
 ) : Module()

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/Profile.extensions.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/Profile.extensions.kt
@@ -9,11 +9,13 @@ import kotlinx.coroutines.CoroutineScope
  * Converts this core [ProfileDetails] into [ProfileDetails].
  *
  * @param coroutineScope [CoroutineScope] through which converted [Profile]-related suspending will
- * be performed.
+ *   be performed.
  * @param colors [Colors] by which visuals can be colored.
- **/
-internal fun Profile.toProfileDetails(coroutineScope: CoroutineScope, colors: Colors):
-    ProfileDetails {
-    val details = ProfileConverterFactory.create(coroutineScope).convert(this, colors)
-    return requireNotNull(details)
+ */
+internal fun Profile.toProfileDetails(
+  coroutineScope: CoroutineScope,
+  colors: Colors
+): ProfileDetails {
+  val details = ProfileConverterFactory.create(coroutineScope).convert(this, colors)
+  return requireNotNull(details)
 }

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetails.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetails.kt
@@ -69,477 +69,462 @@ import java.net.URL
 internal const val PROFILE_DETAILS_TOP_BAR_TAG = "profile-details-top-bar"
 
 internal sealed class ProfileDetails : Serializable {
-    protected abstract val account: Account
+  protected abstract val account: Account
 
-    abstract val id: String
-    abstract val avatarURL: URL
-    abstract val name: String
-    abstract val bio: AnnotatedString
-    abstract val url: URL
+  abstract val id: String
+  abstract val avatarURL: URL
+  abstract val name: String
+  abstract val bio: AnnotatedString
+  abstract val url: URL
 
-    val formattedAccount
-        get() = "${account.username}@${account.domain}"
-    val username
-        get() = "@${account.username}"
+  val formattedAccount
+    get() = "${account.username}@${account.domain}"
 
-    data class Default(
-        override val id: String,
-        override val avatarURL: URL,
-        override val name: String,
-        override val account: Account,
-        override val bio: AnnotatedString,
-        override val url: URL
-    ) : ProfileDetails() {
-        companion object {
-            fun createSample(colors: Colors): Default {
-                return Default(
-                    Profile.sample.id,
-                    Profile.sample.avatarURL,
-                    Profile.sample.name,
-                    Profile.sample.account,
-                    Profile.sample.bio.toAnnotatedString(colors),
-                    Profile.sample.url
-                )
-            }
-        }
+  val username
+    get() = "@${account.username}"
+
+  data class Default(
+    override val id: String,
+    override val avatarURL: URL,
+    override val name: String,
+    override val account: Account,
+    override val bio: AnnotatedString,
+    override val url: URL
+  ) : ProfileDetails() {
+    companion object {
+      fun createSample(colors: Colors): Default {
+        return Default(
+          Profile.sample.id,
+          Profile.sample.avatarURL,
+          Profile.sample.name,
+          Profile.sample.account,
+          Profile.sample.bio.toAnnotatedString(colors),
+          Profile.sample.url
+        )
+      }
     }
+  }
 
-    data class Editable(
-        override val id: String,
-        override val avatarURL: URL,
-        override val name: String,
-        override val account: Account,
-        override val bio: AnnotatedString,
-        override val url: URL
-    ) : ProfileDetails() {
-        @Composable
-        override fun FloatingActionButton(navigator: ProfileDetailsBoundary, modifier: Modifier) {
-            FloatingActionButton(onClick = { }) {
-                Icon(OrcaTheme.iconography.edit.filled, contentDescription = "Edit")
-            }
-        }
-
-        companion object {
-            fun createSample(colors: Colors): Editable {
-                return Editable(
-                    EditableProfile.sample.id,
-                    EditableProfile.sample.avatarURL,
-                    EditableProfile.sample.name,
-                    EditableProfile.sample.account,
-                    EditableProfile.sample.bio.toAnnotatedString(colors),
-                    EditableProfile.sample.url
-                )
-            }
-        }
-    }
-
-    data class Followable(
-        override val id: String,
-        override val avatarURL: URL,
-        override val name: String,
-        override val account: Account,
-        override val bio: AnnotatedString,
-        override val url: URL,
-        val status: Status,
-        private val onStatusToggle: () -> Unit
-    ) : ProfileDetails() {
-        enum class Status {
-            UNFOLLOWED {
-                override val label = "Follow"
-            },
-            REQUESTED {
-                override val label = "Requested"
-            },
-            FOLLOWING {
-                override val label = "Unfollow"
-            };
-
-            abstract val label: String
-        }
-
-        @Composable
-        override fun MainActionButton(modifier: Modifier) {
-            Button(onClick = onStatusToggle, modifier.testTag(MAIN_ACTION_BUTTON_TAG)) {
-                Text(status.label)
-            }
-        }
-
-        companion object {
-            const val MAIN_ACTION_BUTTON_TAG = "followable-profile-details-main-action-button"
-
-            fun createSample(colors: Colors, onStatusToggle: () -> Unit): Followable {
-                return Followable(
-                    FollowableProfile.sample.id,
-                    FollowableProfile.sample.avatarURL,
-                    FollowableProfile.sample.name,
-                    FollowableProfile.sample.account,
-                    FollowableProfile.sample.bio.toAnnotatedString(colors),
-                    FollowableProfile.sample.url,
-                    FollowableProfile.sample.follow.toStatus(),
-                    onStatusToggle
-                )
-            }
-        }
-    }
-
+  data class Editable(
+    override val id: String,
+    override val avatarURL: URL,
+    override val name: String,
+    override val account: Account,
+    override val bio: AnnotatedString,
+    override val url: URL
+  ) : ProfileDetails() {
     @Composable
-    fun MainActionButton() {
-        MainActionButton(Modifier)
-    }
-
-    @Composable
-    open fun MainActionButton(modifier: Modifier) {
-    }
-
-    @Composable
-    fun FloatingActionButton(navigator: ProfileDetailsBoundary) {
-        FloatingActionButton(navigator, Modifier)
-    }
-
-    @Composable
-    open fun FloatingActionButton(navigator: ProfileDetailsBoundary, modifier: Modifier) {
+    override fun FloatingActionButton(navigator: ProfileDetailsBoundary, modifier: Modifier) {
+      FloatingActionButton(onClick = {}) {
+        Icon(OrcaTheme.iconography.edit.filled, contentDescription = "Edit")
+      }
     }
 
     companion object {
-        val sample
-            @Composable get() = Default.createSample(OrcaTheme.colors)
+      fun createSample(colors: Colors): Editable {
+        return Editable(
+          EditableProfile.sample.id,
+          EditableProfile.sample.avatarURL,
+          EditableProfile.sample.name,
+          EditableProfile.sample.account,
+          EditableProfile.sample.bio.toAnnotatedString(colors),
+          EditableProfile.sample.url
+        )
+      }
     }
+  }
+
+  data class Followable(
+    override val id: String,
+    override val avatarURL: URL,
+    override val name: String,
+    override val account: Account,
+    override val bio: AnnotatedString,
+    override val url: URL,
+    val status: Status,
+    private val onStatusToggle: () -> Unit
+  ) : ProfileDetails() {
+    enum class Status {
+      UNFOLLOWED {
+        override val label = "Follow"
+      },
+      REQUESTED {
+        override val label = "Requested"
+      },
+      FOLLOWING {
+        override val label = "Unfollow"
+      };
+
+      abstract val label: String
+    }
+
+    @Composable
+    override fun MainActionButton(modifier: Modifier) {
+      Button(onClick = onStatusToggle, modifier.testTag(MAIN_ACTION_BUTTON_TAG)) {
+        Text(status.label)
+      }
+    }
+
+    companion object {
+      const val MAIN_ACTION_BUTTON_TAG = "followable-profile-details-main-action-button"
+
+      fun createSample(colors: Colors, onStatusToggle: () -> Unit): Followable {
+        return Followable(
+          FollowableProfile.sample.id,
+          FollowableProfile.sample.avatarURL,
+          FollowableProfile.sample.name,
+          FollowableProfile.sample.account,
+          FollowableProfile.sample.bio.toAnnotatedString(colors),
+          FollowableProfile.sample.url,
+          FollowableProfile.sample.follow.toStatus(),
+          onStatusToggle
+        )
+      }
+    }
+  }
+
+  @Composable
+  fun MainActionButton() {
+    MainActionButton(Modifier)
+  }
+
+  @Composable open fun MainActionButton(modifier: Modifier) {}
+
+  @Composable
+  fun FloatingActionButton(navigator: ProfileDetailsBoundary) {
+    FloatingActionButton(navigator, Modifier)
+  }
+
+  @Composable
+  open fun FloatingActionButton(navigator: ProfileDetailsBoundary, modifier: Modifier) {}
+
+  companion object {
+    val sample
+      @Composable get() = Default.createSample(OrcaTheme.colors)
+  }
 }
 
 @Composable
 internal fun ProfileDetails(
-    viewModel: ProfileDetailsViewModel,
-    navigator: ProfileDetailsBoundary,
-    origin: BackwardsNavigationState,
-    onBottomAreaAvailabilityChangeListener: OnBottomAreaAvailabilityChangeListener,
-    modifier: Modifier = Modifier
+  viewModel: ProfileDetailsViewModel,
+  navigator: ProfileDetailsBoundary,
+  origin: BackwardsNavigationState,
+  onBottomAreaAvailabilityChangeListener: OnBottomAreaAvailabilityChangeListener,
+  modifier: Modifier = Modifier
 ) {
-    val detailsLoadable by viewModel.detailsLoadableFlow.collectAsState()
-    val tootsLoadable by viewModel.tootPreviewsLoadableFlow.collectAsState()
-    val bottomAreaAvailabilityNestedScrollConnection =
-        rememberBottomAreaAvailabilityNestedScrollConnection(onBottomAreaAvailabilityChangeListener)
+  val detailsLoadable by viewModel.detailsLoadableFlow.collectAsState()
+  val tootsLoadable by viewModel.tootPreviewsLoadableFlow.collectAsState()
+  val bottomAreaAvailabilityNestedScrollConnection =
+    rememberBottomAreaAvailabilityNestedScrollConnection(onBottomAreaAvailabilityChangeListener)
 
-    ProfileDetails(
-        navigator,
-        detailsLoadable,
-        tootsLoadable,
-        onFavorite = viewModel::favorite,
-        onReblog = viewModel::reblog,
-        navigator::navigateToTootDetails,
-        onNext = viewModel::loadTootsAt,
-        origin,
-        navigator::navigateTo,
-        onShare = viewModel::share,
-        bottomAreaAvailabilityNestedScrollConnection,
-        modifier
-    )
+  ProfileDetails(
+    navigator,
+    detailsLoadable,
+    tootsLoadable,
+    onFavorite = viewModel::favorite,
+    onReblog = viewModel::reblog,
+    navigator::navigateToTootDetails,
+    onNext = viewModel::loadTootsAt,
+    origin,
+    navigator::navigateTo,
+    onShare = viewModel::share,
+    bottomAreaAvailabilityNestedScrollConnection,
+    modifier
+  )
 }
 
 @Composable
 internal fun ProfileDetails(
-    detailsLoadable: Loadable<ProfileDetails>,
-    tootPreviewsLoadable: ListLoadable<TootPreview>,
-    modifier: Modifier = Modifier,
-    isTopBarDropdownMenuExpanded: Boolean = false,
-    initialFirstVisibleTimelineItemIndex: Int = 0
+  detailsLoadable: Loadable<ProfileDetails>,
+  tootPreviewsLoadable: ListLoadable<TootPreview>,
+  modifier: Modifier = Modifier,
+  isTopBarDropdownMenuExpanded: Boolean = false,
+  initialFirstVisibleTimelineItemIndex: Int = 0
 ) {
-    ProfileDetails(
-        ProfileDetailsBoundary.empty,
-        detailsLoadable,
+  ProfileDetails(
+    ProfileDetailsBoundary.empty,
+    detailsLoadable,
+    tootPreviewsLoadable,
+    onFavorite = {},
+    onReblog = {},
+    onNavigationToTootDetails = {},
+    onNext = {},
+    BackwardsNavigationState.Unavailable,
+    onNavigateToWebpage = {},
+    onShare = {},
+    BottomAreaAvailabilityNestedScrollConnection.empty,
+    modifier,
+    isTopBarDropdownMenuExpanded,
+    initialFirstVisibleTimelineItemIndex
+  )
+}
+
+@Composable
+private fun ProfileDetails(
+  boundary: ProfileDetailsBoundary,
+  detailsLoadable: Loadable<ProfileDetails>,
+  tootPreviewsLoadable: ListLoadable<TootPreview>,
+  onFavorite: (tootID: String) -> Unit,
+  onReblog: (tootID: String) -> Unit,
+  onNavigationToTootDetails: (id: String) -> Unit,
+  onNext: (index: Int) -> Unit,
+  origin: BackwardsNavigationState,
+  onNavigateToWebpage: (URL) -> Unit,
+  onShare: (URL) -> Unit,
+  bottomAreaAvailabilityNestedScrollConnection: BottomAreaAvailabilityNestedScrollConnection,
+  modifier: Modifier = Modifier,
+  isTopBarDropdownMenuExpanded: Boolean = false,
+  initialFirstVisibleTimelineItemIndex: Int = 0
+) {
+  when (detailsLoadable) {
+    is Loadable.Loading ->
+      ProfileDetails(origin, bottomAreaAvailabilityNestedScrollConnection, modifier)
+    is Loadable.Loaded ->
+      ProfileDetails(
+        boundary,
+        detailsLoadable.content,
         tootPreviewsLoadable,
-        onFavorite = { },
-        onReblog = { },
-        onNavigationToTootDetails = { },
-        onNext = { },
-        BackwardsNavigationState.Unavailable,
-        onNavigateToWebpage = { },
-        onShare = { },
-        BottomAreaAvailabilityNestedScrollConnection.empty,
+        onHighlightClick = boundary::navigateTo,
+        onFavorite,
+        onReblog,
+        onNavigationToTootDetails,
+        onNext,
+        origin,
+        onNavigateToWebpage,
+        onShare,
+        bottomAreaAvailabilityNestedScrollConnection,
         modifier,
         isTopBarDropdownMenuExpanded,
         initialFirstVisibleTimelineItemIndex
-    )
+      )
+    is Loadable.Failed -> Unit
+  }
 }
 
 @Composable
 private fun ProfileDetails(
-    boundary: ProfileDetailsBoundary,
-    detailsLoadable: Loadable<ProfileDetails>,
-    tootPreviewsLoadable: ListLoadable<TootPreview>,
-    onFavorite: (tootID: String) -> Unit,
-    onReblog: (tootID: String) -> Unit,
-    onNavigationToTootDetails: (id: String) -> Unit,
-    onNext: (index: Int) -> Unit,
-    origin: BackwardsNavigationState,
-    onNavigateToWebpage: (URL) -> Unit,
-    onShare: (URL) -> Unit,
-    bottomAreaAvailabilityNestedScrollConnection: BottomAreaAvailabilityNestedScrollConnection,
-    modifier: Modifier = Modifier,
-    isTopBarDropdownMenuExpanded: Boolean = false,
-    initialFirstVisibleTimelineItemIndex: Int = 0
+  origin: BackwardsNavigationState,
+  bottomAreaAvailabilityNestedScrollConnection: BottomAreaAvailabilityNestedScrollConnection,
+  modifier: Modifier = Modifier
 ) {
-    when (detailsLoadable) {
-        is Loadable.Loading ->
-            ProfileDetails(origin, bottomAreaAvailabilityNestedScrollConnection, modifier)
-        is Loadable.Loaded ->
-            ProfileDetails(
-                boundary,
-                detailsLoadable.content,
-                tootPreviewsLoadable,
-                onHighlightClick = boundary::navigateTo,
-                onFavorite,
-                onReblog,
-                onNavigationToTootDetails,
-                onNext,
-                origin,
-                onNavigateToWebpage,
-                onShare,
-                bottomAreaAvailabilityNestedScrollConnection,
-                modifier,
-                isTopBarDropdownMenuExpanded,
-                initialFirstVisibleTimelineItemIndex
-            )
-        is Loadable.Failed ->
-            Unit
-    }
-}
+  @OptIn(ExperimentalMaterial3Api::class)
+  val topAppBarScrollBehavior = _TopAppBarDefaults.scrollBehavior
 
-@Composable
-private fun ProfileDetails(
-    origin: BackwardsNavigationState,
-    bottomAreaAvailabilityNestedScrollConnection: BottomAreaAvailabilityNestedScrollConnection,
-    modifier: Modifier = Modifier
-) {
-    @OptIn(ExperimentalMaterial3Api::class)
-    val topAppBarScrollBehavior = _TopAppBarDefaults.scrollBehavior
-
-    @OptIn(ExperimentalMaterial3Api::class)
-    ProfileDetails(
-        topAppBarScrollBehavior,
-        title = { MediumTextualPlaceholder() },
-        actions = { },
-        timelineState = rememberLazyListState(),
-        timeline = { shouldNestScrollToTopAppBar, _ ->
-            Timeline(
-                Modifier
-                    .nestedScroll(bottomAreaAvailabilityNestedScrollConnection)
-                    .`if`(shouldNestScrollToTopAppBar) {
-                        nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
-                    }
-            ) {
-                Header()
-            }
-        },
-        floatingActionButton = { },
-        origin,
-        modifier
-    )
-}
-
-@Composable
-@OptIn(ExperimentalMaterial3Api::class)
-private fun ProfileDetails(
-    boundary: ProfileDetailsBoundary,
-    details: ProfileDetails,
-    tootsLoadable: ListLoadable<TootPreview>,
-    onHighlightClick: (URL) -> Unit,
-    onFavorite: (tootID: String) -> Unit,
-    onReblog: (tootID: String) -> Unit,
-    onNavigationToTootDetails: (id: String) -> Unit,
-    onNext: (index: Int) -> Unit,
-    origin: BackwardsNavigationState,
-    onNavigateToWebpage: (URL) -> Unit,
-    onShare: (URL) -> Unit,
-    bottomAreaAvailabilityNestedScrollConnection: BottomAreaAvailabilityNestedScrollConnection,
-    modifier: Modifier = Modifier,
-    isTopBarDropdownMenuExpanded: Boolean = false,
-    initialFirstVisibleTimelineItemIndex: Int = 0
-) {
-    val clipboardManager = LocalClipboardManager.current
-    val topAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
-    var isTopBarDropdownExpanded by remember(isTopBarDropdownMenuExpanded) {
-        mutableStateOf(isTopBarDropdownMenuExpanded)
-    }
-    val timelineState = rememberLazyListState(initialFirstVisibleTimelineItemIndex)
-
-    ProfileDetails(
-        topAppBarScrollBehavior,
-        title = { AutoSizeText(details.username) },
-        actions = {
-            Box {
-                HoverableIconButton(onClick = { isTopBarDropdownExpanded = true }) {
-                    Icon(
-                        OrcaTheme.iconography.expand,
-                        contentDescription = stringResource(R.string.profile_details_more)
-                    )
-                }
-
-                DropdownMenu(
-                    isTopBarDropdownExpanded,
-                    onDismissal = { isTopBarDropdownExpanded = false }
-                ) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.profile_details_open_in_browser)) },
-                        onClick = {
-                            onNavigateToWebpage(details.url)
-                            isTopBarDropdownExpanded = false
-                        },
-                        leadingIcon = {
-                            Icon(
-                                OrcaTheme.iconography.link,
-                                contentDescription = stringResource(
-                                    R.string.profile_details_external_link
-                                )
-                            )
-                        }
-                    )
-
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.profile_details_copy_url)) },
-                        onClick = {
-                            clipboardManager.setText(AnnotatedString("${details.url}"))
-                            isTopBarDropdownExpanded = false
-                        },
-                        leadingIcon = {
-                            Icon(
-                                OrcaTheme.iconography.link,
-                                contentDescription = stringResource(R.string.profile_details_share)
-                            )
-                        }
-                    )
-
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.profile_details_share)) },
-                        onClick = {
-                            onShare(details.url)
-                            isTopBarDropdownExpanded = false
-                        },
-                        leadingIcon = {
-                            Icon(
-                                OrcaTheme.iconography.share.outlined,
-                                contentDescription = stringResource(R.string.profile_details_share)
-                            )
-                        }
-                    )
-                }
-            }
-        },
-        timelineState,
-        timeline = { shouldNestScrollToTopAppBar, padding ->
-            Timeline(
-                tootsLoadable,
-                onHighlightClick,
-                onFavorite,
-                onReblog,
-                onShare,
-                onClick = onNavigationToTootDetails,
-                onNext,
-                Modifier
-                    .statusBarsPadding()
-                    .nestedScroll(bottomAreaAvailabilityNestedScrollConnection)
-                    .`if`(shouldNestScrollToTopAppBar) {
-                        nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
-                    },
-                timelineState,
-                contentPadding = padding
-            ) {
-                Header(details)
-            }
-        },
-        floatingActionButton = { details.FloatingActionButton(boundary) },
-        origin,
-        modifier
-    )
-}
-
-@Composable
-@OptIn(ExperimentalMaterial3Api::class)
-private fun ProfileDetails(
-    topAppBarScrollBehavior: TopAppBarScrollBehavior,
-    title: @Composable () -> Unit,
-    actions: @Composable RowScope.() -> Unit,
-    timelineState: LazyListState,
-    timeline: @Composable (shouldNestScrollToTopAppBar: Boolean, padding: PaddingValues) -> Unit,
-    floatingActionButton: @Composable () -> Unit,
-    origin: BackwardsNavigationState,
-    modifier: Modifier = Modifier
-) {
-    val isHeaderHidden by remember(timelineState) {
-        derivedStateOf {
-            timelineState.firstVisibleItemIndex > 0
-        }
-    }
-
-    LaunchedEffect(isHeaderHidden) {
-        if (!isHeaderHidden) {
-            timelineState.animateScrollToItem(0)
-        }
-    }
-
-    Box(modifier) {
-        Scaffold(floatingActionButton = floatingActionButton) {
-            timeline(isHeaderHidden, it)
-        }
-
-        AnimatedVisibility(
-            visible = isHeaderHidden,
-            enter = slideInVertically { -it },
-            exit = slideOutVertically { -it }
+  @OptIn(ExperimentalMaterial3Api::class)
+  ProfileDetails(
+    topAppBarScrollBehavior,
+    title = { MediumTextualPlaceholder() },
+    actions = {},
+    timelineState = rememberLazyListState(),
+    timeline = { shouldNestScrollToTopAppBar, _ ->
+      Timeline(
+        Modifier.nestedScroll(bottomAreaAvailabilityNestedScrollConnection).`if`(
+          shouldNestScrollToTopAppBar
         ) {
-            @OptIn(ExperimentalMaterial3Api::class)
-            TopAppBar(
-                title,
-                Modifier.testTag(PROFILE_DETAILS_TOP_BAR_TAG),
-                navigationIcon = { origin.NavigationButton() },
-                actions = actions,
-                scrollBehavior = topAppBarScrollBehavior
-            )
+          nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
         }
+      ) {
+        Header()
+      }
+    },
+    floatingActionButton = {},
+    origin,
+    modifier
+  )
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun ProfileDetails(
+  boundary: ProfileDetailsBoundary,
+  details: ProfileDetails,
+  tootsLoadable: ListLoadable<TootPreview>,
+  onHighlightClick: (URL) -> Unit,
+  onFavorite: (tootID: String) -> Unit,
+  onReblog: (tootID: String) -> Unit,
+  onNavigationToTootDetails: (id: String) -> Unit,
+  onNext: (index: Int) -> Unit,
+  origin: BackwardsNavigationState,
+  onNavigateToWebpage: (URL) -> Unit,
+  onShare: (URL) -> Unit,
+  bottomAreaAvailabilityNestedScrollConnection: BottomAreaAvailabilityNestedScrollConnection,
+  modifier: Modifier = Modifier,
+  isTopBarDropdownMenuExpanded: Boolean = false,
+  initialFirstVisibleTimelineItemIndex: Int = 0
+) {
+  val clipboardManager = LocalClipboardManager.current
+  val topAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+  var isTopBarDropdownExpanded by
+    remember(isTopBarDropdownMenuExpanded) { mutableStateOf(isTopBarDropdownMenuExpanded) }
+  val timelineState = rememberLazyListState(initialFirstVisibleTimelineItemIndex)
+
+  ProfileDetails(
+    topAppBarScrollBehavior,
+    title = { AutoSizeText(details.username) },
+    actions = {
+      Box {
+        HoverableIconButton(onClick = { isTopBarDropdownExpanded = true }) {
+          Icon(
+            OrcaTheme.iconography.expand,
+            contentDescription = stringResource(R.string.profile_details_more)
+          )
+        }
+
+        DropdownMenu(isTopBarDropdownExpanded, onDismissal = { isTopBarDropdownExpanded = false }) {
+          DropdownMenuItem(
+            text = { Text(stringResource(R.string.profile_details_open_in_browser)) },
+            onClick = {
+              onNavigateToWebpage(details.url)
+              isTopBarDropdownExpanded = false
+            },
+            leadingIcon = {
+              Icon(
+                OrcaTheme.iconography.link,
+                contentDescription = stringResource(R.string.profile_details_external_link)
+              )
+            }
+          )
+
+          DropdownMenuItem(
+            text = { Text(stringResource(R.string.profile_details_copy_url)) },
+            onClick = {
+              clipboardManager.setText(AnnotatedString("${details.url}"))
+              isTopBarDropdownExpanded = false
+            },
+            leadingIcon = {
+              Icon(
+                OrcaTheme.iconography.link,
+                contentDescription = stringResource(R.string.profile_details_share)
+              )
+            }
+          )
+
+          DropdownMenuItem(
+            text = { Text(stringResource(R.string.profile_details_share)) },
+            onClick = {
+              onShare(details.url)
+              isTopBarDropdownExpanded = false
+            },
+            leadingIcon = {
+              Icon(
+                OrcaTheme.iconography.share.outlined,
+                contentDescription = stringResource(R.string.profile_details_share)
+              )
+            }
+          )
+        }
+      }
+    },
+    timelineState,
+    timeline = { shouldNestScrollToTopAppBar, padding ->
+      Timeline(
+        tootsLoadable,
+        onHighlightClick,
+        onFavorite,
+        onReblog,
+        onShare,
+        onClick = onNavigationToTootDetails,
+        onNext,
+        Modifier.statusBarsPadding()
+          .nestedScroll(bottomAreaAvailabilityNestedScrollConnection)
+          .`if`(shouldNestScrollToTopAppBar) {
+            nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
+          },
+        timelineState,
+        contentPadding = padding
+      ) {
+        Header(details)
+      }
+    },
+    floatingActionButton = { details.FloatingActionButton(boundary) },
+    origin,
+    modifier
+  )
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun ProfileDetails(
+  topAppBarScrollBehavior: TopAppBarScrollBehavior,
+  title: @Composable () -> Unit,
+  actions: @Composable RowScope.() -> Unit,
+  timelineState: LazyListState,
+  timeline: @Composable (shouldNestScrollToTopAppBar: Boolean, padding: PaddingValues) -> Unit,
+  floatingActionButton: @Composable () -> Unit,
+  origin: BackwardsNavigationState,
+  modifier: Modifier = Modifier
+) {
+  val isHeaderHidden by
+    remember(timelineState) { derivedStateOf { timelineState.firstVisibleItemIndex > 0 } }
+
+  LaunchedEffect(isHeaderHidden) {
+    if (!isHeaderHidden) {
+      timelineState.animateScrollToItem(0)
     }
+  }
+
+  Box(modifier) {
+    Scaffold(floatingActionButton = floatingActionButton) { timeline(isHeaderHidden, it) }
+
+    AnimatedVisibility(
+      visible = isHeaderHidden,
+      enter = slideInVertically { -it },
+      exit = slideOutVertically { -it }
+    ) {
+      @OptIn(ExperimentalMaterial3Api::class)
+      TopAppBar(
+        title,
+        Modifier.testTag(PROFILE_DETAILS_TOP_BAR_TAG),
+        navigationIcon = { origin.NavigationButton() },
+        actions = actions,
+        scrollBehavior = topAppBarScrollBehavior
+      )
+    }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadingProfileDetailsPreview() {
-    OrcaTheme {
-        ProfileDetails(
-            BackwardsNavigationState.Unavailable,
-            BottomAreaAvailabilityNestedScrollConnection.empty
-        )
-    }
+  OrcaTheme {
+    ProfileDetails(
+      BackwardsNavigationState.Unavailable,
+      BottomAreaAvailabilityNestedScrollConnection.empty
+    )
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadedProfileDetailsWithoutTootsPreview() {
-    OrcaTheme {
-        ProfileDetails(
-            Loadable.Loaded(ProfileDetails.sample),
-            tootPreviewsLoadable = ListLoadable.Empty()
-        )
-    }
+  OrcaTheme {
+    ProfileDetails(
+      Loadable.Loaded(ProfileDetails.sample),
+      tootPreviewsLoadable = ListLoadable.Empty()
+    )
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadedProfileDetailsWithTootsPreview() {
-    OrcaTheme {
-        ProfileDetails(
-            Loadable.Loaded(ProfileDetails.sample),
-            tootPreviewsLoadable = TootPreview.samples.toSerializableList().toListLoadable()
-        )
-    }
+  OrcaTheme {
+    ProfileDetails(
+      Loadable.Loaded(ProfileDetails.sample),
+      tootPreviewsLoadable = TootPreview.samples.toSerializableList().toListLoadable()
+    )
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadedProfileDetailsWithExpandedTopBarDropdownMenuPreview() {
-    OrcaTheme {
-        ProfileDetails(
-            Loadable.Loaded(ProfileDetails.sample),
-            tootPreviewsLoadable = TootPreview.samples.toSerializableList().toListLoadable(),
-            isTopBarDropdownMenuExpanded = true,
-            initialFirstVisibleTimelineItemIndex = 1
-        )
-    }
+  OrcaTheme {
+    ProfileDetails(
+      Loadable.Loaded(ProfileDetails.sample),
+      tootPreviewsLoadable = TootPreview.samples.toSerializableList().toListLoadable(),
+      isTopBarDropdownMenuExpanded = true,
+      initialFirstVisibleTimelineItemIndex = 1
+    )
+  }
 }

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsBoundary.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsBoundary.kt
@@ -3,17 +3,16 @@ package com.jeanbarrossilva.orca.feature.profiledetails
 import java.net.URL
 
 interface ProfileDetailsBoundary {
-    fun navigateTo(url: URL)
+  fun navigateTo(url: URL)
 
-    fun navigateToTootDetails(id: String)
+  fun navigateToTootDetails(id: String)
 
-    companion object {
-        internal val empty = object : ProfileDetailsBoundary {
-            override fun navigateTo(url: URL) {
-            }
+  companion object {
+    internal val empty =
+      object : ProfileDetailsBoundary {
+        override fun navigateTo(url: URL) {}
 
-            override fun navigateToTootDetails(id: String) {
-            }
-        }
-    }
+        override fun navigateToTootDetails(id: String) {}
+      }
+  }
 }

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsFragment.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsFragment.kt
@@ -17,57 +17,57 @@ import com.jeanbarrossilva.orca.platform.ui.core.navigation.transition.opening
 import com.jeanbarrossilva.orca.std.injector.Injector
 
 class ProfileDetailsFragment internal constructor() : ComposableFragment(), ContextProvider {
-    private val module by lazy { Injector.from<ProfileDetailsModule>() }
-    private val id by argument<String>(ID_KEY)
-    private val viewModel by viewModels<ProfileDetailsViewModel> {
-        ProfileDetailsViewModel.createFactory(
-            contextProvider = this,
-            module.profileProvider(),
-            module.tootProvider(),
+  private val module by lazy { Injector.from<ProfileDetailsModule>() }
+  private val id by argument<String>(ID_KEY)
+  private val viewModel by
+    viewModels<ProfileDetailsViewModel> {
+      ProfileDetailsViewModel.createFactory(
+        contextProvider = this,
+        module.profileProvider(),
+        module.tootProvider(),
+        id
+      )
+    }
+
+  constructor(backwardsNavigationState: BackwardsNavigationState, id: String) : this() {
+    arguments = bundleOf(BACKWARDS_NAVIGATION_STATE_KEY to backwardsNavigationState, ID_KEY to id)
+  }
+
+  @Composable
+  override fun Content() {
+    val backwardsNavigationState by remember {
+      argument<BackwardsNavigationState>(BACKWARDS_NAVIGATION_STATE_KEY)
+    }
+
+    ProfileDetails(
+      viewModel,
+      navigator = module.get(),
+      backwardsNavigationState,
+      onBottomAreaAvailabilityChangeListener = module.get()
+    )
+  }
+
+  override fun provide(): Context {
+    return requireContext()
+  }
+
+  companion object {
+    internal const val ID_KEY = "id"
+    internal const val BACKWARDS_NAVIGATION_STATE_KEY = "backwards-navigation-state"
+
+    fun createRoute(id: String): String {
+      return "profile/$id"
+    }
+
+    fun navigate(navigator: Navigator, id: String) {
+      navigator.navigate(opening()) {
+        to(createRoute(id)) {
+          ProfileDetailsFragment(
+            BackwardsNavigationState.Available.createInstance(navigator::pop),
             id
-        )
-    }
-
-    constructor(backwardsNavigationState: BackwardsNavigationState, id: String) : this() {
-        arguments =
-            bundleOf(BACKWARDS_NAVIGATION_STATE_KEY to backwardsNavigationState, ID_KEY to id)
-    }
-
-    @Composable
-    override fun Content() {
-        val backwardsNavigationState by remember {
-            argument<BackwardsNavigationState>(BACKWARDS_NAVIGATION_STATE_KEY)
+          )
         }
-
-        ProfileDetails(
-            viewModel,
-            navigator = module.get(),
-            backwardsNavigationState,
-            onBottomAreaAvailabilityChangeListener = module.get()
-        )
+      }
     }
-
-    override fun provide(): Context {
-        return requireContext()
-    }
-
-    companion object {
-        internal const val ID_KEY = "id"
-        internal const val BACKWARDS_NAVIGATION_STATE_KEY = "backwards-navigation-state"
-
-        fun createRoute(id: String): String {
-            return "profile/$id"
-        }
-
-        fun navigate(navigator: Navigator, id: String) {
-            navigator.navigate(opening()) {
-                to(createRoute(id)) {
-                    ProfileDetailsFragment(
-                        BackwardsNavigationState.Available.createInstance(navigator::pop),
-                        id
-                    )
-                }
-            }
-        }
-    }
+  }
 }

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/ProfileConverter.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/ProfileConverter.kt
@@ -4,29 +4,29 @@ import com.jeanbarrossilva.orca.core.feed.profile.Profile
 import com.jeanbarrossilva.orca.feature.profiledetails.ProfileDetails
 import com.jeanbarrossilva.orca.platform.theme.configuration.colors.Colors
 
-/** Converts a [Profile] into a [ProfileDetails] through [convert]. **/
+/** Converts a [Profile] into a [ProfileDetails] through [convert]. */
 internal abstract class ProfileConverter {
-    /** [ProfileConverter] to fallback to in case this one's [convert] returns `null`. **/
-    abstract val next: ProfileConverter?
+  /** [ProfileConverter] to fallback to in case this one's [convert] returns `null`. */
+  abstract val next: ProfileConverter?
 
-    /**
-     * Converts the given [profile] into [ProfileDetails].
-     *
-     * @param profile [Profile] to convert into [ProfileDetails].
-     * @param colors [Colors] by which visuals can be colored.
-     **/
-    fun convert(profile: Profile, colors: Colors): ProfileDetails? {
-        return onConvert(profile, colors) ?: next?.convert(profile, colors)
-    }
+  /**
+   * Converts the given [profile] into [ProfileDetails].
+   *
+   * @param profile [Profile] to convert into [ProfileDetails].
+   * @param colors [Colors] by which visuals can be colored.
+   */
+  fun convert(profile: Profile, colors: Colors): ProfileDetails? {
+    return onConvert(profile, colors) ?: next?.convert(profile, colors)
+  }
 
-    /**
-     * Converts the given [profile] into [ProfileDetails].
-     *
-     * Returning `null` signals that this [ProfileConverter] cannot perform the conversion and that
-     * the operation should be delegated to the [next] one.
-     *
-     * @param profile [Profile] to convert into [ProfileDetails].
-     * @param colors [Colors] by which visuals can be colored.
-     **/
-    protected abstract fun onConvert(profile: Profile, colors: Colors): ProfileDetails?
+  /**
+   * Converts the given [profile] into [ProfileDetails].
+   *
+   * Returning `null` signals that this [ProfileConverter] cannot perform the conversion and that
+   * the operation should be delegated to the [next] one.
+   *
+   * @param profile [Profile] to convert into [ProfileDetails].
+   * @param colors [Colors] by which visuals can be colored.
+   */
+  protected abstract fun onConvert(profile: Profile, colors: Colors): ProfileDetails?
 }

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/ProfileConverterFactory.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/ProfileConverterFactory.kt
@@ -6,17 +6,17 @@ import com.jeanbarrossilva.orca.feature.profiledetails.conversion.converter.Edit
 import com.jeanbarrossilva.orca.feature.profiledetails.conversion.converter.followable.FollowableProfileConverter
 import kotlinx.coroutines.CoroutineScope
 
-/** Creates an instance of a [ProfileConverter] through [create]. **/
+/** Creates an instance of a [ProfileConverter] through [create]. */
 internal object ProfileConverterFactory {
-    /**
-     * Creates a [ProfileConverter].
-     *
-     * @param coroutineScope [CoroutineScope] through which converted [Profile]-related suspending
-     * will be performed.
-     **/
-    fun create(coroutineScope: CoroutineScope): ProfileConverter {
-        val defaultConverter = DefaultProfileConverter(next = null)
-        val editableConverter = EditableProfileConverter(next = defaultConverter)
-        return FollowableProfileConverter(coroutineScope, next = editableConverter)
-    }
+  /**
+   * Creates a [ProfileConverter].
+   *
+   * @param coroutineScope [CoroutineScope] through which converted [Profile]-related suspending
+   *   will be performed.
+   */
+  fun create(coroutineScope: CoroutineScope): ProfileConverter {
+    val defaultConverter = DefaultProfileConverter(next = null)
+    val editableConverter = EditableProfileConverter(next = defaultConverter)
+    return FollowableProfileConverter(coroutineScope, next = editableConverter)
+  }
 }

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/DefaultProfileConverter.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/DefaultProfileConverter.kt
@@ -9,16 +9,16 @@ import com.jeanbarrossilva.orca.platform.ui.core.style.toAnnotatedString
 /**
  * [ProfileConverter] that converts a [Profile], regardless of its type, into a
  * [ProfileDetails.Default].
- **/
+ */
 internal class DefaultProfileConverter(override val next: ProfileConverter?) : ProfileConverter() {
-    override fun onConvert(profile: Profile, colors: Colors): ProfileDetails {
-        return ProfileDetails.Default(
-            profile.id,
-            profile.avatarURL,
-            profile.name,
-            profile.account,
-            profile.bio.toAnnotatedString(colors),
-            profile.url
-        )
-    }
+  override fun onConvert(profile: Profile, colors: Colors): ProfileDetails {
+    return ProfileDetails.Default(
+      profile.id,
+      profile.avatarURL,
+      profile.name,
+      profile.account,
+      profile.bio.toAnnotatedString(colors),
+      profile.url
+    )
+  }
 }

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/EditableProfileConverter.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/EditableProfileConverter.kt
@@ -7,20 +7,20 @@ import com.jeanbarrossilva.orca.feature.profiledetails.conversion.ProfileConvert
 import com.jeanbarrossilva.orca.platform.theme.configuration.colors.Colors
 import com.jeanbarrossilva.orca.platform.ui.core.style.toAnnotatedString
 
-/** [ProfileConverter] that converts an [EditableProfile]. **/
+/** [ProfileConverter] that converts an [EditableProfile]. */
 internal class EditableProfileConverter(override val next: ProfileConverter?) : ProfileConverter() {
-    override fun onConvert(profile: Profile, colors: Colors): ProfileDetails? {
-        return if (profile is EditableProfile) {
-            ProfileDetails.Editable(
-                profile.id,
-                profile.avatarURL,
-                profile.name,
-                profile.account,
-                profile.bio.toAnnotatedString(colors),
-                profile.url
-            )
-        } else {
-            null
-        }
+  override fun onConvert(profile: Profile, colors: Colors): ProfileDetails? {
+    return if (profile is EditableProfile) {
+      ProfileDetails.Editable(
+        profile.id,
+        profile.avatarURL,
+        profile.name,
+        profile.account,
+        profile.bio.toAnnotatedString(colors),
+        profile.url
+      )
+    } else {
+      null
     }
+  }
 }

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/followable/Follow.extensions.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/followable/Follow.extensions.kt
@@ -3,14 +3,12 @@ package com.jeanbarrossilva.orca.feature.profiledetails.conversion.converter.fol
 import com.jeanbarrossilva.orca.core.feed.profile.type.followable.Follow
 import com.jeanbarrossilva.orca.feature.profiledetails.ProfileDetails
 
-/** Converts this [Follow] into a [ProfileDetails.Followable.Status]. **/
+/** Converts this [Follow] into a [ProfileDetails.Followable.Status]. */
 internal fun Follow.toStatus(): ProfileDetails.Followable.Status {
-    return when (this) {
-        Follow.Public.following(), Follow.Private.following() ->
-            ProfileDetails.Followable.Status.FOLLOWING
-        Follow.Private.requested() ->
-            ProfileDetails.Followable.Status.REQUESTED
-        else ->
-            ProfileDetails.Followable.Status.UNFOLLOWED
-    }
+  return when (this) {
+    Follow.Public.following(),
+    Follow.Private.following() -> ProfileDetails.Followable.Status.FOLLOWING
+    Follow.Private.requested() -> ProfileDetails.Followable.Status.REQUESTED
+    else -> ProfileDetails.Followable.Status.UNFOLLOWED
+  }
 }

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/followable/FollowableProfileConverter.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/followable/FollowableProfileConverter.kt
@@ -14,29 +14,27 @@ import kotlinx.coroutines.launch
  * [ProfileConverter] that converts a [FollowableProfile].
  *
  * @param coroutineScope [CoroutineScope] through which converted [Profile]'s [Follow] status toggle
- * will be performed.
- **/
+ *   will be performed.
+ */
 internal class FollowableProfileConverter(
-    private val coroutineScope: CoroutineScope,
-    override val next: ProfileConverter?
+  private val coroutineScope: CoroutineScope,
+  override val next: ProfileConverter?
 ) : ProfileConverter() {
-    override fun onConvert(profile: Profile, colors: Colors): ProfileDetails? {
-        return if (profile is FollowableProfile<*>) {
-            ProfileDetails.Followable(
-                profile.id,
-                profile.avatarURL,
-                profile.name,
-                profile.account,
-                profile.bio.toAnnotatedString(colors),
-                profile.url,
-                profile.follow.toStatus()
-            ) {
-                coroutineScope.launch {
-                    profile.toggleFollow()
-                }
-            }
-        } else {
-            null
-        }
+  override fun onConvert(profile: Profile, colors: Colors): ProfileDetails? {
+    return if (profile is FollowableProfile<*>) {
+      ProfileDetails.Followable(
+        profile.id,
+        profile.avatarURL,
+        profile.name,
+        profile.account,
+        profile.bio.toAnnotatedString(colors),
+        profile.url,
+        profile.follow.toStatus()
+      ) {
+        coroutineScope.launch { profile.toggleFollow() }
+      }
+    } else {
+      null
     }
+  }
 }

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/navigation/BackwardsNavigationState.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/navigation/BackwardsNavigationState.kt
@@ -14,58 +14,54 @@ import java.io.Serializable
  *
  * @see Unavailable
  * @see Available
- **/
+ */
 sealed class BackwardsNavigationState : Serializable {
-    /** Defines that backwards navigation is not available. **/
-    object Unavailable : BackwardsNavigationState() {
-        @Composable
-        override fun NavigationButton(modifier: Modifier) {
-        }
-    }
+  /** Defines that backwards navigation is not available. */
+  object Unavailable : BackwardsNavigationState() {
+    @Composable override fun NavigationButton(modifier: Modifier) {}
+  }
 
-    /**
-     * Defines that backwards navigation is available, and thus can be performed through
-     * [navigateBackwards].
-     **/
-    abstract class Available private constructor() : BackwardsNavigationState() {
-        @Composable
-        override fun NavigationButton(modifier: Modifier) {
-            HoverableIconButton(onClick = ::navigateBackwards) {
-                Icon(OrcaTheme.iconography.back, contentDescription = "Back")
-            }
-        }
-
-        /** Navigates backwards, to the previous screen. **/
-        internal abstract fun navigateBackwards()
-
-        companion object {
-            /**
-             * Creates an [Available] instance.
-             *
-             * @param onBackwardsNavigation Action to be performed when [navigateBackwards] is
-             * called.
-             **/
-            fun createInstance(onBackwardsNavigation: () -> Unit): Available {
-                return object : Available() {
-                    override fun navigateBackwards() {
-                        onBackwardsNavigation()
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * [Composable] that represents the action that can be performed.
-     *
-     * @param modifier [Modifier] to be applied to the underlying [Composable].
-     **/
+  /**
+   * Defines that backwards navigation is available, and thus can be performed through
+   * [navigateBackwards].
+   */
+  abstract class Available private constructor() : BackwardsNavigationState() {
     @Composable
-    internal abstract fun NavigationButton(modifier: Modifier)
+    override fun NavigationButton(modifier: Modifier) {
+      HoverableIconButton(onClick = ::navigateBackwards) {
+        Icon(OrcaTheme.iconography.back, contentDescription = "Back")
+      }
+    }
+
+    /** Navigates backwards, to the previous screen. */
+    internal abstract fun navigateBackwards()
+
+    companion object {
+      /**
+       * Creates an [Available] instance.
+       *
+       * @param onBackwardsNavigation Action to be performed when [navigateBackwards] is called.
+       */
+      fun createInstance(onBackwardsNavigation: () -> Unit): Available {
+        return object : Available() {
+          override fun navigateBackwards() {
+            onBackwardsNavigation()
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * [Composable] that represents the action that can be performed.
+   *
+   * @param modifier [Modifier] to be applied to the underlying [Composable].
+   */
+  @Composable internal abstract fun NavigationButton(modifier: Modifier)
 }
 
-/** [Composable] that represents the action that can be performed. **/
+/** [Composable] that represents the action that can be performed. */
 @Composable
 internal fun BackwardsNavigationState.NavigationButton() {
-    NavigationButton(Modifier)
+  NavigationButton(Modifier)
 }

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ui/Header.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ui/Header.kt
@@ -21,83 +21,75 @@ import com.jeanbarrossilva.orca.platform.ui.component.LargeAvatar
 
 @Composable
 internal fun Header(modifier: Modifier = Modifier) {
-    Header(
-        avatar = { LargeAvatar() },
-        name = { MediumTextualPlaceholder() },
-        account = { LargeTextualPlaceholder() },
-        bio = {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.extraSmall),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                repeat(3) { LargeTextualPlaceholder() }
-                MediumTextualPlaceholder()
-            }
-        },
-        mainActionButton = { },
-        modifier
-    )
+  Header(
+    avatar = { LargeAvatar() },
+    name = { MediumTextualPlaceholder() },
+    account = { LargeTextualPlaceholder() },
+    bio = {
+      Column(
+        verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.extraSmall),
+        horizontalAlignment = Alignment.CenterHorizontally
+      ) {
+        repeat(3) { LargeTextualPlaceholder() }
+        MediumTextualPlaceholder()
+      }
+    },
+    mainActionButton = {},
+    modifier
+  )
 }
 
 @Composable
 internal fun Header(details: ProfileDetails, modifier: Modifier = Modifier) {
-    Header(
-        avatar = { LargeAvatar(details.name, details.avatarURL) },
-        name = { Text(details.name) },
-        account = { Text(details.formattedAccount) },
-        bio = { Text(details.bio) },
-        mainActionButton = { details.MainActionButton() },
-        modifier
-    )
+  Header(
+    avatar = { LargeAvatar(details.name, details.avatarURL) },
+    name = { Text(details.name) },
+    account = { Text(details.formattedAccount) },
+    bio = { Text(details.bio) },
+    mainActionButton = { details.MainActionButton() },
+    modifier
+  )
 }
 
 @Composable
 private fun Header(
-    avatar: @Composable () -> Unit,
-    name: @Composable () -> Unit,
-    account: @Composable () -> Unit,
-    bio: @Composable () -> Unit,
-    mainActionButton: @Composable () -> Unit,
-    modifier: Modifier = Modifier
+  avatar: @Composable () -> Unit,
+  name: @Composable () -> Unit,
+  account: @Composable () -> Unit,
+  bio: @Composable () -> Unit,
+  mainActionButton: @Composable () -> Unit,
+  modifier: Modifier = Modifier
 ) {
+  Column(
+    modifier.padding(OrcaTheme.spacings.extraLarge).fillMaxWidth(),
+    Arrangement.spacedBy(OrcaTheme.spacings.extraLarge),
+    Alignment.CenterHorizontally
+  ) {
+    avatar()
+
     Column(
-        modifier
-            .padding(OrcaTheme.spacings.extraLarge)
-            .fillMaxWidth(),
-        Arrangement.spacedBy(OrcaTheme.spacings.extraLarge),
-        Alignment.CenterHorizontally
+      verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.extraSmall),
+      horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        avatar()
-
-        Column(
-            verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.extraSmall),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            ProvideTextStyle(OrcaTheme.typography.headlineLarge, name)
-            ProvideTextStyle(OrcaTheme.typography.titleSmall, account)
-        }
-
-        ProvideTextStyle(LocalTextStyle.current.copy(textAlign = TextAlign.Center), bio)
-        mainActionButton()
+      ProvideTextStyle(OrcaTheme.typography.headlineLarge, name)
+      ProvideTextStyle(OrcaTheme.typography.titleSmall, account)
     }
+
+    ProvideTextStyle(LocalTextStyle.current.copy(textAlign = TextAlign.Center), bio)
+    mainActionButton()
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadingHeaderPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            Header()
-        }
-    }
+  OrcaTheme { Surface(color = OrcaTheme.colors.background.container) { Header() } }
 }
 
 @Composable
 @MultiThemePreview
 private fun HeaderPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            Header(ProfileDetails.sample)
-        }
-    }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) { Header(ProfileDetails.sample) }
+  }
 }

--- a/feature/profile-details/src/test/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/ProfileConverterFactoryTests.kt
+++ b/feature/profile-details/src/test/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/ProfileConverterFactoryTests.kt
@@ -13,39 +13,34 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class ProfileConverterFactoryTests {
-    private val coroutineScope = TestScope()
+  private val coroutineScope = TestScope()
 
-    @Test
-    fun createdConverterConvertsDefaultProfile() {
-        assertEquals(
-            ProfileDetails.Default.createSample(Colors.Unspecified),
-            ProfileConverterFactory.create(coroutineScope).convert(
-                Profile.sample,
-                Colors.Unspecified
-            )
-        )
-    }
+  @Test
+  fun createdConverterConvertsDefaultProfile() {
+    assertEquals(
+      ProfileDetails.Default.createSample(Colors.Unspecified),
+      ProfileConverterFactory.create(coroutineScope).convert(Profile.sample, Colors.Unspecified)
+    )
+  }
 
-    @Test
-    fun createdConverterConvertsEditableProfile() {
-        assertEquals(
-            ProfileDetails.Editable.createSample(Colors.Unspecified),
-            ProfileConverterFactory.create(coroutineScope).convert(
-                EditableProfile.sample,
-                Colors.Unspecified
-            )
-        )
-    }
+  @Test
+  fun createdConverterConvertsEditableProfile() {
+    assertEquals(
+      ProfileDetails.Editable.createSample(Colors.Unspecified),
+      ProfileConverterFactory.create(coroutineScope)
+        .convert(EditableProfile.sample, Colors.Unspecified)
+    )
+  }
 
-    @Test
-    fun createdConverterConvertsFollowableProfile() {
-        val onStatusToggle = { }
-        assertEquals(
-            ProfileDetails.Followable.createSample(Colors.Unspecified, onStatusToggle),
-            ProfileConverterFactory.create(coroutineScope)
-                .convert(FollowableProfile.sample, Colors.Unspecified)
-                .let { it as ProfileDetails.Followable }
-                .copy(onStatusToggle = onStatusToggle)
-        )
-    }
+  @Test
+  fun createdConverterConvertsFollowableProfile() {
+    val onStatusToggle = {}
+    assertEquals(
+      ProfileDetails.Followable.createSample(Colors.Unspecified, onStatusToggle),
+      ProfileConverterFactory.create(coroutineScope)
+        .convert(FollowableProfile.sample, Colors.Unspecified)
+        .let { it as ProfileDetails.Followable }
+        .copy(onStatusToggle = onStatusToggle)
+    )
+  }
 }

--- a/feature/profile-details/src/test/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/DefaultProfileConverterTests.kt
+++ b/feature/profile-details/src/test/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/DefaultProfileConverterTests.kt
@@ -12,29 +12,29 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class DefaultProfileConverterTests {
-    private val converter = DefaultProfileConverter(next = null)
+  private val converter = DefaultProfileConverter(next = null)
 
-    @Test
-    fun convertsDefaultProfile() {
-        assertEquals(
-            ProfileDetails.Default.createSample(Colors.Unspecified),
-            converter.convert(Profile.sample, Colors.Unspecified)
-        )
-    }
+  @Test
+  fun convertsDefaultProfile() {
+    assertEquals(
+      ProfileDetails.Default.createSample(Colors.Unspecified),
+      converter.convert(Profile.sample, Colors.Unspecified)
+    )
+  }
 
-    @Test
-    fun convertsEditableProfile() {
-        assertEquals(
-            ProfileDetails.Default.createSample(Colors.Unspecified),
-            converter.convert(EditableProfile.sample, Colors.Unspecified)
-        )
-    }
+  @Test
+  fun convertsEditableProfile() {
+    assertEquals(
+      ProfileDetails.Default.createSample(Colors.Unspecified),
+      converter.convert(EditableProfile.sample, Colors.Unspecified)
+    )
+  }
 
-    @Test
-    fun convertsFollowableProfile() {
-        assertEquals(
-            ProfileDetails.Default.createSample(Colors.Unspecified),
-            converter.convert(FollowableProfile.sample, Colors.Unspecified)
-        )
-    }
+  @Test
+  fun convertsFollowableProfile() {
+    assertEquals(
+      ProfileDetails.Default.createSample(Colors.Unspecified),
+      converter.convert(FollowableProfile.sample, Colors.Unspecified)
+    )
+  }
 }

--- a/feature/profile-details/src/test/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/EditableProfileConverterTests.kt
+++ b/feature/profile-details/src/test/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/EditableProfileConverterTests.kt
@@ -13,23 +13,23 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class EditableProfileConverterTests {
-    private val converter = EditableProfileConverter(next = null)
+  private val converter = EditableProfileConverter(next = null)
 
-    @Test
-    fun convertsEditableProfile() {
-        assertEquals(
-            ProfileDetails.Editable.createSample(Colors.Unspecified),
-            converter.convert(EditableProfile.sample, Colors.Unspecified)
-        )
-    }
+  @Test
+  fun convertsEditableProfile() {
+    assertEquals(
+      ProfileDetails.Editable.createSample(Colors.Unspecified),
+      converter.convert(EditableProfile.sample, Colors.Unspecified)
+    )
+  }
 
-    @Test
-    fun doesNotConvertDefaultProfile() {
-        assertNull(converter.convert(Profile.sample, Colors.Unspecified))
-    }
+  @Test
+  fun doesNotConvertDefaultProfile() {
+    assertNull(converter.convert(Profile.sample, Colors.Unspecified))
+  }
 
-    @Test
-    fun doesNotConvertFollowableProfile() {
-        assertNull(converter.convert(FollowableProfile.sample, Colors.Unspecified))
-    }
+  @Test
+  fun doesNotConvertFollowableProfile() {
+    assertNull(converter.convert(FollowableProfile.sample, Colors.Unspecified))
+  }
 }

--- a/feature/profile-details/src/test/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/followable/FollowExtensionsTests.kt
+++ b/feature/profile-details/src/test/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/followable/FollowExtensionsTests.kt
@@ -6,43 +6,31 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class FollowExtensionsTests {
-    @Test
-    fun `GIVEN a public unfollowed Follow WHEN converting it into a Status THEN it's UNFOLLOWED`() {
-        assertEquals(
-            ProfileDetails.Followable.Status.UNFOLLOWED,
-            Follow.Public.unfollowed().toStatus()
-        )
-    }
+  @Test
+  fun `GIVEN a public unfollowed Follow WHEN converting it into a Status THEN it's UNFOLLOWED`() {
+    assertEquals(ProfileDetails.Followable.Status.UNFOLLOWED, Follow.Public.unfollowed().toStatus())
+  }
 
-    @Test
-    fun `GIVEN a private unfollowed Follow WHEN converting it into a Status THEN it's UNFOLLOWED`() { // ktlint-disable max-line-length
-        assertEquals(
-            ProfileDetails.Followable.Status.UNFOLLOWED,
-            Follow.Private.unfollowed().toStatus()
-        )
-    }
+  @Test
+  fun `GIVEN a private unfollowed Follow WHEN converting it into a Status THEN it's UNFOLLOWED`() {
+    assertEquals(
+      ProfileDetails.Followable.Status.UNFOLLOWED,
+      Follow.Private.unfollowed().toStatus()
+    )
+  }
 
-    @Test
-    fun `GIVEN a requested Follow WHEN converting it into a Status THEN it's REQUESTED`() {
-        assertEquals(
-            ProfileDetails.Followable.Status.REQUESTED,
-            Follow.Private.requested().toStatus()
-        )
-    }
+  @Test
+  fun `GIVEN a requested Follow WHEN converting it into a Status THEN it's REQUESTED`() {
+    assertEquals(ProfileDetails.Followable.Status.REQUESTED, Follow.Private.requested().toStatus())
+  }
 
-    @Test
-    fun `GIVEN a public following Follow WHEN converting it into a Status THEN it's FOLLOWING`() {
-        assertEquals(
-            ProfileDetails.Followable.Status.FOLLOWING,
-            Follow.Public.following().toStatus()
-        )
-    }
+  @Test
+  fun `GIVEN a public following Follow WHEN converting it into a Status THEN it's FOLLOWING`() {
+    assertEquals(ProfileDetails.Followable.Status.FOLLOWING, Follow.Public.following().toStatus())
+  }
 
-    @Test
-    fun `GIVEN a private following Follow WHEN converting it into a Status THEN it's FOLLOWING`() {
-        assertEquals(
-            ProfileDetails.Followable.Status.FOLLOWING,
-            Follow.Private.following().toStatus()
-        )
-    }
+  @Test
+  fun `GIVEN a private following Follow WHEN converting it into a Status THEN it's FOLLOWING`() {
+    assertEquals(ProfileDetails.Followable.Status.FOLLOWING, Follow.Private.following().toStatus())
+  }
 }

--- a/feature/profile-details/src/test/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/followable/FollowableProfileConverterTests.kt
+++ b/feature/profile-details/src/test/java/com/jeanbarrossilva/orca/feature/profiledetails/conversion/converter/followable/FollowableProfileConverterTests.kt
@@ -14,27 +14,28 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class FollowableProfileConverterTests {
-    private val coroutineScope = TestScope()
-    private val converter = FollowableProfileConverter(coroutineScope, next = null)
+  private val coroutineScope = TestScope()
+  private val converter = FollowableProfileConverter(coroutineScope, next = null)
 
-    @Test
-    fun convertsFollowableProfile() {
-        val onStatusToggle = { }
-        assertEquals(
-            ProfileDetails.Followable.createSample(Colors.Unspecified, onStatusToggle),
-            converter.convert(FollowableProfile.sample, Colors.Unspecified)
-                .let { it as ProfileDetails.Followable }
-                .copy(onStatusToggle = onStatusToggle)
-        )
-    }
+  @Test
+  fun convertsFollowableProfile() {
+    val onStatusToggle = {}
+    assertEquals(
+      ProfileDetails.Followable.createSample(Colors.Unspecified, onStatusToggle),
+      converter
+        .convert(FollowableProfile.sample, Colors.Unspecified)
+        .let { it as ProfileDetails.Followable }
+        .copy(onStatusToggle = onStatusToggle)
+    )
+  }
 
-    @Test
-    fun doesNotConvertDefaultProfile() {
-        assertNull(converter.convert(Profile.sample, Colors.Unspecified))
-    }
+  @Test
+  fun doesNotConvertDefaultProfile() {
+    assertNull(converter.convert(Profile.sample, Colors.Unspecified))
+  }
 
-    @Test
-    fun doesNotConvertEditableProfile() {
-        assertNull(converter.convert(EditableProfile.sample, Colors.Unspecified))
-    }
+  @Test
+  fun doesNotConvertEditableProfile() {
+    assertNull(converter.convert(EditableProfile.sample, Colors.Unspecified))
+  }
 }

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     buildFeatures.compose = true
-    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.get()
 }
 
 dependencies {

--- a/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/Search.kt
+++ b/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/Search.kt
@@ -47,221 +47,193 @@ import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.top.BackAction
 import com.jeanbarrossilva.orca.platform.ui.core.requestFocusWithDelay
 
 internal object SearchDefaults {
-    val VerticalArrangement = Arrangement.Top
-    val HorizontalAlignment = Alignment.Start
+  val VerticalArrangement = Arrangement.Top
+  val HorizontalAlignment = Alignment.Start
 }
 
 @Composable
 internal fun Search(
-    viewModel: SearchViewModel,
-    boundary: SearchBoundary,
-    modifier: Modifier = Modifier
+  viewModel: SearchViewModel,
+  boundary: SearchBoundary,
+  modifier: Modifier = Modifier
 ) {
-    val query by viewModel.queryFlow.collectAsState()
-    val resultsLoadable by viewModel.resultsFlow.collectAsState()
+  val query by viewModel.queryFlow.collectAsState()
+  val resultsLoadable by viewModel.resultsFlow.collectAsState()
 
-    when (
-        @Suppress("NAME_SHADOWING")
-        val resultsLoadable = resultsLoadable
-    ) {
-        is Loadable.Loading ->
-            Search(
-                query,
-                onQueryChange = viewModel::setQuery,
-                onBackwardsNavigation = boundary::pop
-            )
-        is Loadable.Loaded ->
-            Search(
-                query,
-                onQueryChange = viewModel::setQuery,
-                resultsLoadable.content,
-                onNavigateToProfileDetails = boundary::navigateToProfileDetails,
-                onBackwardsNavigation = boundary::pop,
-                modifier
-            )
-        is Loadable.Failed ->
-            Unit
-    }
-}
-
-@Composable
-private fun Search(
-    query: String,
-    onQueryChange: (query: String) -> Unit,
-    onBackwardsNavigation: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Search(query, onQueryChange, onBackwardsNavigation, modifier) {
-        items(128) {
-            SearchResultCard()
-        }
-    }
-}
-
-@Composable
-private fun Search(
-    query: String,
-    onQueryChange: (query: String) -> Unit,
-    results: List<ProfileSearchResult>,
-    onNavigateToProfileDetails: (id: String) -> Unit,
-    onBackwardsNavigation: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    @OptIn(ExperimentalComposeUiApi::class)
-    val softwareKeyboardController = LocalSoftwareKeyboardController.current
-
-    val areResultsEmpty = remember(query, results) { query.isNotBlank() && results.isEmpty() }
-
-    Search(
+  when (@Suppress("NAME_SHADOWING") val resultsLoadable = resultsLoadable) {
+    is Loadable.Loading ->
+      Search(query, onQueryChange = viewModel::setQuery, onBackwardsNavigation = boundary::pop)
+    is Loadable.Loaded ->
+      Search(
         query,
-        onQueryChange,
-        onBackwardsNavigation,
-        modifier,
-        verticalArrangement = if (areResultsEmpty) {
-            Arrangement.spacedBy(OrcaTheme.spacings.medium, Alignment.CenterVertically)
-        } else {
-            SearchDefaults.VerticalArrangement
-        },
-        horizontalAlignment = if (areResultsEmpty) {
-            Alignment.CenterHorizontally
-        } else {
-            SearchDefaults.HorizontalAlignment
-        }
-    ) {
-        if (areResultsEmpty) {
-            item {
-                EmptyResultsMessage()
-            }
-        } else {
-            items(results) {
-                SearchResultCard(
-                    it,
-                    onClick = {
-                        onNavigateToProfileDetails(it.id)
-
-                        @OptIn(ExperimentalComposeUiApi::class)
-                        softwareKeyboardController?.hide()
-                    }
-                )
-            }
-        }
-    }
+        onQueryChange = viewModel::setQuery,
+        resultsLoadable.content,
+        onNavigateToProfileDetails = boundary::navigateToProfileDetails,
+        onBackwardsNavigation = boundary::pop,
+        modifier
+      )
+    is Loadable.Failed -> Unit
+  }
 }
 
 @Composable
 private fun Search(
-    query: String,
-    onQueryChange: (query: String) -> Unit,
-    onBackwardsNavigation: () -> Unit,
-    modifier: Modifier = Modifier,
-    verticalArrangement: Arrangement.Vertical = SearchDefaults.VerticalArrangement,
-    horizontalAlignment: Alignment.Horizontal = SearchDefaults.HorizontalAlignment,
-    content: LazyListScope.() -> Unit
+  query: String,
+  onQueryChange: (query: String) -> Unit,
+  onBackwardsNavigation: () -> Unit,
+  modifier: Modifier = Modifier
 ) {
-    val focusRequester = remember(::FocusRequester)
-    val spacing = OrcaTheme.spacings.medium
+  Search(query, onQueryChange, onBackwardsNavigation, modifier) {
+    items(128) { SearchResultCard() }
+  }
+}
 
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocusWithDelay()
-    }
+@Composable
+private fun Search(
+  query: String,
+  onQueryChange: (query: String) -> Unit,
+  results: List<ProfileSearchResult>,
+  onNavigateToProfileDetails: (id: String) -> Unit,
+  onBackwardsNavigation: () -> Unit,
+  modifier: Modifier = Modifier
+) {
+  @OptIn(ExperimentalComposeUiApi::class)
+  val softwareKeyboardController = LocalSoftwareKeyboardController.current
 
-    Scaffold(
-        modifier,
-        topAppBar = {
-            Row(
-                Modifier
-                    .background(OrcaTheme.colors.background.container)
-                    .padding(top = spacing, end = spacing, bottom = spacing)
-                    .statusBarsPadding(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Box(Modifier.fillMaxWidth(.2f), Alignment.Center) {
-                    BackAction(onClick = onBackwardsNavigation)
-                }
+  val areResultsEmpty = remember(query, results) { query.isNotBlank() && results.isEmpty() }
 
-                TextField(
-                    query,
-                    onQueryChange,
-                    Modifier
-                        .focusRequester(focusRequester)
-                        .fillMaxWidth()
-                ) {
-                    Text(stringResource(R.string.search_placeholder))
-                }
-            }
-        }
-    ) {
-        LazyColumn(
-            @OptIn(ExperimentalLayoutApi::class)
-            Modifier
-                // TODO: Add bottom bar overlay to Overlays.
-                .consumeWindowInsets(PaddingValues(104.dp))
-                .imePadding()
-                .fillMaxSize(),
-            verticalArrangement = verticalArrangement,
-            horizontalAlignment = horizontalAlignment,
-            contentPadding = it,
-            content = content
+  Search(
+    query,
+    onQueryChange,
+    onBackwardsNavigation,
+    modifier,
+    verticalArrangement =
+      if (areResultsEmpty) {
+        Arrangement.spacedBy(OrcaTheme.spacings.medium, Alignment.CenterVertically)
+      } else {
+        SearchDefaults.VerticalArrangement
+      },
+    horizontalAlignment =
+      if (areResultsEmpty) {
+        Alignment.CenterHorizontally
+      } else {
+        SearchDefaults.HorizontalAlignment
+      }
+  ) {
+    if (areResultsEmpty) {
+      item { EmptyResultsMessage() }
+    } else {
+      items(results) {
+        SearchResultCard(
+          it,
+          onClick = {
+            onNavigateToProfileDetails(it.id)
+
+            @OptIn(ExperimentalComposeUiApi::class) softwareKeyboardController?.hide()
+          }
         )
+      }
     }
+  }
+}
+
+@Composable
+private fun Search(
+  query: String,
+  onQueryChange: (query: String) -> Unit,
+  onBackwardsNavigation: () -> Unit,
+  modifier: Modifier = Modifier,
+  verticalArrangement: Arrangement.Vertical = SearchDefaults.VerticalArrangement,
+  horizontalAlignment: Alignment.Horizontal = SearchDefaults.HorizontalAlignment,
+  content: LazyListScope.() -> Unit
+) {
+  val focusRequester = remember(::FocusRequester)
+  val spacing = OrcaTheme.spacings.medium
+
+  LaunchedEffect(Unit) { focusRequester.requestFocusWithDelay() }
+
+  Scaffold(
+    modifier,
+    topAppBar = {
+      Row(
+        Modifier.background(OrcaTheme.colors.background.container)
+          .padding(top = spacing, end = spacing, bottom = spacing)
+          .statusBarsPadding(),
+        verticalAlignment = Alignment.CenterVertically
+      ) {
+        Box(Modifier.fillMaxWidth(.2f), Alignment.Center) {
+          BackAction(onClick = onBackwardsNavigation)
+        }
+
+        TextField(query, onQueryChange, Modifier.focusRequester(focusRequester).fillMaxWidth()) {
+          Text(stringResource(R.string.search_placeholder))
+        }
+      }
+    }
+  ) {
+    LazyColumn(
+      @OptIn(ExperimentalLayoutApi::class)
+      Modifier
+        // TODO: Add bottom bar overlay to Overlays.
+        .consumeWindowInsets(PaddingValues(104.dp))
+        .imePadding()
+        .fillMaxSize(),
+      verticalArrangement = verticalArrangement,
+      horizontalAlignment = horizontalAlignment,
+      contentPadding = it,
+      content = content
+    )
+  }
 }
 
 @Composable
 private fun EmptyResultsMessage(modifier: Modifier = Modifier) {
-    Column(
-        modifier,
-        Arrangement.spacedBy(OrcaTheme.spacings.medium),
-        Alignment.CenterHorizontally
-    ) {
-        CompositionLocalProvider(
-            LocalContentColor provides OrcaTheme.typography.headlineMedium.color
-        ) {
-            Icon(
-                OrcaTheme.iconography.search,
-                contentDescription = stringResource(R.string.search),
-                Modifier.size(64.dp)
-            )
+  Column(modifier, Arrangement.spacedBy(OrcaTheme.spacings.medium), Alignment.CenterHorizontally) {
+    CompositionLocalProvider(LocalContentColor provides OrcaTheme.typography.headlineMedium.color) {
+      Icon(
+        OrcaTheme.iconography.search,
+        contentDescription = stringResource(R.string.search),
+        Modifier.size(64.dp)
+      )
 
-            Text(
-                stringResource(R.string.search_no_results_found),
-                style = OrcaTheme.typography.headlineMedium
-            )
-        }
+      Text(
+        stringResource(R.string.search_no_results_found),
+        style = OrcaTheme.typography.headlineMedium
+      )
     }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadingSearchPreview() {
-    OrcaTheme {
-        Search(query = "", onQueryChange = { }, onBackwardsNavigation = { })
-    }
+  OrcaTheme { Search(query = "", onQueryChange = {}, onBackwardsNavigation = {}) }
 }
 
 @Composable
 @MultiThemePreview
 private fun EmptyResultsPreview() {
-    OrcaTheme {
-        Search(
-            query = "${ProfileSearchResult.sample.account}",
-            onQueryChange = { },
-            results = emptyList(),
-            onNavigateToProfileDetails = { },
-            onBackwardsNavigation = { }
-        )
-    }
+  OrcaTheme {
+    Search(
+      query = "${ProfileSearchResult.sample.account}",
+      onQueryChange = {},
+      results = emptyList(),
+      onNavigateToProfileDetails = {},
+      onBackwardsNavigation = {}
+    )
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadedSearchPreview() {
-    OrcaTheme {
-        Search(
-            query = "",
-            onQueryChange = { },
-            ProfileSearchResult.samples,
-            onNavigateToProfileDetails = { },
-            onBackwardsNavigation = { }
-        )
-    }
+  OrcaTheme {
+    Search(
+      query = "",
+      onQueryChange = {},
+      ProfileSearchResult.samples,
+      onNavigateToProfileDetails = {},
+      onBackwardsNavigation = {}
+    )
+  }
 }

--- a/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/SearchBoundary.kt
+++ b/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/SearchBoundary.kt
@@ -1,7 +1,7 @@
 package com.jeanbarrossilva.orca.feature.search
 
 interface SearchBoundary {
-    fun navigateToProfileDetails(id: String)
+  fun navigateToProfileDetails(id: String)
 
-    fun pop()
+  fun pop()
 }

--- a/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/SearchFragment.kt
+++ b/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/SearchFragment.kt
@@ -8,21 +8,18 @@ import com.jeanbarrossilva.orca.platform.ui.core.navigation.transition.opening
 import com.jeanbarrossilva.orca.std.injector.Injector
 
 class SearchFragment : ComposableFragment() {
-    private val module by lazy { Injector.from<SearchModule>() }
-    private val viewModel by viewModels<SearchViewModel> {
-        SearchViewModel.createFactory(module.searcher())
-    }
+  private val module by lazy { Injector.from<SearchModule>() }
+  private val viewModel by
+    viewModels<SearchViewModel> { SearchViewModel.createFactory(module.searcher()) }
 
-    @Composable
-    override fun Content() {
-        Search(viewModel, module.boundary())
-    }
+  @Composable
+  override fun Content() {
+    Search(viewModel, module.boundary())
+  }
 
-    companion object {
-        fun navigate(navigator: Navigator) {
-            navigator.navigate(opening()) {
-                to("search", ::SearchFragment)
-            }
-        }
+  companion object {
+    fun navigate(navigator: Navigator) {
+      navigator.navigate(opening()) { to("search", ::SearchFragment) }
     }
+  }
 }

--- a/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/SearchModule.kt
+++ b/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/SearchModule.kt
@@ -5,6 +5,6 @@ import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
 
 abstract class SearchModule(
-    @Inject internal val searcher: Module.() -> ProfileSearcher,
-    @Inject internal val boundary: Module.() -> SearchBoundary
+  @Inject internal val searcher: Module.() -> ProfileSearcher,
+  @Inject internal val boundary: Module.() -> SearchBoundary
 ) : Module()

--- a/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/SearchViewModel.kt
@@ -16,30 +16,27 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 
 internal class SearchViewModel private constructor(private val searcher: ProfileSearcher) :
-    ViewModel() {
-    private val queryMutableFlow = MutableStateFlow("")
+  ViewModel() {
+  private val queryMutableFlow = MutableStateFlow("")
 
-    val queryFlow = queryMutableFlow.asStateFlow()
+  val queryFlow = queryMutableFlow.asStateFlow()
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val resultsFlow = loadableFlow(viewModelScope) {
-        queryFlow
-            .flatMapLatest(searcher::search)
-            .map(List<ProfileSearchResult>::toSerializableList)
-            .collect(::load)
+  @OptIn(ExperimentalCoroutinesApi::class)
+  val resultsFlow =
+    loadableFlow(viewModelScope) {
+      queryFlow
+        .flatMapLatest(searcher::search)
+        .map(List<ProfileSearchResult>::toSerializableList)
+        .collect(::load)
     }
 
-    fun setQuery(query: String) {
-        queryMutableFlow.value = query
-    }
+  fun setQuery(query: String) {
+    queryMutableFlow.value = query
+  }
 
-    companion object {
-        fun createFactory(searcher: ProfileSearcher): ViewModelProvider.Factory {
-            return viewModelFactory {
-                initializer {
-                    SearchViewModel(searcher)
-                }
-            }
-        }
+  companion object {
+    fun createFactory(searcher: ProfileSearcher): ViewModelProvider.Factory {
+      return viewModelFactory { initializer { SearchViewModel(searcher) } }
     }
+  }
 }

--- a/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/ui/SearchResultCard.kt
+++ b/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/ui/SearchResultCard.kt
@@ -27,75 +27,71 @@ import com.jeanbarrossilva.orca.std.imageloader.compose.rememberImageLoader
 
 @Composable
 internal fun SearchResultCard(modifier: Modifier = Modifier) {
-    SearchResultCard(
-        avatar = { SmallAvatar() },
-        name = { MediumTextualPlaceholder() },
-        account = { SmallTextualPlaceholder() },
-        onClick = { },
-        modifier
-    )
+  SearchResultCard(
+    avatar = { SmallAvatar() },
+    name = { MediumTextualPlaceholder() },
+    account = { SmallTextualPlaceholder() },
+    onClick = {},
+    modifier
+  )
 }
 
 @Composable
 internal fun SearchResultCard(
-    searchResult: ProfileSearchResult,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    imageLoader: ImageLoader = rememberImageLoader()
+  searchResult: ProfileSearchResult,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  imageLoader: ImageLoader = rememberImageLoader()
 ) {
-    SearchResultCard(
-        avatar = { SmallAvatar(searchResult.name, searchResult.url, imageLoader = imageLoader) },
-        name = { Text(searchResult.name) },
-        account = { Text("${searchResult.account}") },
-        onClick,
-        modifier
-    )
+  SearchResultCard(
+    avatar = { SmallAvatar(searchResult.name, searchResult.url, imageLoader = imageLoader) },
+    name = { Text(searchResult.name) },
+    account = { Text("${searchResult.account}") },
+    onClick,
+    modifier
+  )
 }
 
 @Composable
 private fun SearchResultCard(
-    avatar: @Composable () -> Unit,
-    name: @Composable () -> Unit,
-    account: @Composable () -> Unit,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
+  avatar: @Composable () -> Unit,
+  name: @Composable () -> Unit,
+  account: @Composable () -> Unit,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier
 ) {
-    val horizontalSpacing = OrcaTheme.spacings.large
+  val horizontalSpacing = OrcaTheme.spacings.large
 
-    Row(
-        modifier
-            .padding(horizontalSpacing, vertical = OrcaTheme.spacings.medium)
-            .clickable(onClick = onClick)
-            .fillMaxWidth()
-            .semantics { role = Role.Button },
-        Arrangement.spacedBy(horizontalSpacing),
-        Alignment.CenterVertically
-    ) {
-        avatar()
+  Row(
+    modifier
+      .padding(horizontalSpacing, vertical = OrcaTheme.spacings.medium)
+      .clickable(onClick = onClick)
+      .fillMaxWidth()
+      .semantics { role = Role.Button },
+    Arrangement.spacedBy(horizontalSpacing),
+    Alignment.CenterVertically
+  ) {
+    avatar()
 
-        Column(verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.extraSmall)) {
-            ProvideTextStyle(OrcaTheme.typography.bodyLarge, content = name)
-            ProvideTextStyle(OrcaTheme.typography.bodyMedium, content = account)
-        }
+    Column(verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.extraSmall)) {
+      ProvideTextStyle(OrcaTheme.typography.bodyLarge, content = name)
+      ProvideTextStyle(OrcaTheme.typography.bodyMedium, content = account)
     }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadingSearchResultCardPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            SearchResultCard()
-        }
-    }
+  OrcaTheme { Surface(color = OrcaTheme.colors.background.container) { SearchResultCard() } }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadedSearchResultCardPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            SearchResultCard(ProfileSearchResult.sample, onClick = { })
-        }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) {
+      SearchResultCard(ProfileSearchResult.sample, onClick = {})
     }
+  }
 }

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     buildFeatures.compose = true
-    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.get()
 }
 
 dependencies {

--- a/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/Settings.kt
+++ b/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/Settings.kt
@@ -21,58 +21,58 @@ import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.top.text.AutoSiz
 
 @Composable
 internal fun Settings(
-    viewModel: SettingsViewModel,
-    boundary: SettingsBoundary,
-    modifier: Modifier = Modifier
+  viewModel: SettingsViewModel,
+  boundary: SettingsBoundary,
+  modifier: Modifier = Modifier
 ) {
-    val mutedTerms by viewModel.mutedTermsFlow.collectAsState()
+  val mutedTerms by viewModel.mutedTermsFlow.collectAsState()
 
-    Settings(
-        mutedTerms,
-        onNavigationToTermMuting = boundary::navigateToTermMuting,
-        onTermUnmute = viewModel::unmute,
-        modifier
-    )
+  Settings(
+    mutedTerms,
+    onNavigationToTermMuting = boundary::navigateToTermMuting,
+    onTermUnmute = viewModel::unmute,
+    modifier
+  )
 }
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 private fun Settings(
-    mutedTerms: List<String>,
-    onNavigationToTermMuting: () -> Unit,
-    onTermUnmute: (term: String) -> Unit,
-    modifier: Modifier = Modifier
+  mutedTerms: List<String>,
+  onNavigationToTermMuting: () -> Unit,
+  onTermUnmute: (term: String) -> Unit,
+  modifier: Modifier = Modifier
 ) {
-    val topAppBarScrollBehavior = TopAppBarDefaults.scrollBehavior
-    val lazyListState = rememberLazyListState()
+  val topAppBarScrollBehavior = TopAppBarDefaults.scrollBehavior
+  val lazyListState = rememberLazyListState()
 
-    Scaffold(
-        modifier,
-        topAppBar = {
-            TopAppBar(
-                title = { AutoSizeText(stringResource(R.string.settings)) },
-                scrollBehavior = topAppBarScrollBehavior
-            )
-        }
-    ) {
-        LazyColumn(
-            Modifier.nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
-            state = lazyListState,
-            contentPadding = it + PaddingValues(OrcaTheme.spacings.medium)
-        ) {
-            item {
-                Section(stringResource(R.string.settings_general)) {
-                    muting(mutedTerms, onNavigationToTermMuting, onTermUnmute)
-                }
-            }
-        }
+  Scaffold(
+    modifier,
+    topAppBar = {
+      TopAppBar(
+        title = { AutoSizeText(stringResource(R.string.settings)) },
+        scrollBehavior = topAppBarScrollBehavior
+      )
     }
+  ) {
+    LazyColumn(
+      Modifier.nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
+      state = lazyListState,
+      contentPadding = it + PaddingValues(OrcaTheme.spacings.medium)
+    ) {
+      item {
+        Section(stringResource(R.string.settings_general)) {
+          muting(mutedTerms, onNavigationToTermMuting, onTermUnmute)
+        }
+      }
+    }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun SettingsPreview() {
-    OrcaTheme {
-        Settings(mutedTerms = listOf("Java"), onNavigationToTermMuting = { }, onTermUnmute = { })
-    }
+  OrcaTheme {
+    Settings(mutedTerms = listOf("Java"), onNavigationToTermMuting = {}, onTermUnmute = {})
+  }
 }

--- a/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/SettingsBoundary.kt
+++ b/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/SettingsBoundary.kt
@@ -1,5 +1,5 @@
 package com.jeanbarrossilva.orca.feature.settings
 
 interface SettingsBoundary {
-    fun navigateToTermMuting()
+  fun navigateToTermMuting()
 }

--- a/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/SettingsFragment.kt
+++ b/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/SettingsFragment.kt
@@ -6,13 +6,12 @@ import com.jeanbarrossilva.orca.platform.ui.core.composable.ComposableFragment
 import com.jeanbarrossilva.orca.std.injector.Injector
 
 class SettingsFragment : ComposableFragment() {
-    private val module by lazy { Injector.from<SettingsModule>() }
-    private val viewModel by viewModels<SettingsViewModel> {
-        SettingsViewModel.createFactory(module.termMuter())
-    }
+  private val module by lazy { Injector.from<SettingsModule>() }
+  private val viewModel by
+    viewModels<SettingsViewModel> { SettingsViewModel.createFactory(module.termMuter()) }
 
-    @Composable
-    override fun Content() {
-        Settings(viewModel, module.boundary())
-    }
+  @Composable
+  override fun Content() {
+    Settings(viewModel, module.boundary())
+  }
 }

--- a/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/SettingsModule.kt
+++ b/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/SettingsModule.kt
@@ -5,6 +5,6 @@ import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
 
 abstract class SettingsModule(
-    @Inject internal val termMuter: Module.() -> TermMuter,
-    @Inject internal val boundary: Module.() -> SettingsBoundary
+  @Inject internal val termMuter: Module.() -> TermMuter,
+  @Inject internal val boundary: Module.() -> SettingsBoundary
 ) : Module()

--- a/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/SettingsScope.extensions.kt
+++ b/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/SettingsScope.extensions.kt
@@ -11,42 +11,39 @@ import com.jeanbarrossilva.orca.platform.theme.kit.action.setting.list.SettingsS
  *
  * @param mutedTerms Terms that have been muted.
  * @param onNavigationToTermMuting Lambda that's invoked when navigation to term muting settings is
- * requested to be performed.
+ *   requested to be performed.
  * @param onUnmute Callback run whenever one of the [mutedTerms] is requested to be unmuted.
- **/
+ */
 internal fun SettingsScope.muting(
-    mutedTerms: List<String>,
-    onNavigationToTermMuting: () -> Unit,
-    onUnmute: (term: String) -> Unit
+  mutedTerms: List<String>,
+  onNavigationToTermMuting: () -> Unit,
+  onUnmute: (term: String) -> Unit
 ) {
-    group(
-        icon = {
-            Icon(
-                OrcaTheme.iconography.mute.filled,
-                contentDescription = stringResource(R.string.settings_muting)
-            )
-        },
-        label = { Text(stringResource(R.string.settings_muting)) }
-    ) {
-        setting(
-            onClick = onNavigationToTermMuting,
-            label = { Text(stringResource(R.string.settings_add)) },
-            icon = {
-                Icon(
-                    OrcaTheme.iconography.add,
-                    contentDescription = stringResource(R.string.settings_add)
-                )
-            }
-        )
-        mutedTerms.forEach {
-            setting(label = { Text(it) }) {
-                button(
-                    contentDescription = { stringResource(R.string.settings_remove) },
-                    onClick = { onUnmute(it) }
-                ) {
-                    delete.filled
-                }
-            }
+  group(
+    icon = {
+      Icon(
+        OrcaTheme.iconography.mute.filled,
+        contentDescription = stringResource(R.string.settings_muting)
+      )
+    },
+    label = { Text(stringResource(R.string.settings_muting)) }
+  ) {
+    setting(
+      onClick = onNavigationToTermMuting,
+      label = { Text(stringResource(R.string.settings_add)) },
+      icon = {
+        Icon(OrcaTheme.iconography.add, contentDescription = stringResource(R.string.settings_add))
+      }
+    )
+    mutedTerms.forEach {
+      setting(label = { Text(it) }) {
+        button(
+          contentDescription = { stringResource(R.string.settings_remove) },
+          onClick = { onUnmute(it) }
+        ) {
+          delete.filled
         }
+      }
     }
+  }
 }

--- a/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/SettingsViewModel.kt
@@ -11,27 +11,19 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 internal class SettingsViewModel private constructor(private val termMuter: TermMuter) :
-    ViewModel() {
-    val mutedTermsFlow =
-        termMuter.getTerms().stateIn(
-            viewModelScope,
-            SharingStarted.WhileSubscribed(),
-            initialValue = emptyList()
-        )
+  ViewModel() {
+  val mutedTermsFlow =
+    termMuter
+      .getTerms()
+      .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), initialValue = emptyList())
 
-    fun unmute(term: String) {
-        viewModelScope.launch {
-            termMuter.unmute(term)
-        }
-    }
+  fun unmute(term: String) {
+    viewModelScope.launch { termMuter.unmute(term) }
+  }
 
-    companion object {
-        fun createFactory(termMuter: TermMuter): ViewModelProvider.Factory {
-            return viewModelFactory {
-                initializer {
-                    SettingsViewModel(termMuter)
-                }
-            }
-        }
+  companion object {
+    fun createFactory(termMuter: TermMuter): ViewModelProvider.Factory {
+      return viewModelFactory { initializer { SettingsViewModel(termMuter) } }
     }
+  }
 }

--- a/feature/settings/term-muting/build.gradle.kts
+++ b/feature/settings/term-muting/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 android {
     namespace = namespaceFor("feature.settings.termmuting")
     buildFeatures.compose = true
-    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.get()
 }
 
 dependencies {

--- a/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMuting.kt
+++ b/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMuting.kt
@@ -34,95 +34,89 @@ import com.jeanbarrossilva.orca.platform.ui.core.requestFocusWithDelay
 
 @Composable
 internal fun TermMuting(
-    viewModel: TermMutingViewModel,
-    boundary: TermMutingBoundary,
-    modifier: Modifier = Modifier
+  viewModel: TermMutingViewModel,
+  boundary: TermMutingBoundary,
+  modifier: Modifier = Modifier
 ) {
-    val term by viewModel.termFlow.collectAsState()
+  val term by viewModel.termFlow.collectAsState()
 
-    TermMuting(
-        term,
-        onTermChange = viewModel::setTerm,
-        onMute = viewModel::mute,
-        onPop = boundary::pop,
-        modifier
-    )
+  TermMuting(
+    term,
+    onTermChange = viewModel::setTerm,
+    onMute = viewModel::mute,
+    onPop = boundary::pop,
+    modifier
+  )
 }
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 private fun TermMuting(
-    term: String,
-    onTermChange: (term: String) -> Unit,
-    onMute: () -> Unit,
-    onPop: () -> Unit,
-    modifier: Modifier = Modifier
+  term: String,
+  onTermChange: (term: String) -> Unit,
+  onMute: () -> Unit,
+  onPop: () -> Unit,
+  modifier: Modifier = Modifier
 ) {
-    val topAppBarScrollBehavior = TopAppBarDefaults.scrollBehavior
-    val lazyListState = rememberLazyListState()
-    val spacing = OrcaTheme.spacings.medium
-    val focusRequester = remember(::FocusRequester)
-    val muteAndPop by rememberUpdatedState {
-        onMute()
-        onPop()
-    }
+  val topAppBarScrollBehavior = TopAppBarDefaults.scrollBehavior
+  val lazyListState = rememberLazyListState()
+  val spacing = OrcaTheme.spacings.medium
+  val focusRequester = remember(::FocusRequester)
+  val muteAndPop by rememberUpdatedState {
+    onMute()
+    onPop()
+  }
 
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocusWithDelay()
-    }
+  LaunchedEffect(Unit) { focusRequester.requestFocusWithDelay() }
 
-    Scaffold(
-        modifier,
-        topAppBar = {
-            TopAppBarWithBackNavigation(
-                onNavigation = onPop,
-                title = { Text(stringResource(R.string.settings_term_muting)) },
-                subtitle = { Text(stringResource(R.string.settings_term_muting_settings)) },
-                scrollBehavior = topAppBarScrollBehavior
-            )
-        },
-        buttonBar = {
-            ButtonBar(lazyListState) {
-                PrimaryButton(onClick = muteAndPop) {
-                    Text(stringResource(R.string.settings_term_muting_mute))
-                }
-            }
+  Scaffold(
+    modifier,
+    topAppBar = {
+      TopAppBarWithBackNavigation(
+        onNavigation = onPop,
+        title = { Text(stringResource(R.string.settings_term_muting)) },
+        subtitle = { Text(stringResource(R.string.settings_term_muting_settings)) },
+        scrollBehavior = topAppBarScrollBehavior
+      )
+    },
+    buttonBar = {
+      ButtonBar(lazyListState) {
+        PrimaryButton(onClick = muteAndPop) {
+          Text(stringResource(R.string.settings_term_muting_mute))
         }
+      }
+    }
+  ) {
+    LazyColumn(
+      Modifier.nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
+      lazyListState,
+      verticalArrangement = Arrangement.spacedBy(spacing),
+      contentPadding = it + PaddingValues(spacing)
     ) {
-        LazyColumn(
-            Modifier.nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
-            lazyListState,
-            verticalArrangement = Arrangement.spacedBy(spacing),
-            contentPadding = it + PaddingValues(spacing)
+      item {
+        TextField(
+          term,
+          onTermChange,
+          Modifier.focusRequester(focusRequester).fillMaxWidth(),
+          KeyboardOptions(imeAction = ImeAction.Done),
+          KeyboardActions(onDone = { muteAndPop() })
         ) {
-            item {
-                TextField(
-                    term,
-                    onTermChange,
-                    Modifier
-                        .focusRequester(focusRequester)
-                        .fillMaxWidth(),
-                    KeyboardOptions(imeAction = ImeAction.Done),
-                    KeyboardActions(onDone = { muteAndPop() })
-                ) {
-                    Text(stringResource(R.string.settings_term_muting_term))
-                }
-            }
-
-            item {
-                Text(
-                    stringResource(R.string.settings_term_muting_explanation),
-                    style = OrcaTheme.typography.bodySmall
-                )
-            }
+          Text(stringResource(R.string.settings_term_muting_term))
         }
+      }
+
+      item {
+        Text(
+          stringResource(R.string.settings_term_muting_explanation),
+          style = OrcaTheme.typography.bodySmall
+        )
+      }
     }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun TermMutingPreview() {
-    OrcaTheme {
-        TermMuting(term = "🐛", onTermChange = { }, onMute = { }, onPop = { })
-    }
+  OrcaTheme { TermMuting(term = "🐛", onTermChange = {}, onMute = {}, onPop = {}) }
 }

--- a/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMutingBoundary.kt
+++ b/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMutingBoundary.kt
@@ -1,5 +1,5 @@
 package com.jeanbarrossilva.orca.feature.settings.termmuting
 
 interface TermMutingBoundary {
-    fun pop()
+  fun pop()
 }

--- a/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMutingFragment.kt
+++ b/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMutingFragment.kt
@@ -8,21 +8,18 @@ import com.jeanbarrossilva.orca.platform.ui.core.navigation.transition.opening
 import com.jeanbarrossilva.orca.std.injector.Injector
 
 class TermMutingFragment internal constructor() : ComposableFragment() {
-    private val module by lazy { Injector.from<TermMutingModule>() }
-    private val viewModel by viewModels<TermMutingViewModel> {
-        TermMutingViewModel.createFactory(module.termMuter())
-    }
+  private val module by lazy { Injector.from<TermMutingModule>() }
+  private val viewModel by
+    viewModels<TermMutingViewModel> { TermMutingViewModel.createFactory(module.termMuter()) }
 
-    @Composable
-    override fun Content() {
-        TermMuting(viewModel, module.boundary())
-    }
+  @Composable
+  override fun Content() {
+    TermMuting(viewModel, module.boundary())
+  }
 
-    companion object {
-        fun navigate(navigator: Navigator) {
-            navigator.navigate(opening()) {
-                to("settings/term-muting", ::TermMutingFragment)
-            }
-        }
+  companion object {
+    fun navigate(navigator: Navigator) {
+      navigator.navigate(opening()) { to("settings/term-muting", ::TermMutingFragment) }
     }
+  }
 }

--- a/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMutingModule.kt
+++ b/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMutingModule.kt
@@ -5,6 +5,6 @@ import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
 
 abstract class TermMutingModule(
-    @Inject internal val termMuter: Module.() -> TermMuter,
-    @Inject internal val boundary: Module.() -> TermMutingBoundary
+  @Inject internal val termMuter: Module.() -> TermMuter,
+  @Inject internal val boundary: Module.() -> TermMutingBoundary
 ) : Module()

--- a/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMutingViewModel.kt
+++ b/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMutingViewModel.kt
@@ -11,28 +11,22 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 internal class TermMutingViewModel private constructor(private val termMuter: TermMuter) :
-    ViewModel() {
-    private val termMutableFlow = MutableStateFlow("")
+  ViewModel() {
+  private val termMutableFlow = MutableStateFlow("")
 
-    val termFlow = termMutableFlow.asStateFlow()
+  val termFlow = termMutableFlow.asStateFlow()
 
-    fun setTerm(term: String) {
-        termMutableFlow.value = term
+  fun setTerm(term: String) {
+    termMutableFlow.value = term
+  }
+
+  fun mute() {
+    viewModelScope.launch { termMuter.mute(termFlow.value) }
+  }
+
+  companion object {
+    fun createFactory(termMuter: TermMuter): ViewModelProvider.Factory {
+      return viewModelFactory { initializer { TermMutingViewModel(termMuter) } }
     }
-
-    fun mute() {
-        viewModelScope.launch {
-            termMuter.mute(termFlow.value)
-        }
-    }
-
-    companion object {
-        fun createFactory(termMuter: TermMuter): ViewModelProvider.Factory {
-            return viewModelFactory {
-                initializer {
-                    TermMutingViewModel(termMuter)
-                }
-            }
-        }
-    }
+  }
 }

--- a/feature/toot-details/build.gradle.kts
+++ b/feature/toot-details/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     buildFeatures.compose = true
-    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.get()
     namespace = namespaceFor("feature.tootdetails")
 }
 

--- a/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/Toot.extensions.kt
+++ b/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/Toot.extensions.kt
@@ -14,54 +14,54 @@ import kotlinx.coroutines.flow.combine
  * Converts this core [Toot] into a [Flow] of [TootDetails].
  *
  * @param colors [Colors] by which the emitted [TootDetails]' [TootDetails.text] can be colored.
- **/
+ */
 internal fun Toot.toTootDetailsFlow(colors: Colors): Flow<TootDetails> {
-    return combine(
-        comment.countFlow,
-        favorite.isEnabledFlow,
-        favorite.countFlow,
-        reblog.isEnabledFlow,
-        reblog.countFlow
-    ) { commentCount, isFavorite, favoriteCount, isReblogged, reblogCount ->
-        TootDetails(
-            id,
-            author.avatarURL,
-            author.name,
-            author.account,
-            content.text.toAnnotatedString(colors),
-            content.highlight,
-            publicationDateTime,
-            commentCount,
-            isFavorite,
-            favoriteCount,
-            isReblogged,
-            reblogCount,
-            url
-        )
-    }
+  return combine(
+    comment.countFlow,
+    favorite.isEnabledFlow,
+    favorite.countFlow,
+    reblog.isEnabledFlow,
+    reblog.countFlow
+  ) { commentCount, isFavorite, favoriteCount, isReblogged, reblogCount ->
+    TootDetails(
+      id,
+      author.avatarURL,
+      author.name,
+      author.account,
+      content.text.toAnnotatedString(colors),
+      content.highlight,
+      publicationDateTime,
+      commentCount,
+      isFavorite,
+      favoriteCount,
+      isReblogged,
+      reblogCount,
+      url
+    )
+  }
 }
 
-/** Converts this [Toot] into [TootDetails]. **/
+/** Converts this [Toot] into [TootDetails]. */
 @Composable
 internal fun Toot.toTootDetails(): TootDetails {
-    val commentCount by comment.countFlow.collectAsState()
-    val isFavorite by favorite.isEnabledFlow.collectAsState()
-    val favoriteCount by favorite.countFlow.collectAsState()
-    val isReblogged by reblog.isEnabledFlow.collectAsState()
-    val reblogCount by reblog.countFlow.collectAsState()
-    return TootDetails(
-        id,
-        author.avatarURL,
-        author.name,
-        author.account,
-        content.text.toAnnotatedString(OrcaTheme.colors),
-        content.highlight,
-        publicationDateTime,
-        commentCount,
-        isFavorite,
-        favoriteCount,
-        isReblogged,
-        reblogCount,
-        url
-    )
+  val commentCount by comment.countFlow.collectAsState()
+  val isFavorite by favorite.isEnabledFlow.collectAsState()
+  val favoriteCount by favorite.countFlow.collectAsState()
+  val isReblogged by reblog.isEnabledFlow.collectAsState()
+  val reblogCount by reblog.countFlow.collectAsState()
+  return TootDetails(
+    id,
+    author.avatarURL,
+    author.name,
+    author.account,
+    content.text.toAnnotatedString(OrcaTheme.colors),
+    content.highlight,
+    publicationDateTime,
+    commentCount,
+    isFavorite,
+    favoriteCount,
+    isReblogged,
+    reblogCount,
+    url
+  )
 }

--- a/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/TootDetails.kt
+++ b/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/TootDetails.kt
@@ -37,161 +37,154 @@ import java.time.ZonedDateTime
 
 @Immutable
 internal data class TootDetails(
-    val id: String,
-    val avatarURL: URL,
-    val name: String,
-    private val account: Account,
-    val text: AnnotatedString,
-    val highlight: Highlight?,
-    private val publicationDateTime: ZonedDateTime,
-    private val commentCount: Int,
-    val isFavorite: Boolean,
-    private val favoriteCount: Int,
-    val isReblogged: Boolean,
-    private val reblogCount: Int,
-    val url: URL
+  val id: String,
+  val avatarURL: URL,
+  val name: String,
+  private val account: Account,
+  val text: AnnotatedString,
+  val highlight: Highlight?,
+  private val publicationDateTime: ZonedDateTime,
+  private val commentCount: Int,
+  val isFavorite: Boolean,
+  private val favoriteCount: Int,
+  val isReblogged: Boolean,
+  private val reblogCount: Int,
+  val url: URL
 ) : Serializable {
-    val formattedPublicationDateTime = publicationDateTime.formatted
-    val formattedUsername = AccountFormatter.username(account)
-    val formattedCommentCount = commentCount.formatted
-    val formattedFavoriteCount = favoriteCount.formatted
-    val formattedReblogCount = reblogCount.formatted
+  val formattedPublicationDateTime = publicationDateTime.formatted
+  val formattedUsername = AccountFormatter.username(account)
+  val formattedCommentCount = commentCount.formatted
+  val formattedFavoriteCount = favoriteCount.formatted
+  val formattedReblogCount = reblogCount.formatted
 
-    companion object {
-        val sample
-            @Composable get() = Toot.sample.toTootDetails()
-    }
+  companion object {
+    val sample
+      @Composable get() = Toot.sample.toTootDetails()
+  }
 }
 
 @Composable
 internal fun TootDetails(
-    viewModel: TootDetailsViewModel,
-    boundary: TootDetailsBoundary,
-    onBottomAreaAvailabilityChangeListener: OnBottomAreaAvailabilityChangeListener,
-    modifier: Modifier = Modifier
+  viewModel: TootDetailsViewModel,
+  boundary: TootDetailsBoundary,
+  onBottomAreaAvailabilityChangeListener: OnBottomAreaAvailabilityChangeListener,
+  modifier: Modifier = Modifier
 ) {
-    val tootLoadable by viewModel.detailsLoadableFlow.collectAsState()
-    val commentsLoadable by viewModel.commentsLoadableFlow.collectAsState()
-    val bottomAreaAvailabilityNestedScrollConnection =
-        rememberBottomAreaAvailabilityNestedScrollConnection(onBottomAreaAvailabilityChangeListener)
+  val tootLoadable by viewModel.detailsLoadableFlow.collectAsState()
+  val commentsLoadable by viewModel.commentsLoadableFlow.collectAsState()
+  val bottomAreaAvailabilityNestedScrollConnection =
+    rememberBottomAreaAvailabilityNestedScrollConnection(onBottomAreaAvailabilityChangeListener)
 
-    TootDetails(
-        tootLoadable,
-        commentsLoadable,
-        onHighlightClick = boundary::navigateTo,
-        onFavorite = viewModel::favorite,
-        onReblog = viewModel::reblog,
-        onShare = viewModel::share,
-        onNavigateToDetails = boundary::navigateToTootDetails,
-        onNext = viewModel::loadCommentsAt,
-        onBackwardsNavigation = boundary::pop,
-        bottomAreaAvailabilityNestedScrollConnection,
-        modifier
-    )
+  TootDetails(
+    tootLoadable,
+    commentsLoadable,
+    onHighlightClick = boundary::navigateTo,
+    onFavorite = viewModel::favorite,
+    onReblog = viewModel::reblog,
+    onShare = viewModel::share,
+    onNavigateToDetails = boundary::navigateToTootDetails,
+    onNext = viewModel::loadCommentsAt,
+    onBackwardsNavigation = boundary::pop,
+    bottomAreaAvailabilityNestedScrollConnection,
+    modifier
+  )
 }
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 private fun TootDetails(
-    tootLoadable: Loadable<TootDetails>,
-    commentsLoadable: ListLoadable<TootPreview>,
-    onHighlightClick: (URL) -> Unit,
-    onFavorite: (tootID: String) -> Unit,
-    onReblog: (tootID: String) -> Unit,
-    onShare: (URL) -> Unit,
-    onNavigateToDetails: (tootID: String) -> Unit,
-    onNext: (index: Int) -> Unit,
-    onBackwardsNavigation: () -> Unit,
-    bottomAreaAvailabilityNestedScrollConnection: BottomAreaAvailabilityNestedScrollConnection,
-    modifier: Modifier = Modifier
+  tootLoadable: Loadable<TootDetails>,
+  commentsLoadable: ListLoadable<TootPreview>,
+  onHighlightClick: (URL) -> Unit,
+  onFavorite: (tootID: String) -> Unit,
+  onReblog: (tootID: String) -> Unit,
+  onShare: (URL) -> Unit,
+  onNavigateToDetails: (tootID: String) -> Unit,
+  onNext: (index: Int) -> Unit,
+  onBackwardsNavigation: () -> Unit,
+  bottomAreaAvailabilityNestedScrollConnection: BottomAreaAvailabilityNestedScrollConnection,
+  modifier: Modifier = Modifier
 ) {
-    val topAppBarScrollBehavior = TopAppBarDefaults.scrollBehavior
+  val topAppBarScrollBehavior = TopAppBarDefaults.scrollBehavior
 
-    Scaffold(
-        modifier,
-        topBar = {
-            @OptIn(ExperimentalMaterial3Api::class)
-            TopAppBarWithBackNavigation(
-                onNavigation = onBackwardsNavigation,
-                title = { AutoSizeText(stringResource(R.string.toot_details)) },
-                scrollBehavior = topAppBarScrollBehavior
-            )
-        }
-    ) {
-        Timeline(
-            commentsLoadable,
-            onHighlightClick,
-            onFavorite,
-            onReblog,
-            onShare,
-            onClick = onNavigateToDetails,
-            onNext,
-            Modifier
-                .nestedScroll(bottomAreaAvailabilityNestedScrollConnection)
-                .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
-            contentPadding = it
-        ) {
-            when (tootLoadable) {
-                is Loadable.Loading ->
-                    Header()
-                is Loadable.Loaded ->
-                    Header(
-                        tootLoadable.content,
-                        onHighlightClick = {
-                            tootLoadable.content.highlight?.url?.run(onHighlightClick)
-                        },
-                        onFavorite = { onFavorite(tootLoadable.content.id) },
-                        onReblog = { onReblog(tootLoadable.content.id) },
-                        onShare = { onShare(tootLoadable.content.url) }
-                    )
-                is Loadable.Failed ->
-                    Unit
-            }
-        }
+  Scaffold(
+    modifier,
+    topBar = {
+      @OptIn(ExperimentalMaterial3Api::class)
+      TopAppBarWithBackNavigation(
+        onNavigation = onBackwardsNavigation,
+        title = { AutoSizeText(stringResource(R.string.toot_details)) },
+        scrollBehavior = topAppBarScrollBehavior
+      )
     }
+  ) {
+    Timeline(
+      commentsLoadable,
+      onHighlightClick,
+      onFavorite,
+      onReblog,
+      onShare,
+      onClick = onNavigateToDetails,
+      onNext,
+      Modifier.nestedScroll(bottomAreaAvailabilityNestedScrollConnection)
+        .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
+      contentPadding = it
+    ) {
+      when (tootLoadable) {
+        is Loadable.Loading -> Header()
+        is Loadable.Loaded ->
+          Header(
+            tootLoadable.content,
+            onHighlightClick = { tootLoadable.content.highlight?.url?.run(onHighlightClick) },
+            onFavorite = { onFavorite(tootLoadable.content.id) },
+            onReblog = { onReblog(tootLoadable.content.id) },
+            onShare = { onShare(tootLoadable.content.url) }
+          )
+        is Loadable.Failed -> Unit
+      }
+    }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadingTootDetailsPreview() {
-    OrcaTheme {
-        TootDetails(Loadable.Loading(), commentsLoadable = ListLoadable.Loading())
-    }
+  OrcaTheme { TootDetails(Loadable.Loading(), commentsLoadable = ListLoadable.Loading()) }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadedTootDetailsWithoutComments() {
-    OrcaTheme {
-        TootDetails(Loadable.Loaded(TootDetails.sample), commentsLoadable = ListLoadable.Empty())
-    }
+  OrcaTheme {
+    TootDetails(Loadable.Loaded(TootDetails.sample), commentsLoadable = ListLoadable.Empty())
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadedTootDetailsPreview() {
-    OrcaTheme {
-        TootDetails(Loadable.Loaded(TootDetails.sample), commentsLoadable = ListLoadable.Loading())
-    }
+  OrcaTheme {
+    TootDetails(Loadable.Loaded(TootDetails.sample), commentsLoadable = ListLoadable.Loading())
+  }
 }
 
 @Composable
 private fun TootDetails(
-    tootLoadable: Loadable<TootDetails>,
-    commentsLoadable: ListLoadable<TootPreview>,
-    modifier: Modifier = Modifier
+  tootLoadable: Loadable<TootDetails>,
+  commentsLoadable: ListLoadable<TootPreview>,
+  modifier: Modifier = Modifier
 ) {
-    TootDetails(
-        tootLoadable,
-        commentsLoadable,
-        onHighlightClick = { },
-        onFavorite = { },
-        onReblog = { },
-        onShare = { },
-        onNavigateToDetails = { },
-        onNext = { },
-        onBackwardsNavigation = { },
-        BottomAreaAvailabilityNestedScrollConnection.empty,
-        modifier
-    )
+  TootDetails(
+    tootLoadable,
+    commentsLoadable,
+    onHighlightClick = {},
+    onFavorite = {},
+    onReblog = {},
+    onShare = {},
+    onNavigateToDetails = {},
+    onNext = {},
+    onBackwardsNavigation = {},
+    BottomAreaAvailabilityNestedScrollConnection.empty,
+    modifier
+  )
 }

--- a/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/TootDetailsBoundary.kt
+++ b/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/TootDetailsBoundary.kt
@@ -3,9 +3,9 @@ package com.jeanbarrossilva.orca.feature.tootdetails
 import java.net.URL
 
 interface TootDetailsBoundary {
-    fun navigateTo(url: URL)
+  fun navigateTo(url: URL)
 
-    fun navigateToTootDetails(id: String)
+  fun navigateToTootDetails(id: String)
 
-    fun pop()
+  fun pop()
 }

--- a/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/TootDetailsFragment.kt
+++ b/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/TootDetailsFragment.kt
@@ -11,35 +11,35 @@ import com.jeanbarrossilva.orca.platform.ui.core.navigation.transition.opening
 import com.jeanbarrossilva.orca.std.injector.Injector
 
 class TootDetailsFragment private constructor() : ComposableFragment() {
-    private val module by lazy { Injector.from<TootDetailsModule>() }
-    private val id by argument<String>(ID_KEY)
-    private val viewModel by viewModels<TootDetailsViewModel> {
-        TootDetailsViewModel
-            .createFactory(contextProvider = ::requireContext, module.tootProvider(), id)
+  private val module by lazy { Injector.from<TootDetailsModule>() }
+  private val id by argument<String>(ID_KEY)
+  private val viewModel by
+    viewModels<TootDetailsViewModel> {
+      TootDetailsViewModel.createFactory(
+        contextProvider = ::requireContext,
+        module.tootProvider(),
+        id
+      )
     }
 
-    private constructor(id: String) : this() {
-        arguments = bundleOf(ID_KEY to id)
+  private constructor(id: String) : this() {
+    arguments = bundleOf(ID_KEY to id)
+  }
+
+  @Composable
+  override fun Content() {
+    TootDetails(viewModel, module.boundary(), module.onBottomAreaAvailabilityChangeListener())
+  }
+
+  companion object {
+    private const val ID_KEY = "id"
+
+    fun getRoute(id: String): String {
+      return "toot/$id"
     }
 
-    @Composable
-    override fun Content() {
-        TootDetails(viewModel, module.boundary(), module.onBottomAreaAvailabilityChangeListener())
+    fun navigate(navigator: Navigator, id: String) {
+      navigator.navigate(opening()) { to(getRoute(id)) { TootDetailsFragment(id) } }
     }
-
-    companion object {
-        private const val ID_KEY = "id"
-
-        fun getRoute(id: String): String {
-            return "toot/$id"
-        }
-
-        fun navigate(navigator: Navigator, id: String) {
-            navigator.navigate(opening()) {
-                to(getRoute(id)) {
-                    TootDetailsFragment(id)
-                }
-            }
-        }
-    }
+  }
 }

--- a/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/TootDetailsModule.kt
+++ b/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/TootDetailsModule.kt
@@ -6,8 +6,9 @@ import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
 
 abstract class TootDetailsModule(
-    @Inject internal val tootProvider: Module.() -> TootProvider,
-    @Inject internal val boundary: Module.() -> TootDetailsBoundary,
-    @Inject internal val onBottomAreaAvailabilityChangeListener:
+  @Inject internal val tootProvider: Module.() -> TootProvider,
+  @Inject internal val boundary: Module.() -> TootDetailsBoundary,
+  @Inject
+  internal val onBottomAreaAvailabilityChangeListener:
     Module.() -> OnBottomAreaAvailabilityChangeListener
 ) : Module()

--- a/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/ui/header/Header.Stat.kt
+++ b/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/ui/header/Header.Stat.kt
@@ -18,40 +18,40 @@ import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
 import com.jeanbarrossilva.orca.platform.theme.kit.action.Hoverable
 
 internal object StatDefaults {
-    val contentColor
-        @Composable get() = OrcaTheme.colors.secondary
+  val contentColor
+    @Composable get() = OrcaTheme.colors.secondary
 }
 
 @Composable
 internal fun Stat(
-    modifier: Modifier = Modifier,
-    contentColor: Color = StatDefaults.contentColor,
-    content: @Composable RowScope.() -> Unit
+  modifier: Modifier = Modifier,
+  contentColor: Color = StatDefaults.contentColor,
+  content: @Composable RowScope.() -> Unit
 ) {
-    Hoverable(modifier) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.small),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            CompositionLocalProvider(
-                LocalContentColor provides contentColor,
-                LocalTextStyle provides OrcaTheme.typography.bodySmall.copy(color = contentColor)
-            ) {
-                content()
-            }
-        }
+  Hoverable(modifier) {
+    Row(
+      horizontalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.small),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      CompositionLocalProvider(
+        LocalContentColor provides contentColor,
+        LocalTextStyle provides OrcaTheme.typography.bodySmall.copy(color = contentColor)
+      ) {
+        content()
+      }
     }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun StatPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            Stat {
-                Icon(OrcaTheme.iconography.comment.outlined, contentDescription = "Comments")
-                Text("8")
-            }
-        }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) {
+      Stat {
+        Icon(OrcaTheme.iconography.comment.outlined, contentDescription = "Comments")
+        Text("8")
+      }
     }
+  }
 }

--- a/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/ui/header/Header.kt
+++ b/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/ui/header/Header.kt
@@ -32,143 +32,133 @@ import com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.headline.Hea
 
 @Composable
 internal fun Header(modifier: Modifier = Modifier) {
-    Header(
-        avatar = { SmallAvatar() },
-        name = { SmallTextualPlaceholder() },
-        username = { MediumTextualPlaceholder() },
-        content = {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.extraSmall)
-            ) {
-                repeat(3) { LargeTextualPlaceholder() }
-                MediumTextualPlaceholder()
-            }
-        },
-        metadata = { SmallTextualPlaceholder() },
-        stats = { },
-        modifier
-    )
+  Header(
+    avatar = { SmallAvatar() },
+    name = { SmallTextualPlaceholder() },
+    username = { MediumTextualPlaceholder() },
+    content = {
+      Column(verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.extraSmall)) {
+        repeat(3) { LargeTextualPlaceholder() }
+        MediumTextualPlaceholder()
+      }
+    },
+    metadata = { SmallTextualPlaceholder() },
+    stats = {},
+    modifier
+  )
 }
 
 @Composable
 internal fun Header(
-    details: TootDetails,
-    onHighlightClick: () -> Unit,
-    onFavorite: () -> Unit,
-    onReblog: () -> Unit,
-    onShare: () -> Unit,
-    modifier: Modifier = Modifier
+  details: TootDetails,
+  onHighlightClick: () -> Unit,
+  onFavorite: () -> Unit,
+  onReblog: () -> Unit,
+  onShare: () -> Unit,
+  modifier: Modifier = Modifier
 ) {
-    Header(
-        avatar = { SmallAvatar(details.name, details.avatarURL) },
-        name = { Text(details.name) },
-        username = { Text(details.formattedUsername) },
-        content = {
-            Column(verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.medium)) {
-                Text(details.text)
+  Header(
+    avatar = { SmallAvatar(details.name, details.avatarURL) },
+    name = { Text(details.name) },
+    username = { Text(details.formattedUsername) },
+    content = {
+      Column(verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.medium)) {
+        Text(details.text)
 
-                details.highlight?.headline?.let {
-                    HeadlineCard(it, onHighlightClick)
-                }
-            }
-        },
-        metadata = { Text(details.formattedPublicationDateTime) },
-        stats = {
-            Divider()
+        details.highlight?.headline?.let { HeadlineCard(it, onHighlightClick) }
+      }
+    },
+    metadata = { Text(details.formattedPublicationDateTime) },
+    stats = {
+      Divider()
 
-            Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween) {
-                Stat {
-                    Icon(
-                        OrcaTheme.iconography.comment.outlined,
-                        contentDescription = stringResource(R.string.toot_details_comments)
-                    )
-                    Text(details.formattedCommentCount)
-                }
+      Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween) {
+        Stat {
+          Icon(
+            OrcaTheme.iconography.comment.outlined,
+            contentDescription = stringResource(R.string.toot_details_comments)
+          )
+          Text(details.formattedCommentCount)
+        }
 
-                FavoriteStat(details, onClick = onFavorite)
-                ReblogStat(details, onClick = onReblog)
+        FavoriteStat(details, onClick = onFavorite)
+        ReblogStat(details, onClick = onReblog)
 
-                Stat {
-                    Icon(
-                        OrcaTheme.iconography.share.outlined,
-                        contentDescription = stringResource(R.string.toot_details_share),
-                        Modifier.clickable(
-                            remember(::MutableInteractionSource),
-                            indication = null,
-                            onClick = onShare
-                        )
-                    )
-                }
-            }
+        Stat {
+          Icon(
+            OrcaTheme.iconography.share.outlined,
+            contentDescription = stringResource(R.string.toot_details_share),
+            Modifier.clickable(
+              remember(::MutableInteractionSource),
+              indication = null,
+              onClick = onShare
+            )
+          )
+        }
+      }
 
-            Divider()
-        },
-        modifier
-    )
+      Divider()
+    },
+    modifier
+  )
 }
 
 @Composable
 private fun Header(
-    avatar: @Composable () -> Unit,
-    name: @Composable () -> Unit,
-    username: @Composable () -> Unit,
-    content: @Composable () -> Unit,
-    metadata: @Composable () -> Unit,
-    stats: @Composable ColumnScope.() -> Unit,
-    modifier: Modifier = Modifier
+  avatar: @Composable () -> Unit,
+  name: @Composable () -> Unit,
+  username: @Composable () -> Unit,
+  content: @Composable () -> Unit,
+  metadata: @Composable () -> Unit,
+  stats: @Composable ColumnScope.() -> Unit,
+  modifier: Modifier = Modifier
 ) {
-    val spacing = OrcaTheme.spacings.large
+  val spacing = OrcaTheme.spacings.large
 
-    Column(modifier.padding(spacing), Arrangement.spacedBy(spacing)) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(spacing),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            avatar()
+  Column(modifier.padding(spacing), Arrangement.spacedBy(spacing)) {
+    Row(
+      horizontalArrangement = Arrangement.spacedBy(spacing),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      avatar()
 
-            Column(
-                verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.extraSmall)
-            ) {
-                ProvideTextStyle(OrcaTheme.typography.bodyLarge, name)
-                ProvideTextStyle(OrcaTheme.typography.bodySmall, username)
-            }
-        }
-
-        Column(verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.medium)) {
-            content()
-            ProvideTextStyle(OrcaTheme.typography.bodySmall, metadata)
-        }
-
-        Column(
-            verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.medium),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            content = stats
-        )
+      Column(verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.extraSmall)) {
+        ProvideTextStyle(OrcaTheme.typography.bodyLarge, name)
+        ProvideTextStyle(OrcaTheme.typography.bodySmall, username)
+      }
     }
+
+    Column(verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.medium)) {
+      content()
+      ProvideTextStyle(OrcaTheme.typography.bodySmall, metadata)
+    }
+
+    Column(
+      verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.medium),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      content = stats
+    )
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadingHeaderPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            Header()
-        }
-    }
+  OrcaTheme { Surface(color = OrcaTheme.colors.background.container) { Header() } }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadedHeaderPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            Header(
-                TootDetails.sample,
-                onHighlightClick = { },
-                onFavorite = { },
-                onReblog = { },
-                onShare = { }
-            )
-        }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) {
+      Header(
+        TootDetails.sample,
+        onHighlightClick = {},
+        onFavorite = {},
+        onReblog = {},
+        onShare = {}
+      )
     }
+  }
 }

--- a/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/ui/header/ZonedDateTime.extensions.kt
+++ b/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/ui/header/ZonedDateTime.extensions.kt
@@ -6,11 +6,11 @@ import java.time.ZonedDateTime
 import java.util.Date
 
 internal val ZonedDateTime.formatted: String
-    get() = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(toDate())
+  get() = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(toDate())
 
-/** Converts this [ZonedDateTime] into a [Date]. **/
+/** Converts this [ZonedDateTime] into a [Date]. */
 private fun ZonedDateTime.toDate(): Date {
-    val epochSecond = toEpochSecond()
-    val instant = Instant.ofEpochSecond(epochSecond)
-    return Date.from(instant)
+  val epochSecond = toEpochSecond()
+  val instant = Instant.ofEpochSecond(epochSecond)
+  return Date.from(instant)
 }

--- a/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/ui/header/stat/Header.Stat.Favorite.kt
+++ b/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/ui/header/stat/Header.Stat.Favorite.kt
@@ -18,39 +18,36 @@ import com.jeanbarrossilva.orca.platform.ui.component.stat.favorite.FavoriteStat
 
 @Composable
 internal fun FavoriteStat(
-    details: TootDetails,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
+  details: TootDetails,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier
 ) {
-    val isActive = remember(details, details::isFavorite)
-    val contentColor by animateColorAsState(
-        if (isActive) OrcaTheme.colors.activation.favorite else StatDefaults.contentColor,
-        label = "ContentColor"
+  val isActive = remember(details, details::isFavorite)
+  val contentColor by
+    animateColorAsState(
+      if (isActive) OrcaTheme.colors.activation.favorite else StatDefaults.contentColor,
+      label = "ContentColor"
     )
 
-    Stat(contentColor = contentColor) {
-        FavoriteStatIcon(
-            isActive,
-            ActivateableStatIconInteractiveness.Interactive { onClick() },
-            modifier.size(24.dp)
-        )
+  Stat(contentColor = contentColor) {
+    FavoriteStatIcon(
+      isActive,
+      ActivateableStatIconInteractiveness.Interactive { onClick() },
+      modifier.size(24.dp)
+    )
 
-        Text(details.formattedFavoriteCount)
-    }
+    Text(details.formattedFavoriteCount)
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun InactiveFavoriteStatPreview() {
-    OrcaTheme {
-        FavoriteStat(TootDetails.sample.copy(isFavorite = false), onClick = { })
-    }
+  OrcaTheme { FavoriteStat(TootDetails.sample.copy(isFavorite = false), onClick = {}) }
 }
 
 @Composable
 @MultiThemePreview
 private fun ActiveFavoriteStatPreview() {
-    OrcaTheme {
-        FavoriteStat(TootDetails.sample.copy(isFavorite = true), onClick = { })
-    }
+  OrcaTheme { FavoriteStat(TootDetails.sample.copy(isFavorite = true), onClick = {}) }
 }

--- a/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/ui/header/stat/Header.Stat.Reblog.kt
+++ b/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/ui/header/stat/Header.Stat.Reblog.kt
@@ -17,40 +17,33 @@ import com.jeanbarrossilva.orca.platform.ui.component.stat.ActivateableStatIconI
 import com.jeanbarrossilva.orca.platform.ui.component.stat.reblog.ReblogStatIcon
 
 @Composable
-internal fun ReblogStat(
-    details: TootDetails,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val isActive = remember(details, details::isReblogged)
-    val contentColor by animateColorAsState(
-        if (isActive) OrcaTheme.colors.activation.reblog else StatDefaults.contentColor,
-        label = "ContentColor"
+internal fun ReblogStat(details: TootDetails, onClick: () -> Unit, modifier: Modifier = Modifier) {
+  val isActive = remember(details, details::isReblogged)
+  val contentColor by
+    animateColorAsState(
+      if (isActive) OrcaTheme.colors.activation.reblog else StatDefaults.contentColor,
+      label = "ContentColor"
     )
 
-    Stat(contentColor = contentColor) {
-        ReblogStatIcon(
-            isActive,
-            ActivateableStatIconInteractiveness.Interactive { onClick() },
-            modifier.size(24.dp)
-        )
+  Stat(contentColor = contentColor) {
+    ReblogStatIcon(
+      isActive,
+      ActivateableStatIconInteractiveness.Interactive { onClick() },
+      modifier.size(24.dp)
+    )
 
-        Text(details.formattedReblogCount)
-    }
+    Text(details.formattedReblogCount)
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun InactiveReblogStatPreview() {
-    OrcaTheme {
-        ReblogStat(TootDetails.sample.copy(isReblogged = false), onClick = { })
-    }
+  OrcaTheme { ReblogStat(TootDetails.sample.copy(isReblogged = false), onClick = {}) }
 }
 
 @Composable
 @MultiThemePreview
 private fun ActiveReblogStatPreview() {
-    OrcaTheme {
-        ReblogStat(TootDetails.sample.copy(isReblogged = true), onClick = { })
-    }
+  OrcaTheme { ReblogStat(TootDetails.sample.copy(isReblogged = true), onClick = {}) }
 }

--- a/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/viewmodel/Flow.extensions.kt
+++ b/feature/toot-details/src/main/java/com/jeanbarrossilva/orca/feature/tootdetails/viewmodel/Flow.extensions.kt
@@ -11,14 +11,13 @@ import kotlinx.coroutines.flow.flow
  * @param firstFlow [Flow] to be [combine]d with [secondFlow].
  * @param secondFlow [Flow] to be [combine]d with [firstFlow].
  * @param transform Creates a [Flow] based on [firstFlow]'s and [secondFlow]'s emissions.
- **/
+ */
 internal fun <F, S, O> flatMapCombine(
-    firstFlow: Flow<F>,
-    secondFlow: Flow<S>,
-    transform: suspend (F, S) -> Flow<O>
+  firstFlow: Flow<F>,
+  secondFlow: Flow<S>,
+  transform: suspend (F, S) -> Flow<O>
 ): Flow<O> {
-    return flow {
-        combine(firstFlow, secondFlow) { first, second -> transform(first, second) }
-            .collect(::emitAll)
-    }
+  return flow {
+    combine(firstFlow, secondFlow) { first, second -> transform(first, second) }.collect(::emitAll)
+  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 project.namespace=com.jeanbarrossilva.orca

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,8 +59,8 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-symbolProcessor = { id = "com.google.devtools.ksp", version.ref = "kotlin-symbolProcessor" }
-ktfmtGradle = { id = "com.ncorti.ktfmt.gradle", version = "0.14.0" }
 moduleDependencyGraph = { id = "com.savvasdalkitsis.module-dependency-graph", version = "0.10" }
+spotless = { id = "com.diffplug.spotless", version = "6.22.0" }
 
 [versions]
 android-activity = "1.7.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,21 +59,21 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-symbolProcessor = { id = "com.google.devtools.ksp", version.ref = "kotlin-symbolProcessor" }
+ktfmtGradle = { id = "com.ncorti.ktfmt.gradle", version = "0.14.0" }
 moduleDependencyGraph = { id = "com.savvasdalkitsis.module-dependency-graph", version = "0.10" }
 
 [versions]
 android-activity = "1.7.2"
-android-compose = "1.5.1"
-android-compose-compiler = "1.4.7"
+android-compose = "1.5.3"
 android-fragment = "1.6.1"
 android-plugin = "8.1.2"
 android-room = "2.5.2"
 android-sdk-min = "28"
 android-sdk-target = "34"
 java = "17"
-kotlin = "1.8.21"
+kotlin = "1.9.10"
 kotlin-coroutines = "1.7.2"
-kotlin-symbolProcessor = "1.8.21-1.0.11"
+kotlin-symbolProcessor = "1.9.10-1.0.13"
 kotlinPoet = "1.14.2"
 ktor = "2.3.2"
 loadable = "1.6.9"

--- a/platform/cache/src/androidTest/java/com/jeanbarrossilva/orca/platform/cache/CacheTests.kt
+++ b/platform/cache/src/androidTest/java/com/jeanbarrossilva/orca/platform/cache/CacheTests.kt
@@ -17,98 +17,91 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 
 internal class CacheTests {
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private val coroutineScope = TestScope(UnconfinedTestDispatcher())
+  @OptIn(ExperimentalCoroutinesApi::class)
+  private val coroutineScope = TestScope(UnconfinedTestDispatcher())
 
-    @get:Rule
-    val cacheRule = CacheTestRule(coroutineScope)
+  @get:Rule val cacheRule = CacheTestRule(coroutineScope)
 
-    @Test
-    fun fetchesWhenValueIsObtainedForTheFirstTime() {
-        val fetcher = spyk(TestFetcher())
-        coroutineScope.runTest {
-            cacheRule.cache.fetchingWith(fetcher).get("0")
-            coVerify { fetcher.fetch("0") }
-        }
+  @Test
+  fun fetchesWhenValueIsObtainedForTheFirstTime() {
+    val fetcher = spyk(TestFetcher())
+    coroutineScope.runTest {
+      cacheRule.cache.fetchingWith(fetcher).get("0")
+      coVerify { fetcher.fetch("0") }
     }
+  }
 
-    @Test
-    fun remembersValueWhenItIsObtainedForTheFirstTime() {
-        val storage = TestStorage()
-        coroutineScope.runTest {
-            val value = cacheRule.cache.storingTo(storage).get("0")
-            assertEquals(value, storage.get("0"))
-        }
+  @Test
+  fun remembersValueWhenItIsObtainedForTheFirstTime() {
+    val storage = TestStorage()
+    coroutineScope.runTest {
+      val value = cacheRule.cache.storingTo(storage).get("0")
+      assertEquals(value, storage.get("0"))
     }
+  }
 
-    @Test
-    fun obtainsRememberedValueWhenItIsReadBeforeTimeToIdle() {
-        val fetcher = spyk(TestFetcher())
-        val storage = spyk(TestStorage())
-        val cache =
-            cacheRule.cache.storingTo(storage).fetchingWith(fetcher).idlingFor(1.days).livingFor(
-                1.days
-            )
-        coroutineScope.runTest {
-            cache.get("0")
+  @Test
+  fun obtainsRememberedValueWhenItIsReadBeforeTimeToIdle() {
+    val fetcher = spyk(TestFetcher())
+    val storage = spyk(TestStorage())
+    val cache =
+      cacheRule.cache.storingTo(storage).fetchingWith(fetcher).idlingFor(1.days).livingFor(1.days)
+    coroutineScope.runTest {
+      cache.get("0")
 
-            @OptIn(ExperimentalCoroutinesApi::class)
-            advanceTimeBy(23.hours)
+      @OptIn(ExperimentalCoroutinesApi::class) advanceTimeBy(23.hours)
 
-            cache.get("0")
-            coVerify { fetcher.fetch("0") }
-            coVerify { storage.get("0") }
-        }
+      cache.get("0")
+      coVerify { fetcher.fetch("0") }
+      coVerify { storage.get("0") }
     }
+  }
 
-    @Test
-    fun remembersValueAgainWhenItIsObtainedAfterTimeToIdle() {
-        val fetcher = spyk(TestFetcher())
-        val storage = spyk(TestStorage())
-        val cache = cacheRule.cache.storingTo(storage).fetchingWith(fetcher).idlingFor(1.days)
-        coroutineScope.runTest {
-            cache.get("0")
+  @Test
+  fun remembersValueAgainWhenItIsObtainedAfterTimeToIdle() {
+    val fetcher = spyk(TestFetcher())
+    val storage = spyk(TestStorage())
+    val cache = cacheRule.cache.storingTo(storage).fetchingWith(fetcher).idlingFor(1.days)
+    coroutineScope.runTest {
+      cache.get("0")
 
-            @OptIn(ExperimentalCoroutinesApi::class)
-            advanceTimeBy(25.hours)
+      @OptIn(ExperimentalCoroutinesApi::class) advanceTimeBy(25.hours)
 
-            cache.get("0")
-            coVerify(exactly = 2) { fetcher.fetch("0") }
-            coVerify(exactly = 2) { storage.store("0", TestFetcher.FETCHED.first()) }
-        }
+      cache.get("0")
+      coVerify(exactly = 2) { fetcher.fetch("0") }
+      coVerify(exactly = 2) { storage.store("0", TestFetcher.FETCHED.first()) }
     }
+  }
 
-    @Test
-    fun obtainsRememberedValueWhenItIsReadBeforeTimeToLive() {
-        val fetcher = spyk(TestFetcher())
-        val storage = spyk(TestStorage())
-        val cache = cacheRule.cache.storingTo(storage).fetchingWith(fetcher).livingFor(1.days)
-        coroutineScope.runTest {
-            cache.get("0")
+  @Test
+  fun obtainsRememberedValueWhenItIsReadBeforeTimeToLive() {
+    val fetcher = spyk(TestFetcher())
+    val storage = spyk(TestStorage())
+    val cache = cacheRule.cache.storingTo(storage).fetchingWith(fetcher).livingFor(1.days)
+    coroutineScope.runTest {
+      cache.get("0")
 
-            @OptIn(ExperimentalCoroutinesApi::class)
-            advanceTimeBy(23.hours)
+      @OptIn(ExperimentalCoroutinesApi::class) advanceTimeBy(23.hours)
 
-            cache.get("0")
-            coVerify { fetcher.fetch("0") }
-            coVerify { storage.get("0") }
-        }
+      cache.get("0")
+      coVerify { fetcher.fetch("0") }
+      coVerify { storage.get("0") }
     }
+  }
 
-    @Test
-    fun remembersValueAgainWhenItIsObtainedAfterTimeToLive() {
-        val fetcher = spyk(TestFetcher())
-        val storage = spyk(TestStorage())
-        val cache = cacheRule.cache.storingTo(storage).fetchingWith(fetcher).livingFor(1.days)
-        coroutineScope.runTest {
-            cache.get("0")
+  @Test
+  fun remembersValueAgainWhenItIsObtainedAfterTimeToLive() {
+    val fetcher = spyk(TestFetcher())
+    val storage = spyk(TestStorage())
+    val cache = cacheRule.cache.storingTo(storage).fetchingWith(fetcher).livingFor(1.days)
+    coroutineScope.runTest {
+      cache.get("0")
 
-            @OptIn(ExperimentalCoroutinesApi::class)
-            advanceTimeBy(25.hours)
+      @OptIn(ExperimentalCoroutinesApi::class) advanceTimeBy(25.hours)
 
-            cache.get("0")
-            coVerify(exactly = 2) { fetcher.fetch("0") }
-            coVerify(exactly = 2) { storage.store("0", TestFetcher.FETCHED.first()) }
-        }
+      cache.get("0")
+      coVerify(exactly = 2) { fetcher.fetch("0") }
+      coVerify(exactly = 2) { storage.store("0", TestFetcher.FETCHED.first()) }
     }
+  }
 }

--- a/platform/cache/src/androidTest/java/com/jeanbarrossilva/orca/platform/cache/test/CacheTestRule.kt
+++ b/platform/cache/src/androidTest/java/com/jeanbarrossilva/orca/platform/cache/test/CacheTestRule.kt
@@ -8,18 +8,16 @@ import kotlinx.coroutines.test.TestScope
 import org.junit.rules.ExternalResource
 
 internal class CacheTestRule(private val coroutineScope: TestScope) : ExternalResource() {
-    private lateinit var database: CacheDatabase
+  private lateinit var database: CacheDatabase
 
-    val cache = TestCache(coroutineScope.testScheduler, ::database)
+  val cache = TestCache(coroutineScope.testScheduler, ::database)
 
-    override fun before() {
-        val context = InstrumentationRegistry.getInstrumentation().context
-        database = Room.databaseBuilder(context, CacheDatabase::class.java, TestCache.NAME).build()
-    }
+  override fun before() {
+    val context = InstrumentationRegistry.getInstrumentation().context
+    database = Room.databaseBuilder(context, CacheDatabase::class.java, TestCache.NAME).build()
+  }
 
-    override fun after() {
-        coroutineScope.launch {
-            cache.terminate()
-        }
-    }
+  override fun after() {
+    coroutineScope.launch { cache.terminate() }
+  }
 }

--- a/platform/cache/src/androidTest/java/com/jeanbarrossilva/orca/platform/cache/test/TestCache.kt
+++ b/platform/cache/src/androidTest/java/com/jeanbarrossilva/orca/platform/cache/test/TestCache.kt
@@ -11,51 +11,42 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScheduler
 
 internal class TestCache(
-    private val coroutineScheduler: TestCoroutineScheduler,
-    override val databaseProvider: CacheDatabase.Provider
+  private val coroutineScheduler: TestCoroutineScheduler,
+  override val databaseProvider: CacheDatabase.Provider
 ) : Cache<Char>(InstrumentationRegistry.getInstrumentation().context, NAME) {
-    override var fetcher = TestFetcher()
-        private set
+  override var fetcher = TestFetcher()
+    private set
 
-    override var storage = TestStorage()
-        private set
+  override var storage = TestStorage()
+    private set
 
-    override var timeToIdle = 1.days
-        private set
+  override var timeToIdle = 1.days
+    private set
 
-    override var timeToLive = 30.minutes
-        private set
+  override var timeToLive = 30.minutes
+    private set
 
-    override val elapsedTimeProvider = ElapsedTimeProvider {
-        @OptIn(ExperimentalCoroutinesApi::class)
-        coroutineScheduler.currentTime.milliseconds
-    }
+  override val elapsedTimeProvider = ElapsedTimeProvider {
+    @OptIn(ExperimentalCoroutinesApi::class) coroutineScheduler.currentTime.milliseconds
+  }
 
-    fun fetchingWith(fetcher: TestFetcher): TestCache {
-        return apply {
-            this.fetcher = fetcher
-        }
-    }
+  fun fetchingWith(fetcher: TestFetcher): TestCache {
+    return apply { this.fetcher = fetcher }
+  }
 
-    fun storingTo(storage: TestStorage): TestCache {
-        return apply {
-            this.storage = storage
-        }
-    }
+  fun storingTo(storage: TestStorage): TestCache {
+    return apply { this.storage = storage }
+  }
 
-    fun idlingFor(timeToIdle: Duration): TestCache {
-        return apply {
-            this.timeToIdle = timeToIdle
-        }
-    }
+  fun idlingFor(timeToIdle: Duration): TestCache {
+    return apply { this.timeToIdle = timeToIdle }
+  }
 
-    fun livingFor(timeToLive: Duration): TestCache {
-        return apply {
-            this.timeToLive = timeToLive
-        }
-    }
+  fun livingFor(timeToLive: Duration): TestCache {
+    return apply { this.timeToLive = timeToLive }
+  }
 
-    companion object {
-        const val NAME = "test-cache"
-    }
+  companion object {
+    const val NAME = "test-cache"
+  }
 }

--- a/platform/cache/src/androidTest/java/com/jeanbarrossilva/orca/platform/cache/test/TestFetcher.kt
+++ b/platform/cache/src/androidTest/java/com/jeanbarrossilva/orca/platform/cache/test/TestFetcher.kt
@@ -3,11 +3,11 @@ package com.jeanbarrossilva.orca.platform.cache.test
 import com.jeanbarrossilva.orca.platform.cache.Fetcher
 
 internal class TestFetcher : Fetcher<Char>() {
-    override suspend fun onFetch(key: String): Char {
-        return FETCHED[key.toInt()]
-    }
+  override suspend fun onFetch(key: String): Char {
+    return FETCHED[key.toInt()]
+  }
 
-    companion object {
-        const val FETCHED = "Hello, world!"
-    }
+  companion object {
+    const val FETCHED = "Hello, world!"
+  }
 }

--- a/platform/cache/src/androidTest/java/com/jeanbarrossilva/orca/platform/cache/test/TestStorage.kt
+++ b/platform/cache/src/androidTest/java/com/jeanbarrossilva/orca/platform/cache/test/TestStorage.kt
@@ -3,30 +3,30 @@ package com.jeanbarrossilva.orca.platform.cache.test
 import com.jeanbarrossilva.orca.platform.cache.Storage
 
 internal class TestStorage : Storage<Char>() {
-    private var stored = ""
+  private var stored = ""
 
-    override suspend fun onStore(key: String, value: Char) {
-        val index = key.toInt()
-        stored = buildString {
-            append(stored)
-            insert(index, value)
-        }
+  override suspend fun onStore(key: String, value: Char) {
+    val index = key.toInt()
+    stored = buildString {
+      append(stored)
+      insert(index, value)
     }
+  }
 
-    override suspend fun onContains(key: String): Boolean {
-        return stored.isNotEmpty() && key.toInt() in 0..stored.lastIndex
-    }
+  override suspend fun onContains(key: String): Boolean {
+    return stored.isNotEmpty() && key.toInt() in 0..stored.lastIndex
+  }
 
-    override suspend fun onGet(key: String): Char {
-        return stored[key.toInt()]
-    }
+  override suspend fun onGet(key: String): Char {
+    return stored[key.toInt()]
+  }
 
-    override suspend fun onRemove(key: String) {
-        val index = key.toInt()
-        stored = stored.substring(0..index) + stored.substring(index.inc()..stored.length)
-    }
+  override suspend fun onRemove(key: String) {
+    val index = key.toInt()
+    stored = stored.substring(0..index) + stored.substring(index.inc()..stored.length)
+  }
 
-    override suspend fun onClear() {
-        stored = ""
-    }
+  override suspend fun onClear() {
+    stored = ""
+  }
 }

--- a/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/Cache.kt
+++ b/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/Cache.kt
@@ -13,177 +13,168 @@ import kotlin.time.Duration.Companion.seconds
  * Decides whether values should be fetched or have their cached version retrieved.
  *
  * @param context [Context] through which an instance of the underlying [CacheDatabase] will be
- * obtained.
+ *   obtained.
  * @param name Identifier for this [Cache].
- **/
+ */
 abstract class Cache<T> internal constructor(context: Context, name: String) {
-    /** [CacheDatabase] provided by the [databaseProvider]. **/
-    private val database
-        get() = databaseProvider.provide()
+  /** [CacheDatabase] provided by the [databaseProvider]. */
+  private val database
+    get() = databaseProvider.provide()
 
-    /** [AccessDao] from which living and idling [Access]es are read and written to. **/
-    private val accessDao
-        get() = database.accessDao
+  /** [AccessDao] from which living and idling [Access]es are read and written to. */
+  private val accessDao
+    get() = database.accessDao
 
-    /** Elapsed time provided by the [elapsedTimeProvider]. **/
-    private val elapsedTime
-        get() = elapsedTimeProvider.provide()
+  /** Elapsed time provided by the [elapsedTimeProvider]. */
+  private val elapsedTime
+    get() = elapsedTimeProvider.provide()
 
-    /** [CacheDatabase.Provider] by which a [CacheDatabase] will be provided. **/
-    internal open val databaseProvider = CacheDatabase.Provider { CacheDatabase.of(context, name) }
+  /** [CacheDatabase.Provider] by which a [CacheDatabase] will be provided. */
+  internal open val databaseProvider = CacheDatabase.Provider { CacheDatabase.of(context, name) }
 
-    /** [ElapsedTimeProvider] for accessing the current elapsed time. **/
-    internal open val elapsedTimeProvider = ElapsedTimeProvider.system
+  /** [ElapsedTimeProvider] for accessing the current elapsed time. */
+  internal open val elapsedTimeProvider = ElapsedTimeProvider.system
 
-    /** [Fetcher] through which values will be obtained from their source (normally the network). **/
-    protected abstract val fetcher: Fetcher<T>
+  /** [Fetcher] through which values will be obtained from their source (normally the network). */
+  protected abstract val fetcher: Fetcher<T>
 
-    /** [Storage] for fetched values to be stored in and retrieved from. **/
-    protected abstract val storage: Storage<T>
+  /** [Storage] for fetched values to be stored in and retrieved from. */
+  protected abstract val storage: Storage<T>
 
-    /**
-     * Time-to-idle is the expiration threshold related to the last time a value has been read or
-     * written.
-     **/
-    protected open val timeToIdle: Duration = 1.minutes
+  /**
+   * Time-to-idle is the expiration threshold related to the last time a value has been read or
+   * written.
+   */
+  protected open val timeToIdle: Duration = 1.minutes
 
-    /** Time-to-live is similar to [timeToIdle], but only considers write operations. **/
-    protected open val timeToLive: Duration = 30.seconds
+  /** Time-to-live is similar to [timeToIdle], but only considers write operations. */
+  protected open val timeToLive: Duration = 30.seconds
 
-    /** Provides the amount of time that has passed through [provide]. **/
-    internal fun interface ElapsedTimeProvider {
-        /** Provides the amount of time that has passed. **/
-        fun provide(): Duration
-
-        companion object {
-            /** [ElapsedTimeProvider] that provides the system's current time in [milliseconds]. **/
-            val system = ElapsedTimeProvider {
-                System.currentTimeMillis().milliseconds
-            }
-        }
-    }
-
-    /**
-     * Gets the value bound to the given [key] either by retrieving it from the [storage] if it's
-     * been cached or fetches it through the [fetcher] if it hasn't, respecting both the
-     * [timeToIdle] and the [timeToLive].
-     *
-     * @param key Unique identifier to which the value to be obtained is associated to.
-     **/
-    suspend fun get(key: String): T {
-        val isActive = isIdle(key) || isAlive(key)
-        return if (isActive) retrieve(key) else remember(key)
-    }
-
-    /** Removes all [Access]es and stored values and closes the [database]. **/
-    internal suspend fun terminate() {
-        storage.clear()
-        database.clearAllTables()
-        database.close()
-    }
-
-    /**
-     * Returns whether the value associated to the given [key] is idle.
-     *
-     * @param key Unique identifier of the value.
-     * @see timeToIdle
-     **/
-    private suspend fun isIdle(key: String): Boolean {
-        return storage.contains(key) && getTimeSinceLastAccessTo(key, Access.Type.IDLE) < timeToIdle
-    }
-
-    /**
-     * Returns whether the value associated to the given [key] is alive.
-     *
-     * @param key Unique identifier of the value.
-     * @see timeToLive
-     **/
-    private suspend fun isAlive(key: String): Boolean {
-        return storage.contains(key) &&
-            getTimeSinceLastAccessTo(key, Access.Type.ALIVE) < timeToLive
-    }
-
-    /**
-     * Gets the amount of time that has passed since the value associated to the [key] was accessed.
-     *
-     * @param key Unique identifier of the value that has been accessed.
-     * @param type [Access.Type] that indicates how the value was accessed.
-     **/
-    private suspend fun getTimeSinceLastAccessTo(key: String, type: Access.Type): Duration {
-        return elapsedTime - accessDao.select(key, type).time.milliseconds
-    }
-
-    /**
-     * Marks the value to which the [key] is associated as idle and gets its previously stored
-     * value.
-     *
-     * @param key Unique identifier of the value to be retrieved.
-     **/
-    private suspend fun retrieve(key: String): T {
-        markAsIdle(key)
-        return storage.get(key)
-    }
-
-    /**
-     * Fetches the value associated to the given [key] and stores it, marking it as both idle and
-     * alive.
-     *
-     * @param key Unique identifier of the value to be fetched and stored.
-     * @return Value that's been fetched/stored.
-     * @see markAsIdle
-     * @see markAsAlive
-     **/
-    private suspend fun remember(key: String): T {
-        val value = fetcher.fetch(key)
-        storage.store(key, value)
-        markAsAlive(key)
-        markAsIdle(key)
-        return value
-    }
-
-    /**
-     * Adds an alive access keyed as [key], bound to the current [elapsedTime].
-     *
-     * @param key Unique identifier of the value to be marked as idle.
-     * @see timeToLive
-     **/
-    private suspend fun markAsAlive(key: String) {
-        val access = Access(key, Access.Type.ALIVE, elapsedTime.inWholeMilliseconds)
-        accessDao.insert(access)
-    }
-
-    /**
-     * Adds an idle access keyed as [key], bound to the current [elapsedTime].
-     *
-     * @param key Unique identifier of the value to be marked as idle.
-     * @see timeToIdle
-     **/
-    private suspend fun markAsIdle(key: String) {
-        val access = Access(key, Access.Type.IDLE, elapsedTime.inWholeMilliseconds)
-        accessDao.insert(access)
-    }
+  /** Provides the amount of time that has passed through [provide]. */
+  internal fun interface ElapsedTimeProvider {
+    /** Provides the amount of time that has passed. */
+    fun provide(): Duration
 
     companion object {
-        /**
-         * Creates a [Cache].
-         *
-         * @param context [Context] through which an instance of the underlying [CacheDatabase] will
-         * be obtained.
-         * @param name Identifier of the [Cache] to be created.
-         * @param fetcher [Fetcher] through which values will be obtained from their source
-         * (normally the network).
-         * @param storage [Storage] for fetched values to be stored in and retrieved from.
-         **/
-        fun <T> of(
-            context: Context,
-            name: String,
-            fetcher: Fetcher<T>,
-            storage: Storage<T>
-        ): Cache<T> {
-            return object : Cache<T>(context, name) {
-                override val fetcher = fetcher
-                override val storage = storage
-            }
-        }
+      /** [ElapsedTimeProvider] that provides the system's current time in [milliseconds]. */
+      val system = ElapsedTimeProvider { System.currentTimeMillis().milliseconds }
     }
+  }
+
+  /**
+   * Gets the value bound to the given [key] either by retrieving it from the [storage] if it's been
+   * cached or fetches it through the [fetcher] if it hasn't, respecting both the [timeToIdle] and
+   * the [timeToLive].
+   *
+   * @param key Unique identifier to which the value to be obtained is associated to.
+   */
+  suspend fun get(key: String): T {
+    val isActive = isIdle(key) || isAlive(key)
+    return if (isActive) retrieve(key) else remember(key)
+  }
+
+  /** Removes all [Access]es and stored values and closes the [database]. */
+  internal suspend fun terminate() {
+    storage.clear()
+    database.clearAllTables()
+    database.close()
+  }
+
+  /**
+   * Returns whether the value associated to the given [key] is idle.
+   *
+   * @param key Unique identifier of the value.
+   * @see timeToIdle
+   */
+  private suspend fun isIdle(key: String): Boolean {
+    return storage.contains(key) && getTimeSinceLastAccessTo(key, Access.Type.IDLE) < timeToIdle
+  }
+
+  /**
+   * Returns whether the value associated to the given [key] is alive.
+   *
+   * @param key Unique identifier of the value.
+   * @see timeToLive
+   */
+  private suspend fun isAlive(key: String): Boolean {
+    return storage.contains(key) && getTimeSinceLastAccessTo(key, Access.Type.ALIVE) < timeToLive
+  }
+
+  /**
+   * Gets the amount of time that has passed since the value associated to the [key] was accessed.
+   *
+   * @param key Unique identifier of the value that has been accessed.
+   * @param type [Access.Type] that indicates how the value was accessed.
+   */
+  private suspend fun getTimeSinceLastAccessTo(key: String, type: Access.Type): Duration {
+    return elapsedTime - accessDao.select(key, type).time.milliseconds
+  }
+
+  /**
+   * Marks the value to which the [key] is associated as idle and gets its previously stored value.
+   *
+   * @param key Unique identifier of the value to be retrieved.
+   */
+  private suspend fun retrieve(key: String): T {
+    markAsIdle(key)
+    return storage.get(key)
+  }
+
+  /**
+   * Fetches the value associated to the given [key] and stores it, marking it as both idle and
+   * alive.
+   *
+   * @param key Unique identifier of the value to be fetched and stored.
+   * @return Value that's been fetched/stored.
+   * @see markAsIdle
+   * @see markAsAlive
+   */
+  private suspend fun remember(key: String): T {
+    val value = fetcher.fetch(key)
+    storage.store(key, value)
+    markAsAlive(key)
+    markAsIdle(key)
+    return value
+  }
+
+  /**
+   * Adds an alive access keyed as [key], bound to the current [elapsedTime].
+   *
+   * @param key Unique identifier of the value to be marked as idle.
+   * @see timeToLive
+   */
+  private suspend fun markAsAlive(key: String) {
+    val access = Access(key, Access.Type.ALIVE, elapsedTime.inWholeMilliseconds)
+    accessDao.insert(access)
+  }
+
+  /**
+   * Adds an idle access keyed as [key], bound to the current [elapsedTime].
+   *
+   * @param key Unique identifier of the value to be marked as idle.
+   * @see timeToIdle
+   */
+  private suspend fun markAsIdle(key: String) {
+    val access = Access(key, Access.Type.IDLE, elapsedTime.inWholeMilliseconds)
+    accessDao.insert(access)
+  }
+
+  companion object {
+    /**
+     * Creates a [Cache].
+     *
+     * @param context [Context] through which an instance of the underlying [CacheDatabase] will be
+     *   obtained.
+     * @param name Identifier of the [Cache] to be created.
+     * @param fetcher [Fetcher] through which values will be obtained from their source (normally
+     *   the network).
+     * @param storage [Storage] for fetched values to be stored in and retrieved from.
+     */
+    fun <T> of(context: Context, name: String, fetcher: Fetcher<T>, storage: Storage<T>): Cache<T> {
+      return object : Cache<T>(context, name) {
+        override val fetcher = fetcher
+        override val storage = storage
+      }
+    }
+  }
 }

--- a/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/Fetcher.kt
+++ b/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/Fetcher.kt
@@ -1,20 +1,20 @@
 package com.jeanbarrossilva.orca.platform.cache
 
-/** Fetches values from an external source (normally the network) through [onFetch]. **/
+/** Fetches values from an external source (normally the network) through [onFetch]. */
 abstract class Fetcher<T> {
-    /**
-     * Fetches a value associated to the given [key].
-     *
-     * @param key Unique identifier of the value to be fetched.
-     **/
-    internal suspend fun fetch(key: String): T {
-        return onFetch(key)
-    }
+  /**
+   * Fetches a value associated to the given [key].
+   *
+   * @param key Unique identifier of the value to be fetched.
+   */
+  internal suspend fun fetch(key: String): T {
+    return onFetch(key)
+  }
 
-    /**
-     * Fetches a value associated to the given [key].
-     *
-     * @param key Unique identifier of the value to be fetched.
-     **/
-    protected abstract suspend fun onFetch(key: String): T
+  /**
+   * Fetches a value associated to the given [key].
+   *
+   * @param key Unique identifier of the value to be fetched.
+   */
+  protected abstract suspend fun onFetch(key: String): T
 }

--- a/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/Storage.kt
+++ b/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/Storage.kt
@@ -1,79 +1,79 @@
 package com.jeanbarrossilva.orca.platform.cache
 
-/** Stores values that have been fetched for later retrieval. **/
+/** Stores values that have been fetched for later retrieval. */
 abstract class Storage<T> {
-    /**
-     * Stores the [value], associating it to the given [key] for it to be posteriorly retrieved.
-     *
-     * @param key Unique identifier of the [value] to be stored.
-     * @param value Value that is associated to the [key] and has been requested to be stored.
-     **/
-    internal suspend fun store(key: String, value: T) {
-        onStore(key, value)
-    }
+  /**
+   * Stores the [value], associating it to the given [key] for it to be posteriorly retrieved.
+   *
+   * @param key Unique identifier of the [value] to be stored.
+   * @param value Value that is associated to the [key] and has been requested to be stored.
+   */
+  internal suspend fun store(key: String, value: T) {
+    onStore(key, value)
+  }
 
-    /**
-     * Returns whether a value associated to the [key] has been stored.
-     *
-     * @param key Unique identifier of the value whose presence will be checked.
-     **/
-    internal suspend fun contains(key: String): Boolean {
-        return onContains(key)
-    }
+  /**
+   * Returns whether a value associated to the [key] has been stored.
+   *
+   * @param key Unique identifier of the value whose presence will be checked.
+   */
+  internal suspend fun contains(key: String): Boolean {
+    return onContains(key)
+  }
 
-    /**
-     * Gets the value that has been stored and is associated to the given [key].
-     *
-     * @param key Unique identifier of the value to be obtained.
-     **/
-    internal suspend fun get(key: String): T {
-        return onGet(key)
-    }
+  /**
+   * Gets the value that has been stored and is associated to the given [key].
+   *
+   * @param key Unique identifier of the value to be obtained.
+   */
+  internal suspend fun get(key: String): T {
+    return onGet(key)
+  }
 
-    /**
-     * Removes the value that has been stored and is associated to the given [key].
-     *
-     * @param key Unique identifier of the value to be removed.
-     **/
-    internal suspend fun remove(key: String) {
-        onRemove(key)
-    }
+  /**
+   * Removes the value that has been stored and is associated to the given [key].
+   *
+   * @param key Unique identifier of the value to be removed.
+   */
+  internal suspend fun remove(key: String) {
+    onRemove(key)
+  }
 
-    /** Removes all stored values. **/
-    internal suspend fun clear() {
-        onClear()
-    }
+  /** Removes all stored values. */
+  internal suspend fun clear() {
+    onClear()
+  }
 
-    /**
-     * Operation to be performed whenever the [value] is requested to be stored while associated to
-     * the given [key].
-     *
-     * @param key Unique identifier of the value that has been requested to be stored.
-     * @param value Value that is associated to the [key] and has been requested to be stored.
-     **/
-    protected abstract suspend fun onStore(key: String, value: T)
+  /**
+   * Operation to be performed whenever the [value] is requested to be stored while associated to
+   * the given [key].
+   *
+   * @param key Unique identifier of the value that has been requested to be stored.
+   * @param value Value that is associated to the [key] and has been requested to be stored.
+   */
+  protected abstract suspend fun onStore(key: String, value: T)
 
-    /**
-     * Returns whether a value associated to the [key] has been stored.
-     *
-     * @param key Unique identifier of the value whose presence will be checked.
-     **/
-    protected abstract suspend fun onContains(key: String): Boolean
+  /**
+   * Returns whether a value associated to the [key] has been stored.
+   *
+   * @param key Unique identifier of the value whose presence will be checked.
+   */
+  protected abstract suspend fun onContains(key: String): Boolean
 
-    /**
-     * Gets the value that has been stored and is associated to the given [key].
-     *
-     * @param key Unique identifier of the value to be obtained.
-     **/
-    protected abstract suspend fun onGet(key: String): T
+  /**
+   * Gets the value that has been stored and is associated to the given [key].
+   *
+   * @param key Unique identifier of the value to be obtained.
+   */
+  protected abstract suspend fun onGet(key: String): T
 
-    /**
-     * Removes the value that has been stored and is associated to the given [key].
-     *
-     * @param key Unique identifier of the value to be removed.
-     **/
-    protected abstract suspend fun onRemove(key: String)
+  /**
+   * Removes the value that has been stored and is associated to the given [key].
+   *
+   * @param key Unique identifier of the value to be removed.
+   */
+  protected abstract suspend fun onRemove(key: String)
 
-    /** Removes all stored values. **/
-    protected abstract suspend fun onClear()
+  /** Removes all stored values. */
+  protected abstract suspend fun onClear()
 }

--- a/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/database/Access.kt
+++ b/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/database/Access.kt
@@ -11,21 +11,20 @@ import androidx.room.PrimaryKey
  * @param key Unique identifier of the stored value.
  * @param type [Type] that indicates how the value was accessed.
  * @param time Time that's been elapsed when the access occurred.
- **/
+ */
 @Entity(tableName = "accesses")
 internal data class Access(val key: String, val type: Type, val time: Long) {
-    /** Unique identifier composed by the [key] and the [type]. **/
-    @PrimaryKey
-    var id = "$type:$key"
-        @Discouraged(message = "ID should not be changed manually.")
-        set
+  /** Unique identifier composed by the [key] and the [type]. */
+  @PrimaryKey
+  var id = "$type:$key"
+    @Discouraged(message = "ID should not be changed manually.") set
 
-    /** Indicates how a value was accessed. **/
-    enum class Type {
-        /** Indicates that a value was written and read. **/
-        IDLE,
+  /** Indicates how a value was accessed. */
+  enum class Type {
+    /** Indicates that a value was written and read. */
+    IDLE,
 
-        /** Indicates that a value was written (created or updated). **/
-        ALIVE
-    }
+    /** Indicates that a value was written (created or updated). */
+    ALIVE
+  }
 }

--- a/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/database/AccessDao.kt
+++ b/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/database/AccessDao.kt
@@ -5,23 +5,22 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 
-/** Data access object for reading and writing [Access]es. **/
+/** Data access object for reading and writing [Access]es. */
 @Dao
 internal interface AccessDao {
-    /**
-     * Selects the [Access] that matches the given [key] and [type].
-     *
-     * @param key Unique identifier to which the stored value is associated.
-     * @param type [Access.Type] of the [Access] to be selected.
-     **/
-    @Query("SELECT * FROM accesses WHERE `key` = :key AND type = :type")
-    suspend fun select(key: String, type: Access.Type): Access
+  /**
+   * Selects the [Access] that matches the given [key] and [type].
+   *
+   * @param key Unique identifier to which the stored value is associated.
+   * @param type [Access.Type] of the [Access] to be selected.
+   */
+  @Query("SELECT * FROM accesses WHERE `key` = :key AND type = :type")
+  suspend fun select(key: String, type: Access.Type): Access
 
-    /**
-     * Inserts the [access].
-     *
-     * @param access [Access] to be inserted.
-     **/
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(access: Access)
+  /**
+   * Inserts the [access].
+   *
+   * @param access [Access] to be inserted.
+   */
+  @Insert(onConflict = OnConflictStrategy.REPLACE) suspend fun insert(access: Access)
 }

--- a/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/database/CacheDatabase.kt
+++ b/platform/cache/src/main/java/com/jeanbarrossilva/orca/platform/cache/database/CacheDatabase.kt
@@ -6,32 +6,32 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.jeanbarrossilva.orca.platform.cache.Cache
 
-/** [RoomDatabase] from which [Cache]-related entities are read and written to. **/
+/** [RoomDatabase] from which [Cache]-related entities are read and written to. */
 @Database(entities = [Access::class], version = 1)
 internal abstract class CacheDatabase : RoomDatabase() {
-    /** [AccessDao] that performs [Access]-related operations. **/
-    abstract val accessDao: AccessDao
+  /** [AccessDao] that performs [Access]-related operations. */
+  abstract val accessDao: AccessDao
 
-    /** Provides a [CacheDatabase] through [provide]. **/
-    fun interface Provider {
-        /** Provides a [CacheDatabase]. **/
-        fun provide(): CacheDatabase
+  /** Provides a [CacheDatabase] through [provide]. */
+  fun interface Provider {
+    /** Provides a [CacheDatabase]. */
+    fun provide(): CacheDatabase
+  }
+
+  companion object {
+    /** [CacheDatabase]s associated to their respective file name. */
+    private val instantiation = HashMap<String, CacheDatabase>()
+
+    /**
+     * Creates or gets a preexistent instance of a [CacheDatabase].
+     *
+     * @param context [Context] with which the [CacheDatabase] will be obtained.
+     * @param name Name of the [CacheDatabase].
+     */
+    fun of(context: Context, name: String): CacheDatabase {
+      return instantiation.getOrPut(name) {
+        Room.databaseBuilder(context, CacheDatabase::class.java, name).build()
+      }
     }
-
-    companion object {
-        /** [CacheDatabase]s associated to their respective file name. **/
-        private val instantiation = HashMap<String, CacheDatabase>()
-
-        /**
-         * Creates or gets a preexistent instance of a [CacheDatabase].
-         *
-         * @param context [Context] with which the [CacheDatabase] will be obtained.
-         * @param name Name of the [CacheDatabase].
-         **/
-        fun of(context: Context, name: String): CacheDatabase {
-            return instantiation.getOrPut(name) {
-                Room.databaseBuilder(context, CacheDatabase::class.java, name).build()
-            }
-        }
-    }
+  }
 }

--- a/platform/launchable/src/main/java/Launchable.kt
+++ b/platform/launchable/src/main/java/Launchable.kt
@@ -8,25 +8,27 @@ import android.content.Context
  * that indicates how many times that's happened.
  *
  * @see markAsLaunched
- **/
+ */
 @Suppress("SpellCheckingInspection")
 interface Launchable {
-    /** Returns the number of times this has been launched. **/
-    fun count(): Int
+  /** Returns the number of times this has been launched. */
+  fun count(): Int
 
-    /** Marks this as launched. **/
-    fun markAsLaunched()
+  /** Marks this as launched. */
+  fun markAsLaunched()
 }
 
 /**
  * Whether this is the first time the application has ever been launched by the user.
  *
  * @throws IllegalStateException If the running [Application] instance isn't [Launchable].
- **/
+ */
 val Context.isFirstLaunch: Boolean
-    get() {
-        val launchable = applicationContext as? Launchable ?: throw IllegalStateException(
-            "Cannot check first launch because the Application is not Launchable."
+  get() {
+    val launchable =
+      applicationContext as? Launchable
+        ?: throw IllegalStateException(
+          "Cannot check first launch because the Application is not Launchable."
         )
-        return launchable.count() == 1
-    }
+    return launchable.count() == 1
+  }

--- a/platform/theme/build.gradle.kts
+++ b/platform/theme/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     buildFeatures.compose = true
-    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.get()
     defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 }
 

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/OptionTests.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/OptionTests.kt
@@ -16,52 +16,37 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class OptionTests {
-    @get:Rule
-    val composeRule = createComposeRule()
+  @get:Rule val composeRule = createComposeRule()
 
-    @Test
-    fun isSemanticallySelectedWhenSelected() {
-        composeRule.setContent {
-            OrcaTheme {
-                Option(isSelected = true)
-            }
-        }
-        composeRule.onOption().assertIsSelected()
-    }
+  @Test
+  fun isSemanticallySelectedWhenSelected() {
+    composeRule.setContent { OrcaTheme { Option(isSelected = true) } }
+    composeRule.onOption().assertIsSelected()
+  }
 
-    @Test
-    fun showsSelectionIconWhenSelected() {
-        composeRule.setContent {
-            OrcaTheme {
-                Option(isSelected = true)
-            }
-        }
-        composeRule
-            .onNodeWithTag(OPTION_SELECTION_ICON_TAG, useUnmergedTree = true)
-            .assertIsDisplayed()
-    }
+  @Test
+  fun showsSelectionIconWhenSelected() {
+    composeRule.setContent { OrcaTheme { Option(isSelected = true) } }
+    composeRule.onNodeWithTag(OPTION_SELECTION_ICON_TAG, useUnmergedTree = true).assertIsDisplayed()
+  }
 
-    @Test
-    fun runsCallbackWhenSelected() {
-        var isSelected by mutableStateOf(false)
-        composeRule.setContent {
-            OrcaTheme {
-                Option(isSelected, onSelectionToggle = { isSelected = it })
-            }
-        }
-        composeRule.onOption().performClick()
-        assertTrue(isSelected)
+  @Test
+  fun runsCallbackWhenSelected() {
+    var isSelected by mutableStateOf(false)
+    composeRule.setContent {
+      OrcaTheme { Option(isSelected, onSelectionToggle = { isSelected = it }) }
     }
+    composeRule.onOption().performClick()
+    assertTrue(isSelected)
+  }
 
-    @Test
-    fun runsCallbackWhenUnselected() {
-        var isSelected by mutableStateOf(true)
-        composeRule.setContent {
-            OrcaTheme {
-                Option(isSelected, onSelectionToggle = { isSelected = it })
-            }
-        }
-        composeRule.onOption().performClick()
-        assertFalse(isSelected)
+  @Test
+  fun runsCallbackWhenUnselected() {
+    var isSelected by mutableStateOf(true)
+    composeRule.setContent {
+      OrcaTheme { Option(isSelected, onSelectionToggle = { isSelected = it }) }
     }
+    composeRule.onOption().performClick()
+    assertFalse(isSelected)
+  }
 }

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/OptionsTests.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/OptionsTests.kt
@@ -28,125 +28,84 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class OptionsTests {
-    private val defaultOptionShape: CornerBasedShape
-        get() {
-            val context = InstrumentationRegistry.getInstrumentation().context
-            val shapes = Shapes.getDefault(context)
-            return OptionDefaults.getShape(shapes)
-        }
-
-    @get:Rule
-    val composeRule = createComposeRule()
-
-    @Test
-    fun shapesSingleOptionWithDefaultShape() {
-        composeRule.setContent {
-            OrcaTheme {
-                SampleOptions(count = 1)
-            }
-        }
-        composeRule.onOption().assertIsShapedBy(defaultOptionShape)
+  private val defaultOptionShape: CornerBasedShape
+    get() {
+      val context = InstrumentationRegistry.getInstrumentation().context
+      val shapes = Shapes.getDefault(context)
+      return OptionDefaults.getShape(shapes)
     }
 
-    @Test
-    fun shapesFirstOptionWithZeroedBottomCornerSizes() {
-        composeRule.setContent {
-            OrcaTheme {
-                Surface(color = Color.Transparent) {
-                    SampleOptions()
-                }
-            }
-        }
-        composeRule.onOptions().onFirst().assertIsShapedBy(defaultOptionShape.top)
-    }
+  @get:Rule val composeRule = createComposeRule()
 
-    @Test
-    fun shapesIntermediateOptionWithZeroedCornerSizes() {
-        composeRule.setContent {
-            OrcaTheme {
-                SampleOptions()
-            }
-        }
-        composeRule.onOptions()[1].assertIsShapedBy(RectangleShape)
-    }
+  @Test
+  fun shapesSingleOptionWithDefaultShape() {
+    composeRule.setContent { OrcaTheme { SampleOptions(count = 1) } }
+    composeRule.onOption().assertIsShapedBy(defaultOptionShape)
+  }
 
-    @Test
-    fun shapesLastOptionWithZeroedTopCornerSizes() {
-        composeRule.setContent {
-            OrcaTheme {
-                Surface(color = Color.Transparent) {
-                    SampleOptions()
-                }
-            }
-        }
-        composeRule.onOptions().onLast().assertIsShapedBy(defaultOptionShape.bottom)
-    }
+  @Test
+  fun shapesFirstOptionWithZeroedBottomCornerSizes() {
+    composeRule.setContent { OrcaTheme { Surface(color = Color.Transparent) { SampleOptions() } } }
+    composeRule.onOptions().onFirst().assertIsShapedBy(defaultOptionShape.top)
+  }
 
-    @Test
-    fun surroundsIntermediateOptionWithDividers() {
-        composeRule.setContent {
-            OrcaTheme {
-                SampleOptions()
-            }
-        }
-        composeRule
-            .onOptions()[1]
-            .onSiblings()
-            .filter(hasTestTag(OPTIONS_DIVIDER_TAG))
-            .assertCountEquals(2)
-    }
+  @Test
+  fun shapesIntermediateOptionWithZeroedCornerSizes() {
+    composeRule.setContent { OrcaTheme { SampleOptions() } }
+    composeRule.onOptions()[1].assertIsShapedBy(RectangleShape)
+  }
 
-    @Test
-    fun selectsFirstOptionByDefault() {
-        composeRule.setContent {
-            OrcaTheme {
-                SampleOptions()
-            }
-        }
-        composeRule.onOptions().onFirst().assertIsSelected()
-    }
+  @Test
+  fun shapesLastOptionWithZeroedTopCornerSizes() {
+    composeRule.setContent { OrcaTheme { Surface(color = Color.Transparent) { SampleOptions() } } }
+    composeRule.onOptions().onLast().assertIsShapedBy(defaultOptionShape.bottom)
+  }
 
-    @Test
-    fun runsCallbackWhenOptionIsSelectedByDefault() {
-        var index = -1
-        composeRule.setContent {
-            OrcaTheme {
-                SampleOptions(
-                    onSelection = {
-                        index = it
-                    }
-                )
-            }
-        }
-        assertEquals(0, index)
-    }
+  @Test
+  fun surroundsIntermediateOptionWithDividers() {
+    composeRule.setContent { OrcaTheme { SampleOptions() } }
+    composeRule
+      .onOptions()[1]
+      .onSiblings()
+      .filter(hasTestTag(OPTIONS_DIVIDER_TAG))
+      .assertCountEquals(2)
+  }
 
-    @Test
-    fun runsCallbackOnceWhenOptionIsSelectedMultipleTimes() {
-        var count = 0
-        composeRule.setContent {
-            OrcaTheme {
-                SampleOptions(
-                    onSelection = {
-                        if (it == 0) {
-                            count++
-                        }
-                    }
-                )
-            }
-        }
-        composeRule.onOptions().onFirst().performClick()
-        assertEquals(1, count)
-    }
+  @Test
+  fun selectsFirstOptionByDefault() {
+    composeRule.setContent { OrcaTheme { SampleOptions() } }
+    composeRule.onOptions().onFirst().assertIsSelected()
+  }
 
-    @Test
-    fun unselectsPreviouslySelectedOptionWhenAnotherOneIsSelected() {
-        composeRule.setContent {
-            OrcaTheme {
-                SampleOptions()
+  @Test
+  fun runsCallbackWhenOptionIsSelectedByDefault() {
+    var index = -1
+    composeRule.setContent { OrcaTheme { SampleOptions(onSelection = { index = it }) } }
+    assertEquals(0, index)
+  }
+
+  @Test
+  fun runsCallbackOnceWhenOptionIsSelectedMultipleTimes() {
+    var count = 0
+    composeRule.setContent {
+      OrcaTheme {
+        SampleOptions(
+          onSelection = {
+            if (it == 0) {
+              count++
             }
-        }
-        composeRule.onOptions().onLast().performClick()
-        composeRule.onOptions().onFirst().assertIsNotSelected()
+          }
+        )
+      }
     }
+    composeRule.onOptions().onFirst().performClick()
+    assertEquals(1, count)
+  }
+
+  @Test
+  fun unselectsPreviouslySelectedOptionWhenAnotherOneIsSelected() {
+    composeRule.setContent { OrcaTheme { SampleOptions() } }
+    composeRule.onOptions().onLast().performClick()
+    composeRule.onOptions().onFirst().assertIsNotSelected()
+  }
 }

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/test/SemanticsMatcher.extensions.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/test/SemanticsMatcher.extensions.kt
@@ -11,16 +11,16 @@ import androidx.compose.ui.test.SemanticsMatcher
  * clipped is the given one.
  *
  * @param shape [Shape] to assert that it's the one by which the [SemanticsNode] is shaped.
- **/
+ */
 internal fun isShapedBy(shape: Shape): SemanticsMatcher {
-    return SemanticsMatcher("Shape = '$shape'") { node ->
-        shape == node
-            .layoutInfo
-            .getModifierInfo()
-            .map(ModifierInfo::modifier)
-            .filterIsInstance<ModifierNodeElement<*>>()
-            .flatMap(ModifierNodeElement<*>::inspectableElements)
-            .find { element -> element.name == "shape" }
-            ?.value
-    }
+  return SemanticsMatcher("Shape = '$shape'") { node ->
+    shape ==
+      node.layoutInfo
+        .getModifierInfo()
+        .map(ModifierInfo::modifier)
+        .filterIsInstance<ModifierNodeElement<*>>()
+        .flatMap(ModifierNodeElement<*>::inspectableElements)
+        .find { element -> element.name == "shape" }
+        ?.value
+  }
 }

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/test/SemanticsNodeInteraction.extensions.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/test/SemanticsNodeInteraction.extensions.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.test.assert
  * Asserts that the [SemanticsNode] has been clipped by the given [shape].
  *
  * @param shape [Shape] to assert that it's the one by which the [SemanticsNode] is shaped.
- **/
+ */
 internal fun SemanticsNodeInteraction.assertIsShapedBy(shape: Shape): SemanticsNodeInteraction {
-    return assert(isShapedBy(shape))
+  return assert(isShapedBy(shape))
 }

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/test/ComposeTestRule.extensions.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/test/ComposeTestRule.extensions.kt
@@ -8,12 +8,12 @@ import androidx.compose.ui.test.onNodeWithTag
 import com.jeanbarrossilva.orca.platform.theme.kit.input.option.OPTION_TAG
 import com.jeanbarrossilva.orca.platform.theme.kit.input.option.Option
 
-/** [SemanticsNodeInteraction] of an [Option]. **/
+/** [SemanticsNodeInteraction] of an [Option]. */
 internal fun ComposeTestRule.onOption(): SemanticsNodeInteraction {
-    return onNodeWithTag(OPTION_TAG)
+  return onNodeWithTag(OPTION_TAG)
 }
 
-/** [SemanticsNodeInteractionCollection] of [Option]s. **/
+/** [SemanticsNodeInteractionCollection] of [Option]s. */
 internal fun ComposeTestRule.onOptions(): SemanticsNodeInteractionCollection {
-    return onAllNodesWithTag(OPTION_TAG)
+  return onAllNodesWithTag(OPTION_TAG)
 }

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/ButtonBarTests.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/ButtonBarTests.kt
@@ -16,44 +16,33 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class ButtonBarTests {
-    @get:Rule
-    val composeRule = createComposeRule()
+  @get:Rule val composeRule = createComposeRule()
 
-    @Test
-    fun hidesDividerWhenListCannotBeScrolled() {
-        val lazyListState = LazyListState()
-        composeRule.setContent {
-            OrcaTheme {
-                Scaffold(buttonBar = { ButtonBar(lazyListState) }) {
-                    LazyColumn(state = lazyListState) {
-                        item {
-                            Spacer(Modifier)
-                        }
-                    }
-                }
-            }
+  @Test
+  fun hidesDividerWhenListCannotBeScrolled() {
+    val lazyListState = LazyListState()
+    composeRule.setContent {
+      OrcaTheme {
+        Scaffold(buttonBar = { ButtonBar(lazyListState) }) {
+          LazyColumn(state = lazyListState) { item { Spacer(Modifier) } }
         }
-        composeRule.onNodeWithTag(BUTTON_BAR_DIVIDER_TAG).assertIsNotDisplayed()
+      }
     }
+    composeRule.onNodeWithTag(BUTTON_BAR_DIVIDER_TAG).assertIsNotDisplayed()
+  }
 
-    @Test
-    fun showsDividerWhenListCanBeScrolled() {
-        val lazyListState = LazyListState()
-        composeRule.setContent {
-            OrcaTheme {
-                Scaffold(buttonBar = { ButtonBar(lazyListState) }) {
-                    LazyColumn(state = lazyListState) {
-                        item {
-                            Spacer(
-                                Modifier
-                                    .padding(it)
-                                    .fillScreenSize()
-                            )
-                        }
-                    }
-                }
-            }
+  @Test
+  fun showsDividerWhenListCanBeScrolled() {
+    val lazyListState = LazyListState()
+    composeRule.setContent {
+      OrcaTheme {
+        Scaffold(buttonBar = { ButtonBar(lazyListState) }) {
+          LazyColumn(state = lazyListState) {
+            item { Spacer(Modifier.padding(it).fillScreenSize()) }
+          }
         }
-        composeRule.onNodeWithTag(BUTTON_BAR_DIVIDER_TAG).assertIsDisplayed()
+      }
     }
+    composeRule.onNodeWithTag(BUTTON_BAR_DIVIDER_TAG).assertIsDisplayed()
+  }
 }

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/test/ComposeTestRule.extensions.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/test/ComposeTestRule.extensions.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.button.BUTTON_BAR_TAG
 import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.button.ButtonBar
 
-/** [SemanticsNodeInteraction] of a [ButtonBar]. **/
+/** [SemanticsNodeInteraction] of a [ButtonBar]. */
 internal fun ComposeTestRule.onButtonBar(): SemanticsNodeInteraction {
-    return onNodeWithTag(BUTTON_BAR_TAG)
+  return onNodeWithTag(BUTTON_BAR_TAG)
 }

--- a/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/test/Modifier.extensions.kt
+++ b/platform/theme/src/androidTest/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/test/Modifier.extensions.kt
@@ -7,11 +7,11 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 
-/** Makes the content fill the screen size. **/
+/** Makes the content fill the screen size. */
 internal fun Modifier.fillScreenSize(): Modifier {
-    return composed {
-        with(LocalContext.current.resources.configuration) {
-            height(screenHeightDp.dp).width(screenWidthDp.dp)
-        }
+  return composed {
+    with(LocalContext.current.resources.configuration) {
+      height(screenHeightDp.dp).width(screenWidthDp.dp)
     }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/MultiThemePreview.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/MultiThemePreview.kt
@@ -3,7 +3,7 @@ package com.jeanbarrossilva.orca.platform.theme
 import android.content.res.Configuration
 import androidx.compose.ui.tooling.preview.Preview
 
-/** [Preview] with all themes supported by Orca. **/
+/** [Preview] with all themes supported by Orca. */
 @Preview
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.FUNCTION)

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/OrcaContextThemeWrapper.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/OrcaContextThemeWrapper.kt
@@ -3,6 +3,6 @@ package com.jeanbarrossilva.orca.platform.theme
 import android.content.Context
 import androidx.appcompat.view.ContextThemeWrapper
 
-/** [ContextThemeWrapper] with [R.style.Theme_Orca] as its theme. **/
+/** [ContextThemeWrapper] with [R.style.Theme_Orca] as its theme. */
 internal class OrcaContextThemeWrapper(context: Context) :
-    ContextThemeWrapper(context, R.style.Theme_Orca)
+  ContextThemeWrapper(context, R.style.Theme_Orca)

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/OrcaTheme.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/OrcaTheme.kt
@@ -27,85 +27,82 @@ import com.jeanbarrossilva.orca.platform.theme.extensions.LocalTypography
 import com.jeanbarrossilva.orca.platform.theme.extensions.Rubik
 import com.jeanbarrossilva.orca.platform.theme.extensions.with
 
-/** Provider of [OrcaTheme]'s configurations. **/
+/** Provider of [OrcaTheme]'s configurations. */
 object OrcaTheme {
-    /** [Current][CompositionLocal.current] [Borders] from [LocalBorders]. **/
-    val borders
-        @Composable get() = LocalBorders.current
+  /** [Current][CompositionLocal.current] [Borders] from [LocalBorders]. */
+  val borders
+    @Composable get() = LocalBorders.current
 
-    /** [Current][CompositionLocal.current] [Colors] from [LocalColors]. **/
-    val colors
-        @Composable get() = LocalColors.current
+  /** [Current][CompositionLocal.current] [Colors] from [LocalColors]. */
+  val colors
+    @Composable get() = LocalColors.current
 
-    /** [Current][CompositionLocal.current] [Iconography] from [LocalIconography]. **/
-    val iconography
-        @Composable get() = LocalIconography.current
+  /** [Current][CompositionLocal.current] [Iconography] from [LocalIconography]. */
+  val iconography
+    @Composable get() = LocalIconography.current
 
-    /** [Current][CompositionLocal.current] [Overlays] from [LocalOverlays]. **/
-    val overlays
-        @Composable get() = LocalOverlays.current
+  /** [Current][CompositionLocal.current] [Overlays] from [LocalOverlays]. */
+  val overlays
+    @Composable get() = LocalOverlays.current
 
-    /** [Current][CompositionLocal.current] [Shapes] from [LocalShapes]. **/
-    val shapes
-        @Composable get() = LocalShapes.current
+  /** [Current][CompositionLocal.current] [Shapes] from [LocalShapes]. */
+  val shapes
+    @Composable get() = LocalShapes.current
 
-    /** [Current][CompositionLocal.current] [Spacings] from [LocalSpacings]. **/
-    val spacings
-        @Composable get() = LocalSpacings.current
+  /** [Current][CompositionLocal.current] [Spacings] from [LocalSpacings]. */
+  val spacings
+    @Composable get() = LocalSpacings.current
 
-    /** [Current][CompositionLocal.current] [Typography] from the underlying [MaterialTheme]. **/
-    val typography
-        @Composable get() = MaterialTheme.typography
+  /** [Current][CompositionLocal.current] [Typography] from the underlying [MaterialTheme]. */
+  val typography
+    @Composable get() = MaterialTheme.typography
 }
 
 /**
  * [MaterialTheme] for Orca.
  *
  * @param content Content to be themed.
- **/
+ */
 @Composable
 fun OrcaTheme(content: @Composable () -> Unit) {
-    val view = LocalView.current
-    val isPreviewing = remember(view) { view.isInEditMode }
-    val themedContent = @Composable {
-        Mdc3Theme(setTextColors = true, setDefaultFontFamily = true) {
+  val view = LocalView.current
+  val isPreviewing = remember(view) { view.isInEditMode }
+  val themedContent =
+    @Composable {
+      Mdc3Theme(setTextColors = true, setDefaultFontFamily = true) {
+        CompositionLocalProvider(
+          LocalBorders provides Borders.default,
+          LocalColors provides Colors.default,
+          LocalIconography provides Iconography.default,
+          LocalOverlays provides Overlays.Default,
+          LocalShapes provides Shapes.default,
+          LocalSpacings provides Spacings.default,
+          LocalTextStyle provides OrcaTheme.typography.bodyMedium
+        ) {
+          /*
+           * Mdc3Theme doesn't apply the font family specified in XML when previewing, so it
+           * has to be set here. This isn't ideal because it requires us to do so twice, but
+           * isn't a huge deal also, since it (hopefully) won't be changed that often.
+           */
+          if (isPreviewing) {
             CompositionLocalProvider(
-                LocalBorders provides Borders.default,
-                LocalColors provides Colors.default,
-                LocalIconography provides Iconography.default,
-                LocalOverlays provides Overlays.Default,
-                LocalShapes provides Shapes.default,
-                LocalSpacings provides Spacings.default,
-                LocalTextStyle provides OrcaTheme.typography.bodyMedium
-            ) {
-                /*
-                 * Mdc3Theme doesn't apply the font family specified in XML when previewing, so it
-                 * has to be set here. This isn't ideal because it requires us to do so twice, but
-                 * isn't a huge deal also, since it (hopefully) won't be changed that often.
-                 */
-                if (isPreviewing) {
-                    CompositionLocalProvider(
-                        LocalTypography provides LocalTypography.current.with(FontFamily.Rubik),
-                        content = content
-                    )
-                } else {
-                    content()
-                }
-            }
+              LocalTypography provides LocalTypography.current.with(FontFamily.Rubik),
+              content = content
+            )
+          } else {
+            content()
+          }
         }
+      }
     }
 
-    /*
-     * Since Mdc3Theme doesn't work with non-Material-3-themed Context instances, we replace the
-     * current local one by a OrcaContextThemeWrapper that has the same configurations as
-     * LocalContext.current but with Theme.Orca as its theme.
-     */
-    CompositionLocalProvider(
-        LocalContext provides with(LocalContext.current) {
-            remember {
-                OrcaContextThemeWrapper(this)
-            }
-        },
-        content = themedContent
-    )
+  /*
+   * Since Mdc3Theme doesn't work with non-Material-3-themed Context instances, we replace the
+   * current local one by a OrcaContextThemeWrapper that has the same configurations as
+   * LocalContext.current but with Theme.Orca as its theme.
+   */
+  CompositionLocalProvider(
+    LocalContext provides with(LocalContext.current) { remember { OrcaContextThemeWrapper(this) } },
+    content = themedContent
+  )
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/Borders.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/Borders.kt
@@ -14,80 +14,76 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.jeanbarrossilva.orca.platform.theme.configuration.colors.Colors
 
-/** [CompositionLocal] that provides [Borders]. **/
-internal val LocalBorders = compositionLocalOf {
-    Borders.Unspecified
-}
+/** [CompositionLocal] that provides [Borders]. */
+internal val LocalBorders = compositionLocalOf { Borders.Unspecified }
 
 /**
  * [BorderStroke]s by which components are bordered.
  *
  * @param default [BorderStroke] that's the default one.
- **/
+ */
 @Immutable
 data class Borders internal constructor(val default: BorderStroke) {
-    companion object {
-        /** Default width of the [default] border. **/
-        @Deprecated(
-            "Prefer referring to OrcaTheme when in Compose.",
-            ReplaceWith(
-                "OrcaTheme.borders.medium.width",
-                "com.jeanbarrossilva.orca.platform.theme.OrcaTheme"
-            )
+  companion object {
+    /** Default width of the [default] border. */
+    @Deprecated(
+      "Prefer referring to OrcaTheme when in Compose.",
+      ReplaceWith(
+        "OrcaTheme.borders.medium.width",
+        "com.jeanbarrossilva.orca.platform.theme.OrcaTheme"
+      )
+    )
+    internal const val DefaultWidth = 2
+
+    /** [Borders] with unspecified values. */
+    internal val Unspecified =
+      Borders(default = BorderStroke(width = Dp.Unspecified, Color.Unspecified))
+
+    /** [Borders] that are provided by default. */
+    internal val default
+      @Composable
+      @Suppress("DEPRECATION")
+      get() =
+        Borders(
+          default = BorderStroke(DefaultWidth.dp, Color(getDefaultColorInArgb(Colors.default)))
         )
-        internal const val DefaultWidth = 2
 
-        /** [Borders] with unspecified values. **/
-        internal val Unspecified =
-            Borders(default = BorderStroke(width = Dp.Unspecified, Color.Unspecified))
+    /** Whether components should have the [BorderStroke]s applied to them. */
+    internal val areApplicable
+      @Composable get() = areApplicable(LocalContext.current)
 
-        /** [Borders] that are provided by default. **/
-        internal val default
-            @Composable
-            @Suppress("DEPRECATION")
-            get() = Borders(
-                default = BorderStroke(
-                    DefaultWidth.dp,
-                    Color(getDefaultColorInArgb(Colors.default))
-                )
-            )
-
-        /** Whether components should have the [BorderStroke]s applied to them. **/
-        internal val areApplicable
-            @Composable get() = areApplicable(LocalContext.current)
-
-        /**
-         * Checks whether components should have the [BorderStroke]s applied to them.
-         *
-         * @param context [Context] through which the theme in which the system currently is will be
-         * obtained.
-         **/
-        @JvmName("areApplicable")
-        @JvmStatic
-        internal fun areApplicable(context: Context): Boolean {
-            return with(context.resources.configuration) {
-                uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_NO
-            }
-        }
-
-        /**
-         * Gets the [Color] by which the [default] border is colored by default.
-         *
-         * @param colors [Colors] by which it can be colored.
-         **/
-        @Deprecated(
-            "Prefer referring to OrcaTheme when in Compose.",
-            ReplaceWith(
-                "(OrcaTheme.borders.medium.brush as SolidColor).value.toArgb()",
-                "androidx.compose.ui.graphics.SolidColor",
-                "androidx.compose.ui.graphics.toArgb",
-                "com.jeanbarrossilva.orca.platform.theme.OrcaTheme"
-            )
-        )
-        @JvmName("getDefaultMediumColorInArgb")
-        @JvmStatic
-        internal fun getDefaultColorInArgb(colors: Colors): Int {
-            return colors.placeholder.toArgb()
-        }
+    /**
+     * Checks whether components should have the [BorderStroke]s applied to them.
+     *
+     * @param context [Context] through which the theme in which the system currently is will be
+     *   obtained.
+     */
+    @JvmName("areApplicable")
+    @JvmStatic
+    internal fun areApplicable(context: Context): Boolean {
+      return with(context.resources.configuration) {
+        uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_NO
+      }
     }
+
+    /**
+     * Gets the [Color] by which the [default] border is colored by default.
+     *
+     * @param colors [Colors] by which it can be colored.
+     */
+    @Deprecated(
+      "Prefer referring to OrcaTheme when in Compose.",
+      ReplaceWith(
+        "(OrcaTheme.borders.medium.brush as SolidColor).value.toArgb()",
+        "androidx.compose.ui.graphics.SolidColor",
+        "androidx.compose.ui.graphics.toArgb",
+        "com.jeanbarrossilva.orca.platform.theme.OrcaTheme"
+      )
+    )
+    @JvmName("getDefaultMediumColorInArgb")
+    @JvmStatic
+    internal fun getDefaultColorInArgb(colors: Colors): Int {
+      return colors.placeholder.toArgb()
+    }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/Overlays.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/Overlays.kt
@@ -6,22 +6,20 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
-/** [CompositionLocal] that provides [Overlays]. **/
-internal val LocalOverlays = compositionLocalOf {
-    Overlays.Unspecified
-}
+/** [CompositionLocal] that provides [Overlays]. */
+internal val LocalOverlays = compositionLocalOf { Overlays.Unspecified }
 
 /**
  * Portions of the UI taken by an element that's hierarchically higher.
  *
  * @param fab [PaddingValues] consumed by the FAB.
- **/
+ */
 data class Overlays internal constructor(val fab: PaddingValues) {
-    companion object {
-        /** [Overlays] with [Dp.Unspecified] values. **/
-        internal val Unspecified = Overlays(fab = PaddingValues(Dp.Unspecified))
+  companion object {
+    /** [Overlays] with [Dp.Unspecified] values. */
+    internal val Unspecified = Overlays(fab = PaddingValues(Dp.Unspecified))
 
-        /** [Overlays] that are provided by default. **/
-        internal val Default = Overlays(fab = PaddingValues(bottom = 88.dp))
-    }
+    /** [Overlays] that are provided by default. */
+    internal val Default = Overlays(fab = PaddingValues(bottom = 88.dp))
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/Shapes.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/Shapes.kt
@@ -11,10 +11,8 @@ import androidx.compose.ui.unit.Dp
 import com.jeanbarrossilva.orca.platform.theme.R
 import com.jeanbarrossilva.orca.platform.theme.extensions.getFraction
 
-/** [CompositionLocal] that provides [Shapes]. **/
-internal val LocalShapes = compositionLocalOf {
-    Shapes.Unspecified
-}
+/** [CompositionLocal] that provides [Shapes]. */
+internal val LocalShapes = compositionLocalOf { Shapes.Unspecified }
 
 /**
  * [CornerBasedShape]s by which UI components throughout the application are clipped.
@@ -22,37 +20,39 @@ internal val LocalShapes = compositionLocalOf {
  * @param large [CornerBasedShape] for large components.
  * @param medium [CornerBasedShape] for medium-sized components
  * @param small [CornerBasedShape] for small components..
- **/
-data class Shapes internal constructor(
-    val large: CornerBasedShape,
-    val medium: CornerBasedShape,
-    val small: CornerBasedShape
+ */
+data class Shapes
+internal constructor(
+  val large: CornerBasedShape,
+  val medium: CornerBasedShape,
+  val small: CornerBasedShape
 ) {
-    companion object {
-        /** [Shapes] with unspecified [CornerBasedShape]s. **/
-        internal val Unspecified = Shapes(
-            large = RoundedCornerShape(Dp.Unspecified),
-            medium = RoundedCornerShape(Dp.Unspecified),
-            small = RoundedCornerShape(Dp.Unspecified)
+  companion object {
+    /** [Shapes] with unspecified [CornerBasedShape]s. */
+    internal val Unspecified =
+      Shapes(
+        large = RoundedCornerShape(Dp.Unspecified),
+        medium = RoundedCornerShape(Dp.Unspecified),
+        small = RoundedCornerShape(Dp.Unspecified)
+      )
+
+    /** [Shapes] that are provided by default. */
+    internal val default
+      @Composable get() = getDefault(LocalContext.current)
+
+    /**
+     * Gets the [Shapes] that are provided by default.
+     *
+     * @param context [Context] from which the [Shapes] will be obtained.
+     */
+    internal fun getDefault(context: Context): Shapes {
+      return Shapes(
+        RoundedCornerShape(context.resources.getDimension(R.dimen.largeShapeCornerSize)),
+        RoundedCornerShape(context.resources.getDimension(R.dimen.mediumShapeCornerSize)),
+        RoundedCornerShape(
+          (context.resources.getFraction(R.fraction.smallShapeCornerSize) ?: 0f) * 100f
         )
-
-        /** [Shapes] that are provided by default. **/
-        internal val default
-            @Composable get() = getDefault(LocalContext.current)
-
-        /**
-         * Gets the [Shapes] that are provided by default.
-         *
-         * @param context [Context] from which the [Shapes] will be obtained.
-         **/
-        internal fun getDefault(context: Context): Shapes {
-            return Shapes(
-                RoundedCornerShape(context.resources.getDimension(R.dimen.largeShapeCornerSize)),
-                RoundedCornerShape(context.resources.getDimension(R.dimen.mediumShapeCornerSize)),
-                RoundedCornerShape(
-                    (context.resources.getFraction(R.fraction.smallShapeCornerSize) ?: 0f) * 100f
-                )
-            )
-        }
+      )
     }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/Spacings.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/Spacings.kt
@@ -6,10 +6,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
-/** [CompositionLocal] that provides [Spacings]. **/
-internal val LocalSpacings = compositionLocalOf {
-    Spacings.Unspecified
-}
+/** [CompositionLocal] that provides [Spacings]. */
+internal val LocalSpacings = compositionLocalOf { Spacings.Unspecified }
 
 /**
  * Sizes for spacing, such as the distance between one component and another or padding.
@@ -19,32 +17,30 @@ internal val LocalSpacings = compositionLocalOf {
  * @param medium Smaller than [large], greater than [small].
  * @param small Smaller than [medium], greater than [extraSmall].
  * @param extraSmall Smallest possible size.
- **/
-data class Spacings internal constructor(
-    val extraLarge: Dp,
-    val large: Dp,
-    val medium: Dp,
-    val small: Dp,
-    val extraSmall: Dp
+ */
+data class Spacings
+internal constructor(
+  val extraLarge: Dp,
+  val large: Dp,
+  val medium: Dp,
+  val small: Dp,
+  val extraSmall: Dp
 ) {
-    companion object {
-        /** [Spacings] with [Dp.Unspecified] values. **/
-        internal val Unspecified = Spacings(
-            extraLarge = Dp.Unspecified,
-            large = Dp.Unspecified,
-            medium = Dp.Unspecified,
-            small = Dp.Unspecified,
-            extraSmall = Dp.Unspecified
-        )
+  companion object {
+    /** [Spacings] with [Dp.Unspecified] values. */
+    internal val Unspecified =
+      Spacings(
+        extraLarge = Dp.Unspecified,
+        large = Dp.Unspecified,
+        medium = Dp.Unspecified,
+        small = Dp.Unspecified,
+        extraSmall = Dp.Unspecified
+      )
 
-        /** [Spacings] that are provided by default. **/
-        val default
-            @Composable get() = Spacings(
-                extraLarge = 32.dp,
-                large = 24.dp,
-                medium = 16.dp,
-                small = 8.dp,
-                extraSmall = 4.dp
-            )
-    }
+    /** [Spacings] that are provided by default. */
+    val default
+      @Composable
+      get() =
+        Spacings(extraLarge = 32.dp, large = 24.dp, medium = 16.dp, small = 8.dp, extraSmall = 4.dp)
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/colors/Colors.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/colors/Colors.kt
@@ -13,10 +13,8 @@ import com.jeanbarrossilva.orca.platform.theme.configuration.colors.contrast.Con
 import com.jeanbarrossilva.orca.platform.theme.configuration.colors.contrast.and
 import com.jeanbarrossilva.orca.platform.theme.extensions.of
 
-/** [CompositionLocal] that provides [Colors]. **/
-internal val LocalColors = compositionLocalOf {
-    Colors.Unspecified
-}
+/** [CompositionLocal] that provides [Colors]. */
+internal val LocalColors = compositionLocalOf { Colors.Unspecified }
 
 /**
  * [Contrast]s and [Color]s that compose the palette to be used by the application.
@@ -31,92 +29,79 @@ internal val LocalColors = compositionLocalOf {
  * @param secondary [Color] for secondary components.
  * @param surface [Contrast] for on-background or nested containers.
  * @param tertiary [Color] for tertiary components.
- **/
+ */
 @Immutable
-data class Colors internal constructor(
-    val activation: Activation,
-    val background: Contrast,
-    val disabled: Contrast,
-    val error: Contrast,
-    val link: Color,
-    val placeholder: Color,
-    val primary: Contrast,
-    val secondary: Color,
-    val surface: Contrast,
-    val tertiary: Color
+data class Colors
+internal constructor(
+  val activation: Activation,
+  val background: Contrast,
+  val disabled: Contrast,
+  val error: Contrast,
+  val link: Color,
+  val placeholder: Color,
+  val primary: Contrast,
+  val secondary: Color,
+  val surface: Contrast,
+  val tertiary: Color
 ) {
-    /**
-     * [Contrast]s representing activation states.
-     *
-     * @param favorite [Contrast] for a "favorited" state.
-     * @param reblog [Contrast] for a "reblogged" state.
-     **/
-    @Immutable
-    data class Activation internal constructor(val favorite: Color, val reblog: Color) {
-        companion object {
-            /** [Activation] with [Contrast.Unspecified] values. **/
-            internal val Unspecified =
-                Activation(favorite = Color.Unspecified, reblog = Color.Unspecified)
-
-            /** [Activation] that's provided by default. **/
-            internal val Default =
-                Activation(favorite = Color(0xFFD32F2F), reblog = Color(0xFF81C784))
-        }
-    }
-
+  /**
+   * [Contrast]s representing activation states.
+   *
+   * @param favorite [Contrast] for a "favorited" state.
+   * @param reblog [Contrast] for a "reblogged" state.
+   */
+  @Immutable
+  data class Activation internal constructor(val favorite: Color, val reblog: Color) {
     companion object {
-        /** [Colors] that are provided by default. **/
-        internal val default
-            @Composable get() = getDefault(LocalContext.current)
+      /** [Activation] with [Contrast.Unspecified] values. */
+      internal val Unspecified =
+        Activation(favorite = Color.Unspecified, reblog = Color.Unspecified)
 
-        /** [Colors] with unspecified values. **/
-        val Unspecified = Colors(
-            Activation.Unspecified,
-            background = Contrast.Unspecified,
-            disabled = Contrast.Unspecified,
-            error = Contrast.Unspecified,
-            link = Color.Unspecified,
-            placeholder = Color.Unspecified,
-            primary = Contrast.Unspecified,
-            secondary = Color.Unspecified,
-            surface = Contrast.Unspecified,
-            tertiary = Color.Unspecified
-        )
-
-        /**
-         * Gets the [Colors] that are provided by default.
-         *
-         * @param context [Context] from which the [Color]s will be obtained.
-         **/
-        @JvmStatic
-        fun getDefault(context: Context): Colors {
-            return Colors(
-                Activation.Default,
-                Color.of(context, R.color.backgroundContainer) and Color.of(
-                    context,
-                    R.color.backgroundContent
-                ),
-                Color.of(context, R.color.disabledContainer) and Color.of(
-                    context,
-                    R.color.disabledContent
-                ),
-                Color.of(context, R.color.errorContainer) and Color.of(
-                    context,
-                    R.color.errorContent
-                ),
-                Color.of(context, R.color.link),
-                Color.of(context, R.color.placeholder),
-                Color.of(context, R.color.primaryContainer) and Color.of(
-                    context,
-                    R.color.primaryContent
-                ),
-                Color.of(context, R.color.secondary),
-                Color.of(context, R.color.surfaceContainer) and Color.of(
-                    context,
-                    R.color.surfaceContent
-                ),
-                Color.of(context, R.color.tertiary)
-            )
-        }
+      /** [Activation] that's provided by default. */
+      internal val Default = Activation(favorite = Color(0xFFD32F2F), reblog = Color(0xFF81C784))
     }
+  }
+
+  companion object {
+    /** [Colors] that are provided by default. */
+    internal val default
+      @Composable get() = getDefault(LocalContext.current)
+
+    /** [Colors] with unspecified values. */
+    val Unspecified =
+      Colors(
+        Activation.Unspecified,
+        background = Contrast.Unspecified,
+        disabled = Contrast.Unspecified,
+        error = Contrast.Unspecified,
+        link = Color.Unspecified,
+        placeholder = Color.Unspecified,
+        primary = Contrast.Unspecified,
+        secondary = Color.Unspecified,
+        surface = Contrast.Unspecified,
+        tertiary = Color.Unspecified
+      )
+
+    /**
+     * Gets the [Colors] that are provided by default.
+     *
+     * @param context [Context] from which the [Color]s will be obtained.
+     */
+    @JvmStatic
+    fun getDefault(context: Context): Colors {
+      return Colors(
+        Activation.Default,
+        Color.of(context, R.color.backgroundContainer) and
+          Color.of(context, R.color.backgroundContent),
+        Color.of(context, R.color.disabledContainer) and Color.of(context, R.color.disabledContent),
+        Color.of(context, R.color.errorContainer) and Color.of(context, R.color.errorContent),
+        Color.of(context, R.color.link),
+        Color.of(context, R.color.placeholder),
+        Color.of(context, R.color.primaryContainer) and Color.of(context, R.color.primaryContent),
+        Color.of(context, R.color.secondary),
+        Color.of(context, R.color.surfaceContainer) and Color.of(context, R.color.surfaceContent),
+        Color.of(context, R.color.tertiary)
+      )
+    }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/colors/contrast/Contrast.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/colors/contrast/Contrast.extensions.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.graphics.Color
  * Creates a [Contrast] with the two contrasting [Color]s, this one and the [contentColor].
  *
  * @param contentColor [Color] to color the content with.
- **/
+ */
 internal infix fun Color.and(contentColor: Color): Contrast {
-    return Contrast(this, contentColor)
+  return Contrast(this, contentColor)
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/colors/contrast/Contrast.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/colors/contrast/Contrast.kt
@@ -8,11 +8,11 @@ import androidx.compose.ui.graphics.Color
  *
  * @param container [Color] to color a container with.
  * @param content [Color] to color the content with.
- **/
+ */
 @Immutable
 data class Contrast internal constructor(val container: Color, val content: Color) {
-    companion object {
-        /** [Contrast] with [Color.Unspecified] values. **/
-        val Unspecified = Color.Unspecified and Color.Unspecified
-    }
+  companion object {
+    /** [Contrast] with [Color.Unspecified] values. */
+    val Unspecified = Color.Unspecified and Color.Unspecified
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/iconography/Icon.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/iconography/Icon.kt
@@ -9,11 +9,11 @@ import com.jeanbarrossilva.orca.platform.theme.extensions.Empty
  *
  * @param outlined [ImageVector] that is outlined.
  * @param filled [ImageVector] that is filled.
- **/
+ */
 @Immutable
 data class Icon internal constructor(val outlined: ImageVector, val filled: ImageVector) {
-    companion object {
-        /** [Icon] with [ImageVector.Companion.Empty] values. **/
-        val Empty = Icon(outlined = ImageVector.Empty, filled = ImageVector.Empty)
-    }
+  companion object {
+    /** [Icon] with [ImageVector.Companion.Empty] values. */
+    val Empty = Icon(outlined = ImageVector.Empty, filled = ImageVector.Empty)
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/iconography/Iconography.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/configuration/iconography/Iconography.kt
@@ -8,10 +8,8 @@ import androidx.compose.ui.res.vectorResource
 import com.jeanbarrossilva.orca.platform.theme.R
 import com.jeanbarrossilva.orca.platform.theme.extensions.Empty
 
-/** [CompositionLocal] that provides an [Iconography]. **/
-internal val LocalIconography = compositionLocalOf {
-    Iconography.Empty
-}
+/** [CompositionLocal] that provides an [Iconography]. */
+internal val LocalIconography = compositionLocalOf { Iconography.Empty }
 
 /**
  * [Icon]s and [ImageVector]s that can be used throughout the app within various contexts.
@@ -33,122 +31,126 @@ internal val LocalIconography = compositionLocalOf {
  * @param profile [Icon] that symbolizes the user's or someone else's account.
  * @param reblog [ImageVector] for a single or various reposts.
  * @param search [ImageVector] that indicates the ability to search or the performance of such
- * operation for elements in a given context.
+ *   operation for elements in a given context.
  * @param selected [ImageVector] for selected states.
  * @param send [ImageVector] that denotes a send operation.
  * @param settings [Icon] for configurations.
  * @param share [Icon] for sharing.
  * @param unavailable [Icon] for unavailable resources.
- **/
-data class Iconography internal constructor(
-    val add: ImageVector,
-    val back: ImageVector,
-    val comment: Icon,
-    val compose: Icon,
-    val delete: Icon,
-    val edit: Icon,
-    val empty: ImageVector,
-    val expand: ImageVector,
-    val favorite: Icon,
-    val forward: ImageVector,
-    val home: Icon,
-    val link: ImageVector,
-    val login: ImageVector,
-    val mute: Icon,
-    val profile: Icon,
-    val reblog: ImageVector,
-    val search: ImageVector,
-    val selected: ImageVector,
-    val send: ImageVector,
-    val settings: Icon,
-    val share: Icon,
-    val unavailable: Icon
+ */
+data class Iconography
+internal constructor(
+  val add: ImageVector,
+  val back: ImageVector,
+  val comment: Icon,
+  val compose: Icon,
+  val delete: Icon,
+  val edit: Icon,
+  val empty: ImageVector,
+  val expand: ImageVector,
+  val favorite: Icon,
+  val forward: ImageVector,
+  val home: Icon,
+  val link: ImageVector,
+  val login: ImageVector,
+  val mute: Icon,
+  val profile: Icon,
+  val reblog: ImageVector,
+  val search: ImageVector,
+  val selected: ImageVector,
+  val send: ImageVector,
+  val settings: Icon,
+  val share: Icon,
+  val unavailable: Icon
 ) {
-    companion object {
-        /** [Iconography] with empty values. **/
-        internal val Empty = Iconography(
-            add = ImageVector.Empty,
-            back = ImageVector.Empty,
-            comment = Icon.Empty,
-            compose = Icon.Empty,
-            delete = Icon.Empty,
-            edit = Icon.Empty,
-            empty = ImageVector.Empty,
-            expand = ImageVector.Empty,
-            favorite = Icon.Empty,
-            forward = ImageVector.Empty,
-            home = Icon.Empty,
-            link = ImageVector.Empty,
-            login = ImageVector.Empty,
-            mute = Icon.Empty,
-            profile = Icon.Empty,
-            reblog = ImageVector.Empty,
-            search = ImageVector.Empty,
-            selected = ImageVector.Empty,
-            send = ImageVector.Empty,
-            settings = Icon.Empty,
-            share = Icon.Empty,
-            unavailable = Icon.Empty
-        )
+  companion object {
+    /** [Iconography] with empty values. */
+    internal val Empty =
+      Iconography(
+        add = ImageVector.Empty,
+        back = ImageVector.Empty,
+        comment = Icon.Empty,
+        compose = Icon.Empty,
+        delete = Icon.Empty,
+        edit = Icon.Empty,
+        empty = ImageVector.Empty,
+        expand = ImageVector.Empty,
+        favorite = Icon.Empty,
+        forward = ImageVector.Empty,
+        home = Icon.Empty,
+        link = ImageVector.Empty,
+        login = ImageVector.Empty,
+        mute = Icon.Empty,
+        profile = Icon.Empty,
+        reblog = ImageVector.Empty,
+        search = ImageVector.Empty,
+        selected = ImageVector.Empty,
+        send = ImageVector.Empty,
+        settings = Icon.Empty,
+        share = Icon.Empty,
+        unavailable = Icon.Empty
+      )
 
-        /** [Iconography] that's provided by default. **/
-        internal val default
-            @Composable get() = Iconography(
-                ImageVector.vectorResource(R.drawable.icon_add),
-                ImageVector.vectorResource(R.drawable.icon_back),
-                Icon(
-                    ImageVector.vectorResource(R.drawable.icon_comment_outlined),
-                    ImageVector.vectorResource(R.drawable.icon_comment_filled)
-                ),
-                Icon(
-                    ImageVector.vectorResource(R.drawable.icon_compose_outlined),
-                    ImageVector.vectorResource(R.drawable.icon_compose_filled)
-                ),
-                Icon(
-                    ImageVector.vectorResource(R.drawable.icon_delete_outlined),
-                    ImageVector.vectorResource(R.drawable.icon_delete_filled)
-                ),
-                Icon(
-                    ImageVector.vectorResource(R.drawable.icon_edit_outlined),
-                    ImageVector.vectorResource(R.drawable.icon_edit_filled)
-                ),
-                ImageVector.vectorResource(R.drawable.icon_empty),
-                ImageVector.vectorResource(R.drawable.icon_expand),
-                Icon(
-                    ImageVector.vectorResource(R.drawable.icon_favorite_outlined),
-                    ImageVector.vectorResource(R.drawable.icon_favorite_filled)
-                ),
-                ImageVector.vectorResource(R.drawable.icon_forward),
-                Icon(
-                    ImageVector.vectorResource(R.drawable.icon_home_outlined),
-                    ImageVector.vectorResource(R.drawable.icon_home_filled)
-                ),
-                ImageVector.vectorResource(R.drawable.icon_link),
-                ImageVector.vectorResource(R.drawable.icon_login),
-                Icon(
-                    ImageVector.vectorResource(R.drawable.icon_mute_outlined),
-                    ImageVector.vectorResource(R.drawable.icon_mute_filled)
-                ),
-                Icon(
-                    ImageVector.vectorResource(R.drawable.icon_profile_outlined),
-                    ImageVector.vectorResource(R.drawable.icon_profile_filled)
-                ),
-                ImageVector.vectorResource(R.drawable.icon_reblog),
-                ImageVector.vectorResource(R.drawable.icon_search),
-                ImageVector.vectorResource(R.drawable.icon_selected),
-                ImageVector.vectorResource(R.drawable.icon_send),
-                Icon(
-                    ImageVector.vectorResource(R.drawable.icon_settings_outlined),
-                    ImageVector.vectorResource(R.drawable.icon_settings_filled)
-                ),
-                Icon(
-                    ImageVector.vectorResource(R.drawable.icon_share_outlined),
-                    ImageVector.vectorResource(R.drawable.icon_share_filled)
-                ),
-                Icon(
-                    ImageVector.vectorResource(R.drawable.icon_unavailable_outlined),
-                    ImageVector.vectorResource(R.drawable.icon_unavailable_filled)
-                )
-            )
-    }
+    /** [Iconography] that's provided by default. */
+    internal val default
+      @Composable
+      get() =
+        Iconography(
+          ImageVector.vectorResource(R.drawable.icon_add),
+          ImageVector.vectorResource(R.drawable.icon_back),
+          Icon(
+            ImageVector.vectorResource(R.drawable.icon_comment_outlined),
+            ImageVector.vectorResource(R.drawable.icon_comment_filled)
+          ),
+          Icon(
+            ImageVector.vectorResource(R.drawable.icon_compose_outlined),
+            ImageVector.vectorResource(R.drawable.icon_compose_filled)
+          ),
+          Icon(
+            ImageVector.vectorResource(R.drawable.icon_delete_outlined),
+            ImageVector.vectorResource(R.drawable.icon_delete_filled)
+          ),
+          Icon(
+            ImageVector.vectorResource(R.drawable.icon_edit_outlined),
+            ImageVector.vectorResource(R.drawable.icon_edit_filled)
+          ),
+          ImageVector.vectorResource(R.drawable.icon_empty),
+          ImageVector.vectorResource(R.drawable.icon_expand),
+          Icon(
+            ImageVector.vectorResource(R.drawable.icon_favorite_outlined),
+            ImageVector.vectorResource(R.drawable.icon_favorite_filled)
+          ),
+          ImageVector.vectorResource(R.drawable.icon_forward),
+          Icon(
+            ImageVector.vectorResource(R.drawable.icon_home_outlined),
+            ImageVector.vectorResource(R.drawable.icon_home_filled)
+          ),
+          ImageVector.vectorResource(R.drawable.icon_link),
+          ImageVector.vectorResource(R.drawable.icon_login),
+          Icon(
+            ImageVector.vectorResource(R.drawable.icon_mute_outlined),
+            ImageVector.vectorResource(R.drawable.icon_mute_filled)
+          ),
+          Icon(
+            ImageVector.vectorResource(R.drawable.icon_profile_outlined),
+            ImageVector.vectorResource(R.drawable.icon_profile_filled)
+          ),
+          ImageVector.vectorResource(R.drawable.icon_reblog),
+          ImageVector.vectorResource(R.drawable.icon_search),
+          ImageVector.vectorResource(R.drawable.icon_selected),
+          ImageVector.vectorResource(R.drawable.icon_send),
+          Icon(
+            ImageVector.vectorResource(R.drawable.icon_settings_outlined),
+            ImageVector.vectorResource(R.drawable.icon_settings_filled)
+          ),
+          Icon(
+            ImageVector.vectorResource(R.drawable.icon_share_outlined),
+            ImageVector.vectorResource(R.drawable.icon_share_filled)
+          ),
+          Icon(
+            ImageVector.vectorResource(R.drawable.icon_unavailable_outlined),
+            ImageVector.vectorResource(R.drawable.icon_unavailable_filled)
+          )
+        )
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Any.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Any.extensions.kt
@@ -6,7 +6,7 @@ package com.jeanbarrossilva.orca.platform.theme.extensions
  *
  * @param condition Determines whether or not the result of [transform] will get returned.
  * @param transform Transformation to be made to the receiver.
- **/
+ */
 inline fun <T> T.`if`(condition: Boolean, transform: T.() -> T): T {
-    return if (condition) transform() else this
+  return if (condition) transform() else this
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Color.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Color.extensions.kt
@@ -9,8 +9,8 @@ import androidx.compose.ui.graphics.Color
  *
  * @param context [Context] from which the [Color] will be obtained.
  * @param id Resource ID of the [Color].
- **/
+ */
 internal fun Color.Companion.of(context: Context, @ColorRes id: Int): Color {
-    val value = context.getColor(id)
-    return Color(value)
+  val value = context.getColor(id)
+  return Color(value)
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/CornerBasedShape.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/CornerBasedShape.extensions.kt
@@ -5,19 +5,22 @@ import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.shape.ZeroCornerSize
 
-/** Version of this [CornerBasedShape] with zeroed top [CornerSize]s. **/
+/** Version of this [CornerBasedShape] with zeroed top [CornerSize]s. */
 internal val CornerBasedShape.bottom
-    get() = copy(topStart = ZeroCornerSize, topEnd = ZeroCornerSize)
+  get() = copy(topStart = ZeroCornerSize, topEnd = ZeroCornerSize)
 
-/** Reversed version of this [CornerBasedShape], with its top and bottom [CornerSize]s switched. **/
+/**
+ * Reversed version of this [CornerBasedShape], with its top and bottom [CornerSize]s switched. *
+ */
 internal val CornerBasedShape.reversed: CornerBasedShape
-    get() = RoundedCornerShape(
-        topStart = bottomStart,
-        topEnd = bottomEnd,
-        bottomEnd = topStart,
-        bottomStart = topStart
+  get() =
+    RoundedCornerShape(
+      topStart = bottomStart,
+      topEnd = bottomEnd,
+      bottomEnd = topStart,
+      bottomStart = topStart
     )
 
-/** Version of this [CornerBasedShape] with zeroed bottom [CornerSize]s. **/
+/** Version of this [CornerBasedShape] with zeroed bottom [CornerSize]s. */
 internal val CornerBasedShape.top
-    get() = copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize)
+  get() = copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize)

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/FontFamily.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/FontFamily.extensions.kt
@@ -6,19 +6,20 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import com.jeanbarrossilva.orca.platform.theme.R
 
-/** [FontFamily] of the Rubik typeface. **/
+/** [FontFamily] of the Rubik typeface. */
 internal val FontFamily.Companion.Rubik
-    get() = FontFamily(
-        Font(R.font.rubik_light, FontWeight.Light),
-        Font(R.font.rubik_light_italic, FontWeight.Light, FontStyle.Italic),
-        Font(R.font.rubik_normal),
-        Font(R.font.rubik_normal_italic, style = FontStyle.Italic),
-        Font(R.font.rubik_medium, FontWeight.Medium),
-        Font(R.font.rubik_medium_italic, FontWeight.Medium, FontStyle.Italic),
-        Font(R.font.rubik_bold, FontWeight.Bold),
-        Font(R.font.rubik_bold_italic, FontWeight.Bold, FontStyle.Italic),
-        Font(R.font.rubik_extra_bold, FontWeight.ExtraBold),
-        Font(R.font.rubik_extra_bold_italic, FontWeight.ExtraBold, FontStyle.Italic),
-        Font(R.font.rubik_black, FontWeight.Black),
-        Font(R.font.rubik_black_italic, FontWeight.Black, FontStyle.Italic)
+  get() =
+    FontFamily(
+      Font(R.font.rubik_light, FontWeight.Light),
+      Font(R.font.rubik_light_italic, FontWeight.Light, FontStyle.Italic),
+      Font(R.font.rubik_normal),
+      Font(R.font.rubik_normal_italic, style = FontStyle.Italic),
+      Font(R.font.rubik_medium, FontWeight.Medium),
+      Font(R.font.rubik_medium_italic, FontWeight.Medium, FontStyle.Italic),
+      Font(R.font.rubik_bold, FontWeight.Bold),
+      Font(R.font.rubik_bold_italic, FontWeight.Bold, FontStyle.Italic),
+      Font(R.font.rubik_extra_bold, FontWeight.ExtraBold),
+      Font(R.font.rubik_extra_bold_italic, FontWeight.ExtraBold, FontStyle.Italic),
+      Font(R.font.rubik_black, FontWeight.Black),
+      Font(R.font.rubik_black_italic, FontWeight.Black, FontStyle.Italic)
     )

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Icons.Rounded.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Icons.Rounded.extensions.kt
@@ -7,16 +7,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 
-/** Icon for backwards navigation that adapts to the direction of the layout. **/
+/** Icon for backwards navigation that adapts to the direction of the layout. */
 val Icons.Rounded.backwardsNavigationArrow
-    @Composable get() = when (LocalLayoutDirection.current) {
-        LayoutDirection.Ltr -> KeyboardArrowLeft
-        LayoutDirection.Rtl -> KeyboardArrowRight
+  @Composable
+  get() =
+    when (LocalLayoutDirection.current) {
+      LayoutDirection.Ltr -> KeyboardArrowLeft
+      LayoutDirection.Rtl -> KeyboardArrowRight
     }
 
-/** Icon for forwards navigation that adapts to the direction of the layout. **/
+/** Icon for forwards navigation that adapts to the direction of the layout. */
 val Icons.Rounded.forwardsNavigationArrow
-    @Composable get() = when (LocalLayoutDirection.current) {
-        LayoutDirection.Ltr -> KeyboardArrowRight
-        LayoutDirection.Rtl -> KeyboardArrowLeft
+  @Composable
+  get() =
+    when (LocalLayoutDirection.current) {
+      LayoutDirection.Ltr -> KeyboardArrowRight
+      LayoutDirection.Rtl -> KeyboardArrowLeft
     }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/ImageVector.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/ImageVector.extensions.kt
@@ -3,14 +3,14 @@ package com.jeanbarrossilva.orca.platform.theme.extensions
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 
-/** An empty [ImageVector]. **/
+/** An empty [ImageVector]. */
 internal val ImageVector.Companion.Empty
-    get() = ImageVector
-        .Builder(
-            name = "ImageVector.Empty",
-            defaultWidth = 1.dp,
-            defaultHeight = 1.dp,
-            viewportWidth = 1f,
-            viewportHeight = 1f
-        )
-        .build()
+  get() =
+    ImageVector.Builder(
+        name = "ImageVector.Empty",
+        defaultWidth = 1.dp,
+        defaultHeight = 1.dp,
+        viewportWidth = 1f,
+        viewportHeight = 1f
+      )
+      .build()

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Modifier.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Modifier.extensions.kt
@@ -13,9 +13,7 @@ import com.jeanbarrossilva.orca.platform.theme.configuration.Borders
  *
  * @param shape [Shape] of the [BorderStroke] to be applied.
  * @see Borders.areApplicable
- **/
+ */
 fun Modifier.border(shape: Shape): Modifier {
-    return composed {
-        if (Borders.areApplicable) border(OrcaTheme.borders.default, shape) else this
-    }
+  return composed { if (Borders.areApplicable) border(OrcaTheme.borders.default, shape) else this }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/MutableInteractionSource.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/MutableInteractionSource.extensions.kt
@@ -7,44 +7,44 @@ import kotlin.reflect.full.isSubclassOf
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
 
-/** [MutableInteractionSource] that doesn't emit the [Interaction]s that are sent to it. **/
+/** [MutableInteractionSource] that doesn't emit the [Interaction]s that are sent to it. */
 @Suppress("FunctionName")
 fun EmptyMutableInteractionSource(): MutableInteractionSource {
-    return object : MutableInteractionSource {
-        override val interactions = emptyFlow<Interaction>()
+  return object : MutableInteractionSource {
+    override val interactions = emptyFlow<Interaction>()
 
-        override suspend fun emit(interaction: Interaction) {
-        }
+    override suspend fun emit(interaction: Interaction) {}
 
-        override fun tryEmit(interaction: Interaction): Boolean {
-            return false
-        }
+    override fun tryEmit(interaction: Interaction): Boolean {
+      return false
     }
+  }
 }
 
 /**
  * [MutableInteractionSource] that ignores all specified [Interaction]s.
  *
  * @param ignored [KClass]es of the [Interaction]s to be ignored.
- **/
+ */
 @Suppress("FunctionName")
-fun IgnoringMutableInteractionSource(vararg ignored: KClass<out Interaction>):
-    MutableInteractionSource {
-    return object : MutableInteractionSource {
-        /** Whether this [Interaction] is ignored. **/
-        private val Interaction.isIgnored
-            get() = ignored.any(this::class::isSubclassOf)
+fun IgnoringMutableInteractionSource(
+  vararg ignored: KClass<out Interaction>
+): MutableInteractionSource {
+  return object : MutableInteractionSource {
+    /** Whether this [Interaction] is ignored. */
+    private val Interaction.isIgnored
+      get() = ignored.any(this::class::isSubclassOf)
 
-        override val interactions = MutableSharedFlow<Interaction>()
+    override val interactions = MutableSharedFlow<Interaction>()
 
-        override suspend fun emit(interaction: Interaction) {
-            if (!interaction.isIgnored) {
-                this.interactions.emit(interaction)
-            }
-        }
-
-        override fun tryEmit(interaction: Interaction): Boolean {
-            return !interaction.isIgnored && interactions.tryEmit(interaction)
-        }
+    override suspend fun emit(interaction: Interaction) {
+      if (!interaction.isIgnored) {
+        this.interactions.emit(interaction)
+      }
     }
+
+    override fun tryEmit(interaction: Interaction): Boolean {
+      return !interaction.isIgnored && interactions.tryEmit(interaction)
+    }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/PaddingValues.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/PaddingValues.extensions.kt
@@ -6,33 +6,33 @@ import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalLayoutDirection
 
-/** Alias for calling [PaddingValues.calculateBottomPadding]. **/
+/** Alias for calling [PaddingValues.calculateBottomPadding]. */
 internal val PaddingValues.bottom
-    get() = calculateBottomPadding()
+  get() = calculateBottomPadding()
 
-/** End padding calculated through the [LocalLayoutDirection]. **/
+/** End padding calculated through the [LocalLayoutDirection]. */
 internal val PaddingValues.end
-    @Composable get() = calculateEndPadding(LocalLayoutDirection.current)
+  @Composable get() = calculateEndPadding(LocalLayoutDirection.current)
 
-/** Start padding calculated through the [LocalLayoutDirection]. **/
+/** Start padding calculated through the [LocalLayoutDirection]. */
 internal val PaddingValues.start
-    @Composable get() = calculateStartPadding(LocalLayoutDirection.current)
+  @Composable get() = calculateStartPadding(LocalLayoutDirection.current)
 
-/** Alias for calling [PaddingValues.calculateTopPadding]. **/
+/** Alias for calling [PaddingValues.calculateTopPadding]. */
 internal val PaddingValues.top
-    get() = calculateTopPadding()
+  get() = calculateTopPadding()
 
 /**
  * Adds the [PaddingValues].
  *
  * @param other [PaddingValues] to add to the receiver one.
- **/
+ */
 @Composable
 operator fun PaddingValues.plus(other: PaddingValues): PaddingValues {
-    return PaddingValues(
-        start + other.start,
-        calculateTopPadding() + other.calculateTopPadding(),
-        end + other.end,
-        calculateBottomPadding() + other.calculateBottomPadding()
-    )
+  return PaddingValues(
+    start + other.start,
+    calculateTopPadding() + other.calculateTopPadding(),
+    end + other.end,
+    calculateBottomPadding() + other.calculateBottomPadding()
+  )
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/ProvidableCompositionLocal.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/ProvidableCompositionLocal.extensions.kt
@@ -5,34 +5,33 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
 
-/** Material 3's [ProvidableCompositionLocal] for [Typography]. **/
+/** Material 3's [ProvidableCompositionLocal] for [Typography]. */
 internal val LocalTypography
-    @Composable get() = material3CompositionLocalOf(MaterialTheme.typography)
+  @Composable get() = material3CompositionLocalOf(MaterialTheme.typography)
 
 /**
  * Gets Material 3's [ProvidableCompositionLocal] for the given type [T] through reflection (since
  * it's private API). If it fails to do so, creates one that provides the [fallback].
  *
  * @param fallback Instance of [T] to fallback to and provide to the created
- * [ProvidableCompositionLocal] if none is found at the default site.
+ *   [ProvidableCompositionLocal] if none is found at the default site.
  * @throws IllegalStateException When the name of [T] cannot be obtained.
  * @throws ClassCastException When the field at the default site exists but is not a
- * [ProvidableCompositionLocal]<[T]>.
- **/
-private inline fun <reified T : Any> material3CompositionLocalOf(fallback: T):
-    ProvidableCompositionLocal<T> {
-    val typeClass = T::class
-    val typeName =
-        typeClass.simpleName ?: throw IllegalStateException("Could not get $typeClass's name.")
-    val siteClassName = "androidx.compose.material3.${typeName}Kt"
-    val fieldName = "Local$typeName"
+ *   [ProvidableCompositionLocal]<[T]>.
+ */
+private inline fun <reified T : Any> material3CompositionLocalOf(
+  fallback: T
+): ProvidableCompositionLocal<T> {
+  val typeClass = T::class
+  val typeName =
+    typeClass.simpleName ?: throw IllegalStateException("Could not get $typeClass's name.")
+  val siteClassName = "androidx.compose.material3.${typeName}Kt"
+  val fieldName = "Local$typeName"
 
-    @Suppress("UNCHECKED_CAST")
-    return Class
-        .forName(siteClassName)
-        ?.getDeclaredField(fieldName)
-        ?.apply { isAccessible = true }
-        ?.get(null)
-        ?.let { it as ProvidableCompositionLocal<T> }
-        ?: staticCompositionLocalOf { fallback }
+  @Suppress("UNCHECKED_CAST")
+  return Class.forName(siteClassName)
+    ?.getDeclaredField(fieldName)
+    ?.apply { isAccessible = true }
+    ?.get(null)
+    ?.let { it as ProvidableCompositionLocal<T> } ?: staticCompositionLocalOf { fallback }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Resources.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Resources.extensions.kt
@@ -8,12 +8,12 @@ import androidx.annotation.FractionRes
  * Loads the fraction associated with the given resource [id].
  *
  * @param id ID of the fraction resource.
- **/
+ */
 @FloatRange(from = 0.0, to = 1.0)
 internal fun Resources.getFraction(@FractionRes id: Int): Float? {
-    return try {
-        getFraction(id, 1, 1)
-    } catch (_: Resources.NotFoundException) {
-        null
-    }
+  return try {
+    getFraction(id, 1, 1)
+  } catch (_: Resources.NotFoundException) {
+    null
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Typeface.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/extensions/Typeface.extensions.kt
@@ -8,23 +8,23 @@ import androidx.compose.ui.text.font.FontFamily
  * Applies the [fontFamily] to each [TextStyle].
  *
  * @param fontFamily [FontFamily] to be applied.
- **/
+ */
 internal fun Typography.with(fontFamily: FontFamily): Typography {
-    return copy(
-        displayLarge.copy(fontFamily = fontFamily),
-        displayMedium.copy(fontFamily = fontFamily),
-        displaySmall.copy(fontFamily = fontFamily),
-        headlineLarge.copy(fontFamily = fontFamily),
-        headlineMedium.copy(fontFamily = fontFamily),
-        headlineSmall.copy(fontFamily = fontFamily),
-        titleLarge.copy(fontFamily = fontFamily),
-        titleMedium.copy(fontFamily = fontFamily),
-        titleSmall.copy(fontFamily = fontFamily),
-        bodyLarge.copy(fontFamily = fontFamily),
-        bodyMedium.copy(fontFamily = fontFamily),
-        bodySmall.copy(fontFamily = fontFamily),
-        labelLarge.copy(fontFamily = fontFamily),
-        labelMedium.copy(fontFamily = fontFamily),
-        labelSmall.copy(fontFamily = fontFamily)
-    )
+  return copy(
+    displayLarge.copy(fontFamily = fontFamily),
+    displayMedium.copy(fontFamily = fontFamily),
+    displaySmall.copy(fontFamily = fontFamily),
+    headlineLarge.copy(fontFamily = fontFamily),
+    headlineMedium.copy(fontFamily = fontFamily),
+    headlineSmall.copy(fontFamily = fontFamily),
+    titleLarge.copy(fontFamily = fontFamily),
+    titleMedium.copy(fontFamily = fontFamily),
+    titleSmall.copy(fontFamily = fontFamily),
+    bodyLarge.copy(fontFamily = fontFamily),
+    bodyMedium.copy(fontFamily = fontFamily),
+    bodySmall.copy(fontFamily = fontFamily),
+    labelLarge.copy(fontFamily = fontFamily),
+    labelMedium.copy(fontFamily = fontFamily),
+    labelSmall.copy(fontFamily = fontFamily)
+  )
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/Hoverable.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/Hoverable.kt
@@ -27,13 +27,13 @@ import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
  *
  * @param modifier [Modifier] to be applied to the underlying [Box].
  * @param content Content to be highlighted when hovered.
- **/
+ */
 @Composable
 fun Hoverable(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
-    val interactionSource = remember(::MutableInteractionSource)
-    val isHovered by interactionSource.collectIsHoveredAsState()
+  val interactionSource = remember(::MutableInteractionSource)
+  val isHovered by interactionSource.collectIsHoveredAsState()
 
-    Hoverable(isHovered, modifier.hoverable(interactionSource), content)
+  Hoverable(isHovered, modifier.hoverable(interactionSource), content)
 }
 
 /**
@@ -43,69 +43,52 @@ fun Hoverable(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
  * @param isHighlighted Whether the [content] is highlighted.
  * @param modifier [Modifier] to be applied to the underlying [Box].
  * @param content Content to be highlighted.
- **/
+ */
 @Composable
 private fun Hoverable(
-    isHighlighted: Boolean,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit
+  isHighlighted: Boolean,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit
 ) {
-    val density = LocalDensity.current
-    val animationSpec = tween<Float>(durationMillis = 128)
-    val alpha by animateFloatAsState(if (isHighlighted) 1f else 0f, animationSpec, label = "Alpha")
-    val containerColor = OrcaTheme.colors.placeholder
-    val shape = OrcaTheme.shapes.large
-    val spacing = OrcaTheme.spacings.small
-    val spacingInPx = remember(density, spacing) {
-        with(density) {
-            spacing.toPx()
-        }
-    }
-    val scale by animateFloatAsState(
-        if (isHighlighted) .95f else 1f,
-        animationSpec,
-        label = "Scale"
-    )
+  val density = LocalDensity.current
+  val animationSpec = tween<Float>(durationMillis = 128)
+  val alpha by animateFloatAsState(if (isHighlighted) 1f else 0f, animationSpec, label = "Alpha")
+  val containerColor = OrcaTheme.colors.placeholder
+  val shape = OrcaTheme.shapes.large
+  val spacing = OrcaTheme.spacings.small
+  val spacingInPx = remember(density, spacing) { with(density) { spacing.toPx() } }
+  val scale by animateFloatAsState(if (isHighlighted) .95f else 1f, animationSpec, label = "Scale")
 
-    Box(
-        Modifier
-            .drawBehind {
-                drawRoundRect(
-                    containerColor,
-                    topLeft = Offset(x = -spacingInPx, y = -spacingInPx),
-                    size = size.copy(
-                        width = size.width + spacingInPx * 2,
-                        height = size.height + spacingInPx * 2
-                    ),
-                    cornerRadius = CornerRadius(shape.topStart.toPx(size, density)),
-                    alpha = alpha
-                )
-            }
-            .scale(scale)
-            .then(modifier)
-    ) {
-        content()
-    }
+  Box(
+    Modifier.drawBehind {
+        drawRoundRect(
+          containerColor,
+          topLeft = Offset(x = -spacingInPx, y = -spacingInPx),
+          size =
+            size.copy(width = size.width + spacingInPx * 2, height = size.height + spacingInPx * 2),
+          cornerRadius = CornerRadius(shape.topStart.toPx(size, density)),
+          alpha = alpha
+        )
+      }
+      .scale(scale)
+      .then(modifier)
+  ) {
+    content()
+  }
 }
 
-/** Preview of an idle [Hoverable]. **/
+/** Preview of an idle [Hoverable]. */
 @Composable
 @MultiThemePreview
 private fun IdleHoverablePreview() {
-    OrcaTheme {
-        Hoverable(isHighlighted = false)
-    }
+  OrcaTheme { Hoverable(isHighlighted = false) }
 }
 
-/** Preview of a highlighted [Hoverable]. **/
+/** Preview of a highlighted [Hoverable]. */
 @Composable
 @MultiThemePreview
 private fun HighlightedHoverablePreview() {
-    OrcaTheme {
-        Column {
-            Hoverable(isHighlighted = true)
-        }
-    }
+  OrcaTheme { Column { Hoverable(isHighlighted = true) } }
 }
 
 /**
@@ -114,12 +97,12 @@ private fun HighlightedHoverablePreview() {
  *
  * @param isHighlighted Whether the content is highlighted.
  * @param modifier [Modifier] to be applied to the underlying [Box].
- **/
+ */
 @Composable
 private fun Hoverable(isHighlighted: Boolean, modifier: Modifier = Modifier) {
-    Hoverable(isHighlighted, modifier) {
-        IconButton(onClick = { }) {
-            Icon(OrcaTheme.iconography.home.outlined, contentDescription = "Home")
-        }
+  Hoverable(isHighlighted, modifier) {
+    IconButton(onClick = {}) {
+      Icon(OrcaTheme.iconography.home.outlined, contentDescription = "Home")
     }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/button/HoverableIconButton.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/button/HoverableIconButton.kt
@@ -18,28 +18,28 @@ import com.jeanbarrossilva.orca.platform.theme.kit.action.Hoverable
  * @param onClick Callback run whenever this [HoverableIconButton] is clicked.
  * @param modifier [Modifier] to be applied to the underlying [Hoverable].
  * @param content [Icon] to be shown.
- **/
+ */
 @Composable
 fun HoverableIconButton(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit
 ) {
-    val interactionSource = remember {
-        IgnoringMutableInteractionSource(PressInteraction.Press::class, HoverInteraction::class)
-    }
+  val interactionSource = remember {
+    IgnoringMutableInteractionSource(PressInteraction.Press::class, HoverInteraction::class)
+  }
 
-    Hoverable(modifier) {
-        IconButton(onClick, interactionSource = interactionSource, content = content)
-    }
+  Hoverable(modifier) {
+    IconButton(onClick, interactionSource = interactionSource, content = content)
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun HoverableIconButtonPreview() {
-    OrcaTheme {
-        HoverableIconButton(onClick = { }) {
-            Icon(OrcaTheme.iconography.home.outlined, contentDescription = "Home")
-        }
+  OrcaTheme {
+    HoverableIconButton(onClick = {}) {
+      Icon(OrcaTheme.iconography.home.outlined, contentDescription = "Home")
     }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/button/PrimaryButton.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/button/PrimaryButton.kt
@@ -27,66 +27,60 @@ import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
  * @param modifier [Modifier] to be applied to the underlying [ElevatedButton].
  * @param isEnabled Whether it can be interacted with.
  * @param content Content to be placed inside of it; generally a [Text] that shortly explains the
- * action performed by [onClick].
- **/
+ *   action performed by [onClick].
+ */
 @Composable
 fun PrimaryButton(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    isEnabled: Boolean = true,
-    content: @Composable () -> Unit
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  isEnabled: Boolean = true,
+  content: @Composable () -> Unit
 ) {
-    val enabledContentColor = OrcaTheme.colors.primary.content
-    val disabledContentColor = OrcaTheme.colors.disabled.content
-    val contentColor = remember(isEnabled, enabledContentColor, disabledContentColor) {
-        if (isEnabled) enabledContentColor else disabledContentColor
+  val enabledContentColor = OrcaTheme.colors.primary.content
+  val disabledContentColor = OrcaTheme.colors.disabled.content
+  val contentColor =
+    remember(isEnabled, enabledContentColor, disabledContentColor) {
+      if (isEnabled) enabledContentColor else disabledContentColor
     }
-    var isLoading by remember { mutableStateOf(false) }
+  var isLoading by remember { mutableStateOf(false) }
 
-    ElevatedButton(
-        onClick = {
-            isLoading = true
-            onClick()
-            isLoading = false
-        },
-        modifier,
-        isEnabled,
-        shape = OrcaTheme.shapes.medium,
-        colors = ButtonDefaults.elevatedButtonColors(
-            OrcaTheme.colors.primary.container,
-            enabledContentColor,
-            OrcaTheme.colors.disabled.container,
-            disabledContentColor
-        ),
-        contentPadding = PaddingValues(OrcaTheme.spacings.large)
-    ) {
-        if (isLoading) {
-            CircularProgressIndicator(
-                Modifier.size(17.4.dp),
-                contentColor,
-                strokeCap = StrokeCap.Round
-            )
-        } else {
-            ProvideTextStyle(LocalTextStyle.current.copy(color = contentColor), content)
-        }
+  ElevatedButton(
+    onClick = {
+      isLoading = true
+      onClick()
+      isLoading = false
+    },
+    modifier,
+    isEnabled,
+    shape = OrcaTheme.shapes.medium,
+    colors =
+      ButtonDefaults.elevatedButtonColors(
+        OrcaTheme.colors.primary.container,
+        enabledContentColor,
+        OrcaTheme.colors.disabled.container,
+        disabledContentColor
+      ),
+    contentPadding = PaddingValues(OrcaTheme.spacings.large)
+  ) {
+    if (isLoading) {
+      CircularProgressIndicator(Modifier.size(17.4.dp), contentColor, strokeCap = StrokeCap.Round)
+    } else {
+      ProvideTextStyle(LocalTextStyle.current.copy(color = contentColor), content)
     }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun DisabledPrimaryButtonPreview() {
-    OrcaTheme {
-        PrimaryButton(isEnabled = false)
-    }
+  OrcaTheme { PrimaryButton(isEnabled = false) }
 }
 
-/** Preview of an enabled [PrimaryButton]. **/
+/** Preview of an enabled [PrimaryButton]. */
 @Composable
 @MultiThemePreview
 private fun EnabledPrimaryButtonPreview() {
-    OrcaTheme {
-        PrimaryButton(isEnabled = true)
-    }
+  OrcaTheme { PrimaryButton(isEnabled = true) }
 }
 
 /**
@@ -95,10 +89,8 @@ private fun EnabledPrimaryButtonPreview() {
  *
  * @param isEnabled Whether it can be interacted with.
  * @param modifier [Modifier] to be applied to the underlying [ElevatedButton].
- **/
+ */
 @Composable
 private fun PrimaryButton(isEnabled: Boolean, modifier: Modifier = Modifier) {
-    PrimaryButton(onClick = { }, modifier, isEnabled) {
-        Text("Label")
-    }
+  PrimaryButton(onClick = {}, modifier, isEnabled) { Text("Label") }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/setting/ActionScope.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/setting/ActionScope.kt
@@ -13,49 +13,47 @@ import androidx.compose.ui.unit.dp
 import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
 import com.jeanbarrossilva.orca.platform.theme.configuration.iconography.Iconography
 
-/** Scope through which either an [icon] or a [button] action can be added. **/
+/** Scope through which either an [icon] or a [button] action can be added. */
 class ActionScope internal constructor() {
-    /** Content that's been set as the action. **/
-    internal var content: @Composable () -> Unit by mutableStateOf({ })
-        private set
+  /** Content that's been set as the action. */
+  internal var content: @Composable () -> Unit by mutableStateOf({})
+    private set
 
-    /**
-     * Adds an [Icon].
-     *
-     * @param contentDescription Returns the description of what the [Icon] within the [IconButton]
-     * represents.
-     * @param modifier [Modifier] to be applied to the [Icon].
-     * @param vector Returns the [ImageVector] to be shown.
-     **/
-    fun icon(
-        contentDescription: @Composable () -> String,
-        modifier: Modifier = Modifier,
-        vector: Iconography.() -> ImageVector
-    ) {
-        content = {
-            Icon(OrcaTheme.iconography.vector(), contentDescription(), modifier)
-        }
-    }
+  /**
+   * Adds an [Icon].
+   *
+   * @param contentDescription Returns the description of what the [Icon] within the [IconButton]
+   *   represents.
+   * @param modifier [Modifier] to be applied to the [Icon].
+   * @param vector Returns the [ImageVector] to be shown.
+   */
+  fun icon(
+    contentDescription: @Composable () -> String,
+    modifier: Modifier = Modifier,
+    vector: Iconography.() -> ImageVector
+  ) {
+    content = { Icon(OrcaTheme.iconography.vector(), contentDescription(), modifier) }
+  }
 
-    /**
-     * Adds an [IconButton].
-     *
-     * @param contentDescription Returns the description of what the [Icon] within the [IconButton]
-     * represents.
-     * @param onClick Callback run whenever the [IconButton] is clicked.
-     * @param modifier [Modifier] to be applied to the [IconButton].
-     * @param vector Returns the [ImageVector] to be shown by the [Icon].
-     **/
-    fun button(
-        contentDescription: @Composable () -> String,
-        onClick: () -> Unit,
-        modifier: Modifier = Modifier,
-        vector: Iconography.() -> ImageVector
-    ) {
-        content = {
-            IconButton(onClick, modifier.offset(x = 12.dp)) {
-                Icon(OrcaTheme.iconography.vector(), contentDescription())
-            }
-        }
+  /**
+   * Adds an [IconButton].
+   *
+   * @param contentDescription Returns the description of what the [Icon] within the [IconButton]
+   *   represents.
+   * @param onClick Callback run whenever the [IconButton] is clicked.
+   * @param modifier [Modifier] to be applied to the [IconButton].
+   * @param vector Returns the [ImageVector] to be shown by the [Icon].
+   */
+  fun button(
+    contentDescription: @Composable () -> String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    vector: Iconography.() -> ImageVector
+  ) {
+    content = {
+      IconButton(onClick, modifier.offset(x = 12.dp)) {
+        Icon(OrcaTheme.iconography.vector(), contentDescription())
+      }
     }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/setting/Group.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/setting/Group.kt
@@ -41,91 +41,86 @@ import com.jeanbarrossilva.orca.platform.theme.kit.action.setting.list.settingsP
  * @param modifier [Modifier] to be applied to the underlying [Column].
  * @param isInitiallyExpanded Whether it is expanded by default.
  * @param content Actions to be run on the given [SettingsScope].
- **/
+ */
 @Composable
 internal fun Group(
-    icon: @Composable () -> Unit,
-    label: @Composable () -> Unit,
-    modifier: Modifier = Modifier,
-    isInitiallyExpanded: Boolean = false,
-    shape: CornerBasedShape = SettingDefaults.shape,
-    content: SettingsScope.() -> Unit
+  icon: @Composable () -> Unit,
+  label: @Composable () -> Unit,
+  modifier: Modifier = Modifier,
+  isInitiallyExpanded: Boolean = false,
+  shape: CornerBasedShape = SettingDefaults.shape,
+  content: SettingsScope.() -> Unit
 ) {
-    val density = LocalDensity.current
-    var isExpanded by remember(isInitiallyExpanded) { mutableStateOf(isInitiallyExpanded) }
-    val expansion = updateTransition(isExpanded, label = "Transition")
-    val actionRotationInDegrees by expansion
-        .animateFloat(label = "ActionRotationInDegrees") { if (it) 90f else 0f }
+  val density = LocalDensity.current
+  var isExpanded by remember(isInitiallyExpanded) { mutableStateOf(isInitiallyExpanded) }
+  val expansion = updateTransition(isExpanded, label = "Transition")
+  val actionRotationInDegrees by
+    expansion.animateFloat(label = "ActionRotationInDegrees") { if (it) 90f else 0f }
 
-    Column(modifier) {
-        BoxWithConstraints(Modifier.zIndex(1f)) {
-            val width = remember(constraints.maxWidth, constraints.maxWidth::toFloat)
-            val height = remember(constraints.maxHeight, constraints.maxHeight::toFloat)
-            val size = remember(width, height) { Size(width, height) }
-            val expandedShapeBottomEndCornerSizeInDp = remember(density, size, shape) {
-                with(density) {
-                    shape.bottomEnd.toPx(size, density).toDp()
-                }
-            }
-            val expandedShapeBottomStartCornerSizeInDp = remember(density, size, shape) {
-                with(density) {
-                    shape.bottomStart.toPx(size, density).toDp()
-                }
-            }
-            val bottomEndCornerSizeInDp by expansion.animateDp(
-                label = "BottomEndCornerSizeInDp"
-            ) { if (it) 0.dp else expandedShapeBottomEndCornerSizeInDp }
-            val bottomStartCornerSizeInDp by expansion.animateDp(
-                label = "BottomStartCornerSizeInDp"
-            ) { if (it) 0.dp else expandedShapeBottomStartCornerSizeInDp }
-            val bottomEndCornerSize =
-                remember(bottomEndCornerSizeInDp) { CornerSize(bottomEndCornerSizeInDp) }
-            val bottomStartCornerSize =
-                remember(bottomStartCornerSizeInDp) { CornerSize(bottomStartCornerSizeInDp) }
-
-            Setting(
-                label,
-                shape = shape
-                    .copy(bottomEnd = bottomEndCornerSize, bottomStart = bottomStartCornerSize),
-                onClick = { isExpanded = !isExpanded },
-                icon = icon
-            ) {
-                icon(
-                    contentDescription = { "Expand" },
-                    Modifier.rotate(actionRotationInDegrees),
-                    Iconography::forward
-                )
-            }
+  Column(modifier) {
+    BoxWithConstraints(Modifier.zIndex(1f)) {
+      val width = remember(constraints.maxWidth, constraints.maxWidth::toFloat)
+      val height = remember(constraints.maxHeight, constraints.maxHeight::toFloat)
+      val size = remember(width, height) { Size(width, height) }
+      val expandedShapeBottomEndCornerSizeInDp =
+        remember(density, size, shape) {
+          with(density) { shape.bottomEnd.toPx(size, density).toDp() }
         }
-
-        @OptIn(ExperimentalAnimationApi::class)
-        expansion.AnimatedVisibility(
-            visible = { it },
-            Modifier.zIndex(0f),
-            enter = slideInVertically { -it } + expandVertically(),
-            exit = slideOutVertically { -it } + shrinkVertically()
-        ) {
-            ChildSettings(content = content)
+      val expandedShapeBottomStartCornerSizeInDp =
+        remember(density, size, shape) {
+          with(density) { shape.bottomStart.toPx(size, density).toDp() }
         }
+      val bottomEndCornerSizeInDp by
+        expansion.animateDp(label = "BottomEndCornerSizeInDp") {
+          if (it) 0.dp else expandedShapeBottomEndCornerSizeInDp
+        }
+      val bottomStartCornerSizeInDp by
+        expansion.animateDp(label = "BottomStartCornerSizeInDp") {
+          if (it) 0.dp else expandedShapeBottomStartCornerSizeInDp
+        }
+      val bottomEndCornerSize =
+        remember(bottomEndCornerSizeInDp) { CornerSize(bottomEndCornerSizeInDp) }
+      val bottomStartCornerSize =
+        remember(bottomStartCornerSizeInDp) { CornerSize(bottomStartCornerSizeInDp) }
+
+      Setting(
+        label,
+        shape = shape.copy(bottomEnd = bottomEndCornerSize, bottomStart = bottomStartCornerSize),
+        onClick = { isExpanded = !isExpanded },
+        icon = icon
+      ) {
+        icon(
+          contentDescription = { "Expand" },
+          Modifier.rotate(actionRotationInDegrees),
+          Iconography::forward
+        )
+      }
     }
+
+    @OptIn(ExperimentalAnimationApi::class)
+    expansion.AnimatedVisibility(
+      visible = { it },
+      Modifier.zIndex(0f),
+      enter = slideInVertically { -it } + expandVertically(),
+      exit = slideOutVertically { -it } + shrinkVertically()
+    ) {
+      ChildSettings(content = content)
+    }
+  }
 }
 
-/** Preview of a collapsed [Group]. **/
+/** Preview of a collapsed [Group]. */
 @Composable
 @MultiThemePreview
 private fun CollapsedGroupPreview() {
-    OrcaTheme {
-        Group(isInitiallyExpanded = false)
-    }
+  OrcaTheme { Group(isInitiallyExpanded = false) }
 }
 
-/** Preview of an expanded [Group]. **/
+/** Preview of an expanded [Group]. */
 @Composable
 @MultiThemePreview
 private fun ExpandedGroupPreview() {
-    OrcaTheme {
-        Group(isInitiallyExpanded = true)
-    }
+  OrcaTheme { Group(isInitiallyExpanded = true) }
 }
 
 /**
@@ -133,14 +128,14 @@ private fun ExpandedGroupPreview() {
  *
  * @param isInitiallyExpanded Whether it is expanded by default.
  * @param modifier [Modifier] to be applied to the underlying [Column].
- **/
+ */
 @Composable
 private fun Group(isInitiallyExpanded: Boolean, modifier: Modifier = Modifier) {
-    Group(
-        icon = { Icon(OrcaTheme.iconography.home.filled, contentDescription = "Setting") },
-        label = { Text("Group") },
-        modifier,
-        isInitiallyExpanded,
-        content = settingsPreviewContent
-    )
+  Group(
+    icon = { Icon(OrcaTheme.iconography.home.filled, contentDescription = "Setting") },
+    label = { Text("Group") },
+    modifier,
+    isInitiallyExpanded,
+    content = settingsPreviewContent
+  )
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/setting/Section.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/setting/Section.kt
@@ -15,23 +15,23 @@ import com.jeanbarrossilva.orca.platform.theme.kit.action.setting.list.settingsP
 
 @Composable
 fun Section(title: String, modifier: Modifier = Modifier, content: SettingsScope.() -> Unit) {
-    Column(modifier, verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.small)) {
-        Text(
-            title.uppercase(),
-            Modifier.offset(x = SettingDefaults.spacing),
-            style = OrcaTheme.typography.labelMedium
-        )
+  Column(modifier, verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.small)) {
+    Text(
+      title.uppercase(),
+      Modifier.offset(x = SettingDefaults.spacing),
+      style = OrcaTheme.typography.labelMedium
+    )
 
-        Settings(modifier, content)
-    }
+    Settings(modifier, content)
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun SectionPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            Section(title = "Section", content = settingsPreviewContent)
-        }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) {
+      Section(title = "Section", content = settingsPreviewContent)
     }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/setting/Setting.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/setting/Setting.kt
@@ -21,15 +21,15 @@ import com.jeanbarrossilva.orca.platform.theme.MultiThemePreview
 import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
 import com.jeanbarrossilva.orca.platform.theme.configuration.iconography.Iconography
 
-/** Default values of a [Setting]. **/
+/** Default values of a [Setting]. */
 internal object SettingDefaults {
-    /** [CornerBasedShape] that clips a [Setting] by default. **/
-    val shape
-        @Composable get() = OrcaTheme.shapes.large
+  /** [CornerBasedShape] that clips a [Setting] by default. */
+  val shape
+    @Composable get() = OrcaTheme.shapes.large
 
-    /** Size in [Dp]s of the default spacing of a [Setting]. **/
-    val spacing
-        @Composable get() = OrcaTheme.spacings.large
+  /** Size in [Dp]s of the default spacing of a [Setting]. */
+  val spacing
+    @Composable get() = OrcaTheme.spacings.large
 }
 
 /**
@@ -41,58 +41,51 @@ internal object SettingDefaults {
  * @param onClick Callback run whenever it's clicked.
  * @param icon [Icon] that visually represents what it does.
  * @param action Portrays the result of invoking [onClick] or executes a related action.
- **/
+ */
 @Composable
 internal fun Setting(
-    label: @Composable () -> Unit,
-    modifier: Modifier = Modifier,
-    shape: Shape = SettingDefaults.shape,
-    onClick: () -> Unit = { },
-    icon: @Composable () -> Unit = { },
-    action: ActionScope.() -> Unit = { }
+  label: @Composable () -> Unit,
+  modifier: Modifier = Modifier,
+  shape: Shape = SettingDefaults.shape,
+  onClick: () -> Unit = {},
+  icon: @Composable () -> Unit = {},
+  action: ActionScope.() -> Unit = {}
 ) {
-    Surface(Modifier.fillMaxWidth(), shape) {
-        Row(
-            Modifier
-                .clickable(onClick = onClick)
-                .padding(SettingDefaults.spacing)
-                .then(modifier),
-            Arrangement.SpaceBetween,
-            Alignment.CenterVertically
-        ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(SettingDefaults.spacing),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                icon()
+  Surface(Modifier.fillMaxWidth(), shape) {
+    Row(
+      Modifier.clickable(onClick = onClick).padding(SettingDefaults.spacing).then(modifier),
+      Arrangement.SpaceBetween,
+      Alignment.CenterVertically
+    ) {
+      Row(
+        horizontalArrangement = Arrangement.spacedBy(SettingDefaults.spacing),
+        verticalAlignment = Alignment.CenterVertically
+      ) {
+        icon()
 
-                ProvideTextStyle(
-                    OrcaTheme.typography.labelMedium.copy(
-                        color = OrcaTheme.colors.background.content
-                    ),
-                    label
-                )
-            }
+        ProvideTextStyle(
+          OrcaTheme.typography.labelMedium.copy(color = OrcaTheme.colors.background.content),
+          label
+        )
+      }
 
-            Spacer(Modifier.width(SettingDefaults.spacing))
-            ActionScope().apply(action).content()
-        }
+      Spacer(Modifier.width(SettingDefaults.spacing))
+      ActionScope().apply(action).content()
     }
+  }
 }
 
-/** Preview of a [Setting]. **/
+/** Preview of a [Setting]. */
 @Composable
 @MultiThemePreview
 private fun SettingPreview() {
-    OrcaTheme {
-        Setting(
-            onClick = { },
-            label = { Text("Label") },
-            icon = {
-                Icon(OrcaTheme.iconography.home.filled, contentDescription = "Setting")
-            }
-        ) {
-            icon(contentDescription = { "Expand" }, vector = Iconography::forward)
-        }
+  OrcaTheme {
+    Setting(
+      onClick = {},
+      label = { Text("Label") },
+      icon = { Icon(OrcaTheme.iconography.home.filled, contentDescription = "Setting") }
+    ) {
+      icon(contentDescription = { "Expand" }, vector = Iconography::forward)
     }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/setting/list/Settings.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/setting/list/Settings.kt
@@ -19,17 +19,17 @@ import com.jeanbarrossilva.orca.platform.theme.extensions.top
 import com.jeanbarrossilva.orca.platform.theme.kit.action.setting.Setting
 import com.jeanbarrossilva.orca.platform.theme.kit.action.setting.SettingDefaults
 
-/** Content of [Settings] shown in previews. **/
+/** Content of [Settings] shown in previews. */
 internal val settingsPreviewContent: SettingsScope.() -> Unit = {
-    repeat(3) {
-        setting(
-            onClick = { },
-            label = { Text("Label #$it") },
-            icon = { Icon(OrcaTheme.iconography.link, contentDescription = "Setting") }
-        ) {
-            icon(contentDescription = { "Navigate" }, vector = Iconography::forward)
-        }
+  repeat(3) {
+    setting(
+      onClick = {},
+      label = { Text("Label #$it") },
+      icon = { Icon(OrcaTheme.iconography.link, contentDescription = "Setting") }
+    ) {
+      icon(contentDescription = { "Navigate" }, vector = Iconography::forward)
     }
+  }
 }
 
 /**
@@ -37,16 +37,16 @@ internal val settingsPreviewContent: SettingsScope.() -> Unit = {
  *
  * @param modifier [Modifier] to be applied to the underlying [Column].
  * @param content Actions to be run on the given [SettingsScope].
- **/
+ */
 @Composable
 fun Settings(modifier: Modifier = Modifier, content: SettingsScope.() -> Unit) {
-    Settings(
-        settingModifier = Modifier,
-        singleSettingShape = SettingDefaults.shape,
-        firstSettingFollowedByOthersShape = SettingDefaults.shape.top,
-        modifier,
-        content = content
-    )
+  Settings(
+    settingModifier = Modifier,
+    singleSettingShape = SettingDefaults.shape,
+    firstSettingFollowedByOthersShape = SettingDefaults.shape.top,
+    modifier,
+    content = content
+  )
 }
 
 /**
@@ -54,16 +54,16 @@ fun Settings(modifier: Modifier = Modifier, content: SettingsScope.() -> Unit) {
  *
  * @param modifier [Modifier] to be applied to the underlying [Column].
  * @param content Actions to be run on the given [SettingsScope].
- **/
+ */
 @Composable
 internal fun ChildSettings(modifier: Modifier = Modifier, content: SettingsScope.() -> Unit) {
-    Settings(
-        settingModifier = Modifier.padding(start = SettingDefaults.spacing),
-        singleSettingShape = SettingDefaults.shape.bottom,
-        firstSettingFollowedByOthersShape = RectangleShape,
-        modifier,
-        content = content
-    )
+  Settings(
+    settingModifier = Modifier.padding(start = SettingDefaults.spacing),
+    singleSettingShape = SettingDefaults.shape.bottom,
+    firstSettingFollowedByOthersShape = RectangleShape,
+    modifier,
+    content = content
+  )
 }
 
 /**
@@ -72,55 +72,47 @@ internal fun ChildSettings(modifier: Modifier = Modifier, content: SettingsScope
  * @param settingModifier [Modifier] to be applied to each [Setting].
  * @param singleSettingShape [Shape] by which the single [Setting] will be shaped.
  * @param firstSettingFollowedByOthersShape [Shape] by which the first [Setting] will be shaped when
- * it's followed by other ones.
+ *   it's followed by other ones.
  * @param modifier [Modifier] to be applied to the underlying [Column].
  * @param content Actions to be run on the given [SettingsScope].
- **/
+ */
 @Composable
 private fun Settings(
-    @Suppress("ModifierParameter") settingModifier: Modifier,
-    singleSettingShape: Shape,
-    firstSettingFollowedByOthersShape: Shape,
-    modifier: Modifier = Modifier,
-    content: SettingsScope.() -> Unit
+  @Suppress("ModifierParameter") settingModifier: Modifier,
+  singleSettingShape: Shape,
+  firstSettingFollowedByOthersShape: Shape,
+  modifier: Modifier = Modifier,
+  content: SettingsScope.() -> Unit
 ) {
-    val defaultOptionShape = SettingDefaults.shape
-    val scope = remember(content) { SettingsScope().apply(content) }
+  val defaultOptionShape = SettingDefaults.shape
+  val scope = remember(content) { SettingsScope().apply(content) }
 
-    Column(modifier.border(defaultOptionShape)) {
-        scope.settings.forEachIndexed { index, setting ->
-            when {
-                scope.settings.size == 1 ->
-                    setting(settingModifier, singleSettingShape)
-                index == 0 ->
-                    setting(settingModifier, firstSettingFollowedByOthersShape)
-                index == scope.settings.lastIndex ->
-                    setting(settingModifier, defaultOptionShape.bottom)
-                else ->
-                    setting(settingModifier, RectangleShape)
-            }
+  Column(modifier.border(defaultOptionShape)) {
+    scope.settings.forEachIndexed { index, setting ->
+      when {
+        scope.settings.size == 1 -> setting(settingModifier, singleSettingShape)
+        index == 0 -> setting(settingModifier, firstSettingFollowedByOthersShape)
+        index == scope.settings.lastIndex -> setting(settingModifier, defaultOptionShape.bottom)
+        else -> setting(settingModifier, RectangleShape)
+      }
 
-            if (index != scope.settings.lastIndex) {
-                Divider()
-            }
-        }
+      if (index != scope.settings.lastIndex) {
+        Divider()
+      }
     }
+  }
 }
 
-/** Preview of parent [Settings]. **/
+/** Preview of parent [Settings]. */
 @Composable
 @MultiThemePreview
 private fun ParentSettingsPreview() {
-    OrcaTheme {
-        Settings(content = settingsPreviewContent)
-    }
+  OrcaTheme { Settings(content = settingsPreviewContent) }
 }
 
-/** Preview of child [Settings]. **/
+/** Preview of child [Settings]. */
 @Composable
 @MultiThemePreview
 private fun ChildSettingsPreview() {
-    OrcaTheme {
-        ChildSettings(content = settingsPreviewContent)
-    }
+  OrcaTheme { ChildSettings(content = settingsPreviewContent) }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/setting/list/SettingsScope.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/action/setting/list/SettingsScope.kt
@@ -11,69 +11,62 @@ import com.jeanbarrossilva.orca.platform.theme.kit.action.setting.ActionScope
 import com.jeanbarrossilva.orca.platform.theme.kit.action.setting.Group
 import com.jeanbarrossilva.orca.platform.theme.kit.action.setting.Setting
 
-/** Scope through which [Setting]s can be added. **/
+/** Scope through which [Setting]s can be added. */
 class SettingsScope internal constructor() {
-    /** [Setting]s that have been added. **/
-    private val mutableSettings = mutableStateListOf<@Composable (Modifier, Shape) -> Unit>()
+  /** [Setting]s that have been added. */
+  private val mutableSettings = mutableStateListOf<@Composable (Modifier, Shape) -> Unit>()
 
-    /** Immutable [List] with the [Setting]s that have been added. **/
-    internal val settings
-        get() = mutableSettings.toList()
+  /** Immutable [List] with the [Setting]s that have been added. */
+  internal val settings
+    get() = mutableSettings.toList()
 
-    /**
-     * Adds a [Group].
-     *
-     * @param icon [Icon] that visually represents what it does.
-     * @param label Short description of what it's for.
-     * @param modifier [Modifier] to be applied to the [Group].
-     * @param isInitiallyExpanded Whether it is expanded by default.
-     **/
-    fun group(
-        icon: @Composable () -> Unit,
-        label: @Composable () -> Unit,
-        modifier: Modifier = Modifier,
-        isInitiallyExpanded: Boolean = false,
-        content: SettingsScope.() -> Unit
-    ) {
-        with(mutableSettings.size) index@{
-            mutableSettings.add { parentModifier, shape ->
-                Group(
-                    icon,
-                    label,
-                    parentModifier then modifier,
-                    isInitiallyExpanded,
-                    shape as? CornerBasedShape ?: RoundedCornerShape(0),
-                    content
-                )
-            }
-        }
+  /**
+   * Adds a [Group].
+   *
+   * @param icon [Icon] that visually represents what it does.
+   * @param label Short description of what it's for.
+   * @param modifier [Modifier] to be applied to the [Group].
+   * @param isInitiallyExpanded Whether it is expanded by default.
+   */
+  fun group(
+    icon: @Composable () -> Unit,
+    label: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    isInitiallyExpanded: Boolean = false,
+    content: SettingsScope.() -> Unit
+  ) {
+    with(mutableSettings.size) index@{
+      mutableSettings.add { parentModifier, shape ->
+        Group(
+          icon,
+          label,
+          parentModifier then modifier,
+          isInitiallyExpanded,
+          shape as? CornerBasedShape ?: RoundedCornerShape(0),
+          content
+        )
+      }
     }
+  }
 
-    /**
-     * Adds a [Setting].
-     *
-     * @param onClick Callback run whenever it's clicked.
-     * @param label Short description of what it's for.
-     * @param modifier [Modifier] to be applied to the [Setting].
-     * @param icon [Icon] that visually represents what it does.
-     * @param action Portrays the result of invoking [onClick] or executes a related action.
-     **/
-    fun setting(
-        label: @Composable () -> Unit,
-        modifier: Modifier = Modifier,
-        onClick: () -> Unit = { },
-        icon: @Composable () -> Unit = { },
-        action: ActionScope.() -> Unit = { }
-    ) {
-        mutableSettings.add { parentModifier, shape ->
-            Setting(
-                label,
-                parentModifier then modifier,
-                shape,
-                onClick,
-                icon,
-                action
-            )
-        }
+  /**
+   * Adds a [Setting].
+   *
+   * @param onClick Callback run whenever it's clicked.
+   * @param label Short description of what it's for.
+   * @param modifier [Modifier] to be applied to the [Setting].
+   * @param icon [Icon] that visually represents what it does.
+   * @param action Portrays the result of invoking [onClick] or executes a related action.
+   */
+  fun setting(
+    label: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+    icon: @Composable () -> Unit = {},
+    action: ActionScope.() -> Unit = {}
+  ) {
+    mutableSettings.add { parentModifier, shape ->
+      Setting(label, parentModifier then modifier, shape, onClick, icon, action)
     }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/TextField.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/TextField.kt
@@ -25,26 +25,26 @@ import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
 import com.jeanbarrossilva.orca.platform.theme.kit.input.TextField as _TextField
 import com.jeanbarrossilva.orca.platform.theme.kit.input.TextFieldDefaults as _TextFieldDefaults
 
-/** Default values used by a [TextField][_TextField]. **/
+/** Default values used by a [TextField][_TextField]. */
 object TextFieldDefaults {
-    /**
-     * [TextFieldColors] by which a [TextField][_TextField] is colored by default.
-     *
-     * @param enabledContainerColor [Color] to color the container with when the
-     * [TextField][_TextField] is enabled.
-     **/
-    @Composable
-    fun colors(enabledContainerColor: Color = OrcaTheme.colors.surface.container): TextFieldColors {
-        return TextFieldDefaults.colors(
-            focusedContainerColor = enabledContainerColor,
-            unfocusedContainerColor = enabledContainerColor,
-            cursorColor = contentColorFor(enabledContainerColor),
-            focusedIndicatorColor = Color.Transparent,
-            unfocusedIndicatorColor = Color.Transparent,
-            disabledIndicatorColor = Color.Transparent,
-            errorIndicatorColor = Color.Transparent
-        )
-    }
+  /**
+   * [TextFieldColors] by which a [TextField][_TextField] is colored by default.
+   *
+   * @param enabledContainerColor [Color] to color the container with when the
+   *   [TextField][_TextField] is enabled.
+   */
+  @Composable
+  fun colors(enabledContainerColor: Color = OrcaTheme.colors.surface.container): TextFieldColors {
+    return TextFieldDefaults.colors(
+      focusedContainerColor = enabledContainerColor,
+      unfocusedContainerColor = enabledContainerColor,
+      cursorColor = contentColorFor(enabledContainerColor),
+      focusedIndicatorColor = Color.Transparent,
+      unfocusedIndicatorColor = Color.Transparent,
+      disabledIndicatorColor = Color.Transparent,
+      errorIndicatorColor = Color.Transparent
+    )
+  }
 }
 
 /**
@@ -56,31 +56,29 @@ object TextFieldDefaults {
  * @param keyboardOptions Software-IME-specific options.
  * @param keyboardActions Software-IME-specific actions.
  * @param isSingleLined Whether there can be multiple lines.
- **/
+ */
 @Composable
 fun TextField(
-    text: String,
-    onTextChange: (text: String) -> Unit,
-    modifier: Modifier = Modifier,
-    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
-    keyboardActions: KeyboardActions = KeyboardActions.Default,
-    isSingleLined: Boolean = false,
-    label: @Composable () -> Unit
+  text: String,
+  onTextChange: (text: String) -> Unit,
+  modifier: Modifier = Modifier,
+  keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+  keyboardActions: KeyboardActions = KeyboardActions.Default,
+  isSingleLined: Boolean = false,
+  label: @Composable () -> Unit
 ) {
-    var isFocused by remember {
-        mutableStateOf(false)
-    }
+  var isFocused by remember { mutableStateOf(false) }
 
-    _TextField(
-        text,
-        onTextChange,
-        isFocused,
-        modifier.onFocusChanged { isFocused = it.isFocused },
-        keyboardOptions,
-        keyboardActions,
-        isSingleLined,
-        label
-    )
+  _TextField(
+    text,
+    onTextChange,
+    isFocused,
+    modifier.onFocusChanged { isFocused = it.isFocused },
+    keyboardOptions,
+    keyboardActions,
+    isSingleLined,
+    label
+  )
 }
 
 /**
@@ -93,74 +91,66 @@ fun TextField(
  * @param keyboardOptions Software-IME-specific options.
  * @param keyboardActions Software-IME-specific actions.
  * @param isSingleLined Whether there can be multiple lines.
- **/
+ */
 @Composable
 private fun TextField(
-    text: String,
-    onTextChange: (text: String) -> Unit,
-    isFocused: Boolean,
-    modifier: Modifier = Modifier,
-    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
-    keyboardActions: KeyboardActions = KeyboardActions.Default,
-    isSingleLined: Boolean = false,
-    label: @Composable () -> Unit
+  text: String,
+  onTextChange: (text: String) -> Unit,
+  isFocused: Boolean,
+  modifier: Modifier = Modifier,
+  keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+  keyboardActions: KeyboardActions = KeyboardActions.Default,
+  isSingleLined: Boolean = false,
+  label: @Composable () -> Unit
 ) {
-    val highlightColor = OrcaTheme.colors.secondary
-    val borderColor by animateColorAsState(
-        if (isFocused) highlightColor else (OrcaTheme.borders.default.brush as SolidColor).value,
-        label = "BorderColor"
+  val highlightColor = OrcaTheme.colors.secondary
+  val borderColor by
+    animateColorAsState(
+      if (isFocused) highlightColor else (OrcaTheme.borders.default.brush as SolidColor).value,
+      label = "BorderColor"
     )
-    val shape = OrcaTheme.shapes.large
+  val shape = OrcaTheme.shapes.large
 
-    TextField(
-        text,
-        onTextChange,
-        modifier.border(OrcaTheme.borders.default.width, borderColor, shape),
-        label = {
-            val color by animateColorAsState(
-                if (isFocused) highlightColor else LocalTextStyle.current.color,
-                label = "LabelColor"
-            )
+  TextField(
+    text,
+    onTextChange,
+    modifier.border(OrcaTheme.borders.default.width, borderColor, shape),
+    label = {
+      val color by
+        animateColorAsState(
+          if (isFocused) highlightColor else LocalTextStyle.current.color,
+          label = "LabelColor"
+        )
 
-            ProvideTextStyle(
-                LocalTextStyle.current.copy(color = color)
-            ) {
-                label()
-            }
-        },
-        keyboardOptions = keyboardOptions,
-        keyboardActions = keyboardActions,
-        singleLine = isSingleLined,
-        shape = shape,
-        colors = _TextFieldDefaults.colors()
-    )
+      ProvideTextStyle(LocalTextStyle.current.copy(color = color)) { label() }
+    },
+    keyboardOptions = keyboardOptions,
+    keyboardActions = keyboardActions,
+    singleLine = isSingleLined,
+    shape = shape,
+    colors = _TextFieldDefaults.colors()
+  )
 }
 
-/** Preview of an empty [TextField][_TextField]. **/
+/** Preview of an empty [TextField][_TextField]. */
 @Composable
 @MultiThemePreview
 private fun EmptyTextFieldPreview() {
-    OrcaTheme {
-        _TextField(text = "")
-    }
+  OrcaTheme { _TextField(text = "") }
 }
 
-/** Preview of an unfocused [TextField][_TextField]. **/
+/** Preview of an unfocused [TextField][_TextField]. */
 @Composable
 @MultiThemePreview
 private fun UnfocusedTextFieldPreview() {
-    OrcaTheme {
-        _TextField(isFocused = false)
-    }
+  OrcaTheme { _TextField(isFocused = false) }
 }
 
-/** Preview of a focused [TextField][_TextField]. **/
+/** Preview of a focused [TextField][_TextField]. */
 @Composable
 @MultiThemePreview
 private fun FocusedTextFieldPreview() {
-    OrcaTheme {
-        _TextField(isFocused = true)
-    }
+  OrcaTheme { _TextField(isFocused = true) }
 }
 
 /**
@@ -169,14 +159,12 @@ private fun FocusedTextFieldPreview() {
  * @param text Text to be shown.
  * @param isFocused Whether it's focused.
  * @param modifier [Modifier] to be applied to the underlying [TextField].
- **/
+ */
 @Composable
 private fun TextField(
-    modifier: Modifier = Modifier,
-    text: String = "Text",
-    isFocused: Boolean = false
+  modifier: Modifier = Modifier,
+  text: String = "Text",
+  isFocused: Boolean = false
 ) {
-    _TextField(text, onTextChange = { }, isFocused, modifier) {
-        Text("Label")
-    }
+  _TextField(text, onTextChange = {}, isFocused, modifier) { Text("Label") }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/Option.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/Option.kt
@@ -34,43 +34,43 @@ import com.jeanbarrossilva.orca.platform.theme.configuration.Shapes
 import com.jeanbarrossilva.orca.platform.theme.extensions.border
 import com.jeanbarrossilva.orca.platform.theme.kit.input.option.list.Options
 
-/** Tag that identifies an [Option] for testing purposes. **/
+/** Tag that identifies an [Option] for testing purposes. */
 internal const val OPTION_TAG = "option"
 
 /**
  * Tag that identifies the [Icon] of an [Option] that indicates that it's selected for testing
  * purposes.
- **/
+ */
 internal const val OPTION_SELECTION_ICON_TAG = "option-selection-icon"
 
-/** Default values of an [Option]. **/
+/** Default values of an [Option]. */
 internal object OptionDefaults {
-    /** [Modifier] that's applied to an [Option] by default. **/
-    val modifier
-        @Composable get() = Modifier.border(shape)
+  /** [Modifier] that's applied to an [Option] by default. */
+  val modifier
+    @Composable get() = Modifier.border(shape)
 
-    /** [CornerBasedShape] that clips an [Option] by default. **/
-    val shape
-        @Composable get() = getShape(OrcaTheme.shapes)
+  /** [CornerBasedShape] that clips an [Option] by default. */
+  val shape
+    @Composable get() = getShape(OrcaTheme.shapes)
 
-    /**
-     * Gets the [CornerBasedShape] that clips an [Option] by default.
-     *
-     * @param shapes [Shapes] from which the [CornerBasedShape] will be obtained.
-     **/
-    fun getShape(shapes: Shapes): CornerBasedShape {
-        return shapes.medium
-    }
+  /**
+   * Gets the [CornerBasedShape] that clips an [Option] by default.
+   *
+   * @param shapes [Shapes] from which the [CornerBasedShape] will be obtained.
+   */
+  fun getShape(shapes: Shapes): CornerBasedShape {
+    return shapes.medium
+  }
 }
 
 /**
  * A loading selectable configuration.
  *
  * @param modifier [Modifier] to be applied to the underlying [Row].
- **/
+ */
 @Composable
 fun Option(modifier: Modifier = Modifier) {
-    CoreOption(OptionDefaults.modifier then modifier)
+  CoreOption(OptionDefaults.modifier then modifier)
 }
 
 /**
@@ -80,20 +80,20 @@ fun Option(modifier: Modifier = Modifier) {
  * @param onSelectionToggle Callback run whenever it is toggled.
  * @param modifier [Modifier] to be applied to the underlying [Row].
  * @param content [Text] that's the label.
- **/
+ */
 @Composable
 fun Option(
-    isSelected: Boolean,
-    onSelectionToggle: (isSelected: Boolean) -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit
+  isSelected: Boolean,
+  onSelectionToggle: (isSelected: Boolean) -> Unit,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit
 ) {
-    CoreOption(
-        isSelected,
-        onSelectionToggle,
-        OptionDefaults.modifier then modifier,
-        content = content
-    )
+  CoreOption(
+    isSelected,
+    onSelectionToggle,
+    OptionDefaults.modifier then modifier,
+    content = content
+  )
 }
 
 /**
@@ -102,16 +102,14 @@ fun Option(
  * @param isSelected Whether it is selected.
  * @param modifier [Modifier] to be applied to the underlying [Row].
  * @param onSelectionToggle Callback run whenever it is toggled.
- **/
+ */
 @Composable
 internal fun Option(
-    isSelected: Boolean,
-    modifier: Modifier = Modifier,
-    onSelectionToggle: (isSelected: Boolean) -> Unit = { }
+  isSelected: Boolean,
+  modifier: Modifier = Modifier,
+  onSelectionToggle: (isSelected: Boolean) -> Unit = {}
 ) {
-    Option(isSelected, onSelectionToggle, modifier) {
-        Text("Label")
-    }
+  Option(isSelected, onSelectionToggle, modifier) { Text("Label") }
 }
 
 /**
@@ -121,12 +119,12 @@ internal fun Option(
  *
  * @param modifier [Modifier] to be applied to the underlying [Row].
  * @param shape [Shape] by which it will be clipped.
- **/
+ */
 @Composable
 internal fun CoreOption(modifier: Modifier = Modifier, shape: Shape = OptionDefaults.shape) {
-    CoreOption(isSelected = false, onSelectionToggle = { }, modifier, shape) {
-        MediumTextualPlaceholder()
-    }
+  CoreOption(isSelected = false, onSelectionToggle = {}, modifier, shape) {
+    MediumTextualPlaceholder()
+  }
 }
 
 /**
@@ -139,76 +137,70 @@ internal fun CoreOption(modifier: Modifier = Modifier, shape: Shape = OptionDefa
  * @param modifier [Modifier] to be applied to the underlying [Row].
  * @param shape [Shape] by which it will be clipped.
  * @param content [Text] that's the label.
- **/
+ */
 @Composable
 internal fun CoreOption(
-    isSelected: Boolean,
-    onSelectionToggle: (isSelected: Boolean) -> Unit,
-    modifier: Modifier = Modifier,
-    shape: Shape = OptionDefaults.shape,
-    content: @Composable () -> Unit
+  isSelected: Boolean,
+  onSelectionToggle: (isSelected: Boolean) -> Unit,
+  modifier: Modifier = Modifier,
+  shape: Shape = OptionDefaults.shape,
+  content: @Composable () -> Unit
 ) {
-    val spacing = OrcaTheme.spacings.large
-    val selectedContainerColor = OrcaTheme.colors.primary.container
-    val containerColor =
-        if (isSelected) selectedContainerColor else OrcaTheme.colors.surface.container
-    val contentColor = contentColorFor(containerColor)
+  val spacing = OrcaTheme.spacings.large
+  val selectedContainerColor = OrcaTheme.colors.primary.container
+  val containerColor =
+    if (isSelected) selectedContainerColor else OrcaTheme.colors.surface.container
+  val contentColor = contentColorFor(containerColor)
 
-    Row(
-        modifier
-            .clip(shape)
-            .clickable(role = Role.Checkbox) { onSelectionToggle(!isSelected) }
-            .background(containerColor)
-            .padding(spacing)
-            .fillMaxWidth()
-            .testTag(OPTION_TAG)
-            .semantics { selected = isSelected },
-        Arrangement.SpaceBetween,
-        Alignment.CenterVertically
+  Row(
+    modifier
+      .clip(shape)
+      .clickable(role = Role.Checkbox) { onSelectionToggle(!isSelected) }
+      .background(containerColor)
+      .padding(spacing)
+      .fillMaxWidth()
+      .testTag(OPTION_TAG)
+      .semantics { selected = isSelected },
+    Arrangement.SpaceBetween,
+    Alignment.CenterVertically
+  ) {
+    CompositionLocalProvider(
+      LocalContentColor provides contentColor,
+      LocalTextStyle provides OrcaTheme.typography.labelLarge.copy(color = contentColor)
     ) {
-        CompositionLocalProvider(
-            LocalContentColor provides contentColor,
-            LocalTextStyle provides OrcaTheme.typography.labelLarge.copy(color = contentColor)
-        ) {
-            content()
-            Spacer(Modifier.width(spacing))
+      content()
+      Spacer(Modifier.width(spacing))
 
-            Box(Modifier.size(24.dp)) {
-                if (isSelected) {
-                    Icon(
-                        OrcaTheme.iconography.selected,
-                        contentDescription = "Selected",
-                        Modifier.testTag(OPTION_SELECTION_ICON_TAG)
-                    )
-                }
-            }
+      Box(Modifier.size(24.dp)) {
+        if (isSelected) {
+          Icon(
+            OrcaTheme.iconography.selected,
+            contentDescription = "Selected",
+            Modifier.testTag(OPTION_SELECTION_ICON_TAG)
+          )
         }
+      }
     }
+  }
 }
 
-/** Preview of a loading [Option]. **/
+/** Preview of a loading [Option]. */
 @Composable
 @MultiThemePreview
 private fun LoadingOptionPreview() {
-    OrcaTheme {
-        Option()
-    }
+  OrcaTheme { Option() }
 }
 
-/** Preview of an unselected [Option]. **/
+/** Preview of an unselected [Option]. */
 @Composable
 @MultiThemePreview
 private fun UnselectedOptionPreview() {
-    OrcaTheme {
-        Option(isSelected = false)
-    }
+  OrcaTheme { Option(isSelected = false) }
 }
 
-/** Preview of a selected [Option]. **/
+/** Preview of a selected [Option]. */
 @Composable
 @MultiThemePreview
 private fun SelectedOptionPreview() {
-    OrcaTheme {
-        Option(isSelected = true)
-    }
+  OrcaTheme { Option(isSelected = true) }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/Options.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/Options.kt
@@ -20,21 +20,17 @@ import com.jeanbarrossilva.orca.platform.theme.extensions.top
 import com.jeanbarrossilva.orca.platform.theme.kit.input.option.Option
 import com.jeanbarrossilva.orca.platform.theme.kit.input.option.OptionDefaults
 
-/** Tag that identifies [Options]' [Divider]s for testing purposes. **/
+/** Tag that identifies [Options]' [Divider]s for testing purposes. */
 internal const val OPTIONS_DIVIDER_TAG = "options-divider"
 
 /**
  * [Column] of loading [Option]s that are shaped according to their position.
  *
  * @param modifier [Modifier] to be applied to the underlying [Column].
- **/
+ */
 @Composable
 fun Options(modifier: Modifier = Modifier) {
-    Options(onSelection = { }, modifier) {
-        repeat(128) {
-            option()
-        }
-    }
+  Options(onSelection = {}, modifier) { repeat(128) { option() } }
 }
 
 /**
@@ -43,39 +39,38 @@ fun Options(modifier: Modifier = Modifier) {
  * @param onSelection Callback run whenever any of the [Option]s is selected.
  * @param modifier [Modifier] to be applied to the underlying [Column].
  * @param content Actions to be run on the given [OptionsScope].
- **/
+ */
 @Composable
 fun Options(
-    onSelection: (index: Int) -> Unit,
-    modifier: Modifier = Modifier,
-    content: OptionsScope.() -> Unit
+  onSelection: (index: Int) -> Unit,
+  modifier: Modifier = Modifier,
+  content: OptionsScope.() -> Unit
 ) {
-    val defaultOptionShape = OptionDefaults.shape
-    var selectedOptionIndex by remember { mutableIntStateOf(0) }
-    val scope = remember(onSelection, content) {
-        OptionsScope { selectedOptionIndex = it }.apply(content)
-    }
+  val defaultOptionShape = OptionDefaults.shape
+  var selectedOptionIndex by remember { mutableIntStateOf(0) }
+  val scope =
+    remember(onSelection, content) { OptionsScope { selectedOptionIndex = it }.apply(content) }
 
-    DisposableEffect(selectedOptionIndex) {
-        onSelection(selectedOptionIndex)
-        onDispose { }
-    }
+  DisposableEffect(selectedOptionIndex) {
+    onSelection(selectedOptionIndex)
+    onDispose {}
+  }
 
-    Column(modifier.border(defaultOptionShape)) {
-        scope.options.forEachIndexed { index, option ->
-            when {
-                scope.options.size == 1 -> option(selectedOptionIndex, defaultOptionShape)
-                index == 0 -> option(selectedOptionIndex, defaultOptionShape.top)
-                index == scope.options.lastIndex -> {
-                    option(selectedOptionIndex, defaultOptionShape.bottom)
-                    return@forEachIndexed
-                }
-                else -> option(selectedOptionIndex, RectangleShape)
-            }
-
-            Divider(Modifier.testTag(OPTIONS_DIVIDER_TAG))
+  Column(modifier.border(defaultOptionShape)) {
+    scope.options.forEachIndexed { index, option ->
+      when {
+        scope.options.size == 1 -> option(selectedOptionIndex, defaultOptionShape)
+        index == 0 -> option(selectedOptionIndex, defaultOptionShape.top)
+        index == scope.options.lastIndex -> {
+          option(selectedOptionIndex, defaultOptionShape.bottom)
+          return@forEachIndexed
         }
+        else -> option(selectedOptionIndex, RectangleShape)
+      }
+
+      Divider(Modifier.testTag(OPTIONS_DIVIDER_TAG))
     }
+  }
 }
 
 /**
@@ -84,34 +79,24 @@ fun Options(
  * @param count Amount of sample [Option]s to be added.
  * @param onSelection Callback run whenever any of the [Option]s is selected.
  * @param modifier [Modifier] to be applied to the underlying [Column].
- **/
+ */
 @Composable
 internal fun SampleOptions(
-    modifier: Modifier = Modifier,
-    count: Int = 3,
-    onSelection: (index: Int) -> Unit = { _ -> }
+  modifier: Modifier = Modifier,
+  count: Int = 3,
+  onSelection: (index: Int) -> Unit = { _ -> }
 ) {
-    Options(onSelection, modifier) {
-        repeat(count) {
-            option {
-                Text("Label #$it")
-            }
-        }
-    }
+  Options(onSelection, modifier) { repeat(count) { option { Text("Label #$it") } } }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadingOptionsPreview() {
-    OrcaTheme {
-        Options()
-    }
+  OrcaTheme { Options() }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadedOptionsPreview() {
-    OrcaTheme {
-        SampleOptions()
-    }
+  OrcaTheme { SampleOptions() }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/OptionsScope.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/input/option/list/OptionsScope.kt
@@ -12,48 +12,46 @@ import com.jeanbarrossilva.orca.platform.theme.kit.input.option.Option
  * Scope through which [Option]s can be added.
  *
  * @param onSelectionToggle Callback run whenever any of the [Option]s is selected.
- **/
+ */
 class OptionsScope internal constructor(private val onSelectionToggle: (index: Int) -> Unit) {
-    /** [Option]s that have been added. **/
-    private val mutableOptions =
-        mutableStateListOf<@Composable (selectedOptionIndex: Int, Shape) -> Unit>()
+  /** [Option]s that have been added. */
+  private val mutableOptions =
+    mutableStateListOf<@Composable (selectedOptionIndex: Int, Shape) -> Unit>()
 
-    /** Immutable [List] with the [Option]s that have been added. **/
-    internal val options
-        get() = mutableOptions.toList()
+  /** Immutable [List] with the [Option]s that have been added. */
+  internal val options
+    get() = mutableOptions.toList()
 
-    /**
-     * Adds an [Option].
-     *
-     * @param modifier [Modifier] to be applied to the [Option].
-     * @param content [Text] that's the label.
-     **/
-    fun option(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
-        with(mutableOptions.size) index@{
-            mutableOptions.add { selectedOptionIndex, shape ->
-                CoreOption(
-                    isSelected = this@index == selectedOptionIndex,
-                    onSelectionToggle = { isSelected ->
-                        if (isSelected) {
-                            onSelectionToggle(this@index)
-                        }
-                    },
-                    modifier,
-                    shape,
-                    content
-                )
+  /**
+   * Adds an [Option].
+   *
+   * @param modifier [Modifier] to be applied to the [Option].
+   * @param content [Text] that's the label.
+   */
+  fun option(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    with(mutableOptions.size) index@{
+      mutableOptions.add { selectedOptionIndex, shape ->
+        CoreOption(
+          isSelected = this@index == selectedOptionIndex,
+          onSelectionToggle = { isSelected ->
+            if (isSelected) {
+              onSelectionToggle(this@index)
             }
-        }
+          },
+          modifier,
+          shape,
+          content
+        )
+      }
     }
+  }
 
-    /**
-     * Adds a loading [Option].
-     *
-     * @param modifier [Modifier] to be applied to the [Option].
-     **/
-    internal fun option(modifier: Modifier = Modifier) {
-        mutableOptions.add { _, shape ->
-            CoreOption(modifier, shape)
-        }
-    }
+  /**
+   * Adds a loading [Option].
+   *
+   * @param modifier [Modifier] to be applied to the [Option].
+   */
+  internal fun option(modifier: Modifier = Modifier) {
+    mutableOptions.add { _, shape -> CoreOption(modifier, shape) }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/menu/DropdownMenu.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/menu/DropdownMenu.kt
@@ -20,34 +20,32 @@ import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
  * @param onDismissal Callback run when it is requested to be dismissed.
  * @param modifier [Modifier] to be applied to the underlying [DropdownMenu].
  * @param content [DropdownMenuItem]s contained by this
- * [DropdownMenu][com.jeanbarrossilva.orca.platform.ui.component.menu.DropdownMenu].
- **/
+ *   [DropdownMenu][com.jeanbarrossilva.orca.platform.ui.component.menu.DropdownMenu].
+ */
 @Composable
 fun DropdownMenu(
-    isExpanded: Boolean,
-    onDismissal: () -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable ColumnScope.() -> Unit
+  isExpanded: Boolean,
+  onDismissal: () -> Unit,
+  modifier: Modifier = Modifier,
+  content: @Composable ColumnScope.() -> Unit
 ) {
-    DropdownMenu(
-        isExpanded,
-        onDismissal,
-        modifier.background(OrcaTheme.colors.surface.container),
-        content = content
-    )
+  DropdownMenu(
+    isExpanded,
+    onDismissal,
+    modifier.background(OrcaTheme.colors.surface.container),
+    content = content
+  )
 }
 
 /**
  * Preview of a [DropdownMenu][com.jeanbarrossilva.orca.platform.ui.component.menu.DropdownMenu].
- **/
+ */
 @Composable
 @MultiThemePreview
 private fun DropdownMenuPreview() {
-    OrcaTheme {
-        DropdownMenu(isExpanded = true, onDismissal = { }) {
-            repeat(8) {
-                DropdownMenuItem(text = { Text("Item $it") }, onClick = { })
-            }
-        }
+  OrcaTheme {
+    DropdownMenu(isExpanded = true, onDismissal = {}) {
+      repeat(8) { DropdownMenuItem(text = { Text("Item $it") }, onClick = {}) }
     }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/Scaffold.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/Scaffold.kt
@@ -34,83 +34,77 @@ import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.top.text.AutoSiz
  * @param modifier [Modifier] to be applied to the underlying [Scaffold].
  * @param topAppBar [TopAppBar] to be placed at the top.
  * @param floatingActionButton [FloatingActionButton] to be placed at the bottom, above the
- * [buttonBar] and below the [SnackbarHost], horizontally centered.
+ *   [buttonBar] and below the [SnackbarHost], horizontally centered.
  * @param floatingActionButtonPosition [FabPosition] that determines where the
- * [floatingActionButton] will be placed.
+ *   [floatingActionButton] will be placed.
  * @param snackbarPresenter [SnackbarPresenter] through which [Snackbar]s can be presented.
  * @param buttonBar [ButtonBar] to be placed at the utmost bottom.
  * @param content Main content of the current context.
- **/
+ */
 @Composable
 fun Scaffold(
-    modifier: Modifier = Modifier,
-    topAppBar: @Composable () -> Unit = { },
-    floatingActionButton: @Composable () -> Unit = { },
-    floatingActionButtonPosition: FabPosition = FabPosition.End,
-    snackbarPresenter: SnackbarPresenter = rememberSnackbarPresenter(),
-    buttonBar: @Composable () -> Unit = { },
-    content: @Composable (padding: PaddingValues) -> Unit
+  modifier: Modifier = Modifier,
+  topAppBar: @Composable () -> Unit = {},
+  floatingActionButton: @Composable () -> Unit = {},
+  floatingActionButtonPosition: FabPosition = FabPosition.End,
+  snackbarPresenter: SnackbarPresenter = rememberSnackbarPresenter(),
+  buttonBar: @Composable () -> Unit = {},
+  content: @Composable (padding: PaddingValues) -> Unit
 ) {
-    Scaffold(
-        modifier,
-        topAppBar,
-        bottomBar = buttonBar,
-        snackbarHost = {
-            SnackbarHost(snackbarPresenter.hostState) {
-                Snackbar(
-                    it,
-                    shape = OrcaTheme.shapes.medium,
-                    containerColor = it.orcaVisuals.containerColor,
-                    dismissActionContentColor = it.orcaVisuals.contentColor
-                )
-            }
-        },
-        floatingActionButton = floatingActionButton,
-        floatingActionButtonPosition = floatingActionButtonPosition,
-        content = content
-    )
+  Scaffold(
+    modifier,
+    topAppBar,
+    bottomBar = buttonBar,
+    snackbarHost = {
+      SnackbarHost(snackbarPresenter.hostState) {
+        Snackbar(
+          it,
+          shape = OrcaTheme.shapes.medium,
+          containerColor = it.orcaVisuals.containerColor,
+          dismissActionContentColor = it.orcaVisuals.contentColor
+        )
+      }
+    },
+    floatingActionButton = floatingActionButton,
+    floatingActionButtonPosition = floatingActionButtonPosition,
+    content = content
+  )
 }
 
-/** Preview of a [Scaffold][_Scaffold]. **/
+/** Preview of a [Scaffold][_Scaffold]. */
 @Composable
 @MultiThemePreview
 private fun ScaffoldPreview() {
-    val lazyListState = rememberLazyListState()
-    val snackbarPresenter = rememberSnackbarPresenter()
+  val lazyListState = rememberLazyListState()
+  val snackbarPresenter = rememberSnackbarPresenter()
 
-    LaunchedEffect(snackbarPresenter) {
-        snackbarPresenter.presentInfo("Info")
-        snackbarPresenter.presentError("Error") { }
-    }
+  LaunchedEffect(snackbarPresenter) {
+    snackbarPresenter.presentInfo("Info")
+    snackbarPresenter.presentError("Error") {}
+  }
 
-    OrcaTheme {
-        _Scaffold(
-            topAppBar = {
-                @OptIn(ExperimentalMaterial3Api::class)
-                TopAppBar(title = { AutoSizeText("Scaffold") })
-            },
-            floatingActionButton = {
-                FloatingActionButton(onClick = { }) {
-                    Icon(OrcaTheme.iconography.compose.filled, contentDescription = "Compose")
-                }
-            },
-            snackbarPresenter = snackbarPresenter,
-            buttonBar = { ButtonBar(lazyListState) }
-        ) {
-            LazyColumn(
-                Modifier.fillMaxSize(),
-                state = lazyListState,
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
-                contentPadding = it + OrcaTheme.overlays.fab
-            ) {
-                item {
-                    Text(
-                        "Content",
-                        style = OrcaTheme.typography.bodyMedium
-                    )
-                }
-            }
+  OrcaTheme {
+    _Scaffold(
+      topAppBar = {
+        @OptIn(ExperimentalMaterial3Api::class) TopAppBar(title = { AutoSizeText("Scaffold") })
+      },
+      floatingActionButton = {
+        FloatingActionButton(onClick = {}) {
+          Icon(OrcaTheme.iconography.compose.filled, contentDescription = "Compose")
         }
+      },
+      snackbarPresenter = snackbarPresenter,
+      buttonBar = { ButtonBar(lazyListState) }
+    ) {
+      LazyColumn(
+        Modifier.fillMaxSize(),
+        state = lazyListState,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        contentPadding = it + OrcaTheme.overlays.fab
+      ) {
+        item { Text("Content", style = OrcaTheme.typography.bodyMedium) }
+      }
     }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/ButtonBar.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/ButtonBar.kt
@@ -26,10 +26,10 @@ import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.button.placement
 import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.button.placement.mapToPlacement
 import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.button.placement.place
 
-/** Tag that identifies a [ButtonBar] for testing purposes. **/
+/** Tag that identifies a [ButtonBar] for testing purposes. */
 internal const val BUTTON_BAR_TAG = "button-bar"
 
-/** Tag that identifies a [ButtonBar]'s [Divider] for testing purposes. **/
+/** Tag that identifies a [ButtonBar]'s [Divider] for testing purposes. */
 internal const val BUTTON_BAR_DIVIDER_TAG = "button-bar-divider"
 
 /**
@@ -38,15 +38,15 @@ internal const val BUTTON_BAR_DIVIDER_TAG = "button-bar-divider"
  * @param lazyListState [LazyListState] that will determine whether it gets highlighted.
  * @param modifier [Modifier] to be applied to the underlying [Layout].
  * @param content [PrimaryButton] to be shown.
- **/
+ */
 @Composable
 fun ButtonBar(
-    lazyListState: LazyListState,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit
+  lazyListState: LazyListState,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit
 ) {
-    val isHighlighted by remember(lazyListState) { derivedStateOf(lazyListState::canScrollForward) }
-    ButtonBar(isHighlighted, modifier, content)
+  val isHighlighted by remember(lazyListState) { derivedStateOf(lazyListState::canScrollForward) }
+  ButtonBar(isHighlighted, modifier, content)
 }
 
 /**
@@ -54,10 +54,10 @@ fun ButtonBar(
  *
  * @param modifier [Modifier] to be applied to the underlying [Layout].
  * @param content [PrimaryButton] to be shown.
- **/
+ */
 @Composable
 fun ButtonBar(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
-    ButtonBar(isHighlighted = false, modifier, content)
+  ButtonBar(isHighlighted = false, modifier, content)
 }
 
 /**
@@ -66,53 +66,45 @@ fun ButtonBar(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
  * @param isHighlighted Whether it should visually stand out.
  * @param modifier [Modifier] to be applied to the underlying [Layout].
  * @param content [PrimaryButton] to be shown.
- **/
+ */
 @Composable
 private fun ButtonBar(
-    isHighlighted: Boolean,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit
+  isHighlighted: Boolean,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit
 ) {
-    val density = LocalDensity.current
-    val border = OrcaTheme.borders.default
-    val borderStrokeWidth by animateDpAsState(
-        if (isHighlighted) border.width else (-1).dp,
-        label = "BorderStrokeWidth"
-    )
-    val spacing = OrcaTheme.spacings.medium
-    val spacingInPx = remember(density, spacing) {
-        with(density) {
-            spacing.roundToPx()
-        }
-    }
-    val containerColor by animateColorAsState(
-        if (isHighlighted) {
-            OrcaTheme.colors.surface.container
-        } else {
-            OrcaTheme.colors.background.container
-        },
-        label = "ContainerColor"
+  val density = LocalDensity.current
+  val border = OrcaTheme.borders.default
+  val borderStrokeWidth by
+    animateDpAsState(if (isHighlighted) border.width else (-1).dp, label = "BorderStrokeWidth")
+  val spacing = OrcaTheme.spacings.medium
+  val spacingInPx = remember(density, spacing) { with(density) { spacing.roundToPx() } }
+  val containerColor by
+    animateColorAsState(
+      if (isHighlighted) {
+        OrcaTheme.colors.surface.container
+      } else {
+        OrcaTheme.colors.background.container
+      },
+      label = "ContainerColor"
     )
 
-    Column(modifier) {
-        Divider(Modifier.testTag(BUTTON_BAR_DIVIDER_TAG), thickness = borderStrokeWidth)
+  Column(modifier) {
+    Divider(Modifier.testTag(BUTTON_BAR_DIVIDER_TAG), thickness = borderStrokeWidth)
 
-        Layout(
-            content,
-            Modifier
-                .drawBehind { drawRect(containerColor) }
-                .padding(spacing)
-                .fillMaxWidth()
-                .testTag(BUTTON_BAR_TAG)
-        ) { measurables, constraints ->
-            val orientation = Orientation.VERTICAL
-            val placements = measurables.mapToPlacement(constraints, orientation, spacingInPx)
+    Layout(
+      content,
+      Modifier.drawBehind { drawRect(containerColor) }
+        .padding(spacing)
+        .fillMaxWidth()
+        .testTag(BUTTON_BAR_TAG)
+    ) { measurables, constraints ->
+      val orientation = Orientation.VERTICAL
+      val placements = measurables.mapToPlacement(constraints, orientation, spacingInPx)
 
-            layout(constraints.maxWidth, placements.height) {
-                place(placements, orientation)
-            }
-        }
+      layout(constraints.maxWidth, placements.height) { place(placements, orientation) }
     }
+  }
 }
 
 /**
@@ -120,32 +112,24 @@ private fun ButtonBar(
  *
  * @param lazyListState [LazyListState] that will determine whether it gets highlighted.
  * @param modifier [Modifier] to be applied to the underlying [Layout].
- **/
+ */
 @Composable
 internal fun ButtonBar(lazyListState: LazyListState, modifier: Modifier = Modifier) {
-    ButtonBar(lazyListState, modifier) {
-        PrimaryButton(onClick = { }) {
-            Text("Label")
-        }
-    }
+  ButtonBar(lazyListState, modifier) { PrimaryButton(onClick = {}) { Text("Label") } }
 }
 
-/** Preview of an idle [ButtonBar]. **/
+/** Preview of an idle [ButtonBar]. */
 @Composable
 @MultiThemePreview
 private fun IdleButtonBarPreview() {
-    OrcaTheme {
-        ButtonBar(isHighlighted = false)
-    }
+  OrcaTheme { ButtonBar(isHighlighted = false) }
 }
 
-/** Preview of a highlighted [ButtonBar]. **/
+/** Preview of a highlighted [ButtonBar]. */
 @Composable
 @MultiThemePreview
 private fun HighlightedButtonBarPreview() {
-    OrcaTheme {
-        ButtonBar(isHighlighted = true)
-    }
+  OrcaTheme { ButtonBar(isHighlighted = true) }
 }
 
 /**
@@ -153,12 +137,8 @@ private fun HighlightedButtonBarPreview() {
  *
  * @param isHighlighted Whether it should visually stand out.
  * @param modifier [Modifier] to be applied to the underlying [Layout].
- **/
+ */
 @Composable
 private fun ButtonBar(isHighlighted: Boolean, modifier: Modifier = Modifier) {
-    ButtonBar(isHighlighted, modifier) {
-        PrimaryButton(onClick = { }) {
-            Text("Label")
-        }
-    }
+  ButtonBar(isHighlighted, modifier) { PrimaryButton(onClick = {}) { Text("Label") } }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/placement/Collection.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/placement/Collection.extensions.kt
@@ -3,9 +3,9 @@ package com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.button.placemen
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.unit.Constraints
 
-/** Height of all [Placement]s combined. **/
+/** Height of all [Placement]s combined. */
 internal val Collection<Placement>.height
-    get() = sumOf { placement -> placement.placeable.height }
+  get() = sumOf { placement -> placement.placeable.height }
 
 /**
  * Maps each [Measurable] to a [Placement].
@@ -13,16 +13,16 @@ internal val Collection<Placement>.height
  * @param constraints Measuring that will limit the [Measurable]s' measured size.
  * @param orientation [Orientation] in which the resulting [Placement]s will be placed.
  * @param spacing Size of the space between each of the [Placement]s in pixels.
- **/
+ */
 internal fun Collection<Measurable>.mapToPlacement(
-    constraints: Constraints,
-    orientation: Orientation,
-    spacing: Int
+  constraints: Constraints,
+  orientation: Orientation,
+  spacing: Int
 ): List<Placement> {
-    var offset = 0
-    return map { measurable ->
-        measurable.toPlacement(constraints, offset).also { placement ->
-            offset += orientation.getDimension(placement.placeable) + spacing
-        }
+  var offset = 0
+  return map { measurable ->
+    measurable.toPlacement(constraints, offset).also { placement ->
+      offset += orientation.getDimension(placement.placeable) + spacing
     }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/placement/Measurable.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/placement/Measurable.extensions.kt
@@ -8,8 +8,8 @@ import androidx.compose.ui.unit.Constraints
  *
  * @param constraints Measuring that will limit this [Measurable]'s measured size.
  * @param offset Amount in pixels by which the [Placement] will be offset.
- **/
+ */
 internal fun Measurable.toPlacement(constraints: Constraints, offset: Int): Placement {
-    val placeable = measure(constraints)
-    return Placement(placeable, offset)
+  val placeable = measure(constraints)
+  return Placement(placeable, offset)
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/placement/Orientation.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/placement/Orientation.kt
@@ -5,29 +5,29 @@ import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.unit.IntOffset
 import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.button.ButtonBar
 
-/** Indicates how [Button]s in a [ButtonBar] are placed in relation to each other. **/
+/** Indicates how [Button]s in a [ButtonBar] are placed in relation to each other. */
 internal enum class Orientation {
-    /** [Button]s are placed below each other. **/
-    VERTICAL {
-        override fun getOffset(placement: Placement): IntOffset {
-            return IntOffset(x = 0, y = placement.axisOffset)
-        }
+  /** [Button]s are placed below each other. */
+  VERTICAL {
+    override fun getOffset(placement: Placement): IntOffset {
+      return IntOffset(x = 0, y = placement.axisOffset)
+    }
 
-        override fun getDimension(placeable: Placeable): Int {
-            return placeable.height
-        }
-    };
+    override fun getDimension(placeable: Placeable): Int {
+      return placeable.height
+    }
+  };
 
-    /**
-     * Gets the [IntOffset] by which the [placement] will be shifted in the axis that's appropriate
-     * for this specific [Orientation].
-     **/
-    abstract fun getOffset(placement: Placement): IntOffset
+  /**
+   * Gets the [IntOffset] by which the [placement] will be shifted in the axis that's appropriate
+   * for this specific [Orientation].
+   */
+  abstract fun getOffset(placement: Placement): IntOffset
 
-    /**
-     * Gets the dimension (width or height) to be considered when placing the [placeable].
-     *
-     * @param placeable [Placeable] whose appropriate dimension will be obtained.
-     **/
-    abstract fun getDimension(placeable: Placeable): Int
+  /**
+   * Gets the dimension (width or height) to be considered when placing the [placeable].
+   *
+   * @param placeable [Placeable] whose appropriate dimension will be obtained.
+   */
+  abstract fun getDimension(placeable: Placeable): Int
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/placement/Placeable.PlacementScope.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/placement/Placeable.PlacementScope.extensions.kt
@@ -7,11 +7,9 @@ import androidx.compose.ui.layout.Placeable
  *
  * @param placements [Placement]s to be placed.
  * @param orientation [Orientation] in which the [placements] will be placed.
- **/
+ */
 internal fun Placeable.PlacementScope.place(placements: List<Placement>, orientation: Orientation) {
-    placements.forEach {
-        place(it, orientation)
-    }
+  placements.forEach { place(it, orientation) }
 }
 
 /**
@@ -19,8 +17,8 @@ internal fun Placeable.PlacementScope.place(placements: List<Placement>, orienta
  *
  * @param placement [Placement] to be placed.
  * @param orientation [Orientation] in which the [placement] will be placed.
- **/
+ */
 internal fun Placeable.PlacementScope.place(placement: Placement, orientation: Orientation) {
-    val offset = orientation.getOffset(placement)
-    placement.placeable.place(offset)
+  val offset = orientation.getOffset(placement)
+  placement.placeable.place(offset)
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/placement/Placement.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/button/placement/Placement.kt
@@ -7,5 +7,5 @@ import androidx.compose.ui.layout.Placeable
  *
  * @param placeable [Placeable] yet to be placed.
  * @param axisOffset Additional horizontal or vertical shift in pixels.
- **/
+ */
 internal data class Placement(val placeable: Placeable, val axisOffset: Int)

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/snack/OrcaSnackbarVisuals.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/snack/OrcaSnackbarVisuals.kt
@@ -15,36 +15,35 @@ import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
  *
  * @see Info
  * @see Error
- **/
+ */
 internal sealed class OrcaSnackbarVisuals : SnackbarVisuals {
-    override val withDismissAction = false
+  override val withDismissAction = false
 
-    /** [Color] of the [Snackbar] container. **/
-    @get:Composable
-    abstract val containerColor: Color
+  /** [Color] of the [Snackbar] container. */
+  @get:Composable abstract val containerColor: Color
 
-    /** [Color] of the [Snackbar] content. **/
-    val contentColor
-        @Composable get() = contentColorFor(containerColor)
+  /** [Color] of the [Snackbar] content. */
+  val contentColor
+    @Composable get() = contentColorFor(containerColor)
 
-    /** Denotes that the [Snackbar] should be styled in a non-intrusive manner. **/
-    data class Info(override val message: String) : OrcaSnackbarVisuals() {
-        override val actionLabel = null
-        override val duration = SnackbarDuration.Short
+  /** Denotes that the [Snackbar] should be styled in a non-intrusive manner. */
+  data class Info(override val message: String) : OrcaSnackbarVisuals() {
+    override val actionLabel = null
+    override val duration = SnackbarDuration.Short
 
-        override val containerColor
-            @Composable get() = OrcaTheme.colors.surface.container
-    }
+    override val containerColor
+      @Composable get() = OrcaTheme.colors.surface.container
+  }
 
-    /**
-     * Denotes that the [Snackbar] should be styled in a way that attempts to draw the attention of
-     * the user to it, for notifying the occurrence of an error.
-     **/
-    data class Error(override val message: String) : OrcaSnackbarVisuals() {
-        override val actionLabel = "Retry"
-        override val duration = SnackbarDuration.Indefinite
+  /**
+   * Denotes that the [Snackbar] should be styled in a way that attempts to draw the attention of
+   * the user to it, for notifying the occurrence of an error.
+   */
+  data class Error(override val message: String) : OrcaSnackbarVisuals() {
+    override val actionLabel = "Retry"
+    override val duration = SnackbarDuration.Indefinite
 
-        override val containerColor
-            @Composable get() = OrcaTheme.colors.error.container
-    }
+    override val containerColor
+      @Composable get() = OrcaTheme.colors.error.container
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/snack/SnackbarData.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/snack/SnackbarData.extensions.kt
@@ -6,6 +6,6 @@ import androidx.compose.material3.SnackbarData
  * [visuals][SnackbarData.visuals] cast to [OrcaSnackbarVisuals].
  *
  * @throws ClassCastException If [visuals][SnackbarData.visuals] is not an [OrcaSnackbarVisuals].
- **/
+ */
 internal val SnackbarData.orcaVisuals
-    get() = visuals as OrcaSnackbarVisuals
+  get() = visuals as OrcaSnackbarVisuals

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/snack/presenter/SnackbarPresenter.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/snack/presenter/SnackbarPresenter.extensions.kt
@@ -4,9 +4,9 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 
-/** Remembers a [SnackbarPresenter]. **/
+/** Remembers a [SnackbarPresenter]. */
 @Composable
 fun rememberSnackbarPresenter(): SnackbarPresenter {
-    val hostState = remember(::SnackbarHostState)
-    return remember(hostState) { SnackbarPresenter(hostState) }
+  val hostState = remember(::SnackbarHostState)
+  return remember(hostState) { SnackbarPresenter(hostState) }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/snack/presenter/SnackbarPresenter.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/snack/presenter/SnackbarPresenter.kt
@@ -5,41 +5,41 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.snack.OrcaSnackbarVisuals
 
-/** Presents various types of [Snackbar]s. **/
+/** Presents various types of [Snackbar]s. */
 class SnackbarPresenter internal constructor(internal val hostState: SnackbarHostState) {
-    /**
-     * Listens to a request to perform a failed operation again.
-     *
-     * @see onRetry
-     **/
-    fun interface OnRetryListener {
-        /** Callback run if a failed operation is requested to be performed again. **/
-        suspend fun onRetry()
-    }
+  /**
+   * Listens to a request to perform a failed operation again.
+   *
+   * @see onRetry
+   */
+  fun interface OnRetryListener {
+    /** Callback run if a failed operation is requested to be performed again. */
+    suspend fun onRetry()
+  }
 
-    /**
-     * Shows a [Snackbar] with the given [message], providing the user information about an error that
-     * has occurred and drawing their attention to it.
-     *
-     * @param message Text to be displayed in the [Snackbar].
-     **/
-    suspend fun presentInfo(message: String) {
-        val visuals = OrcaSnackbarVisuals.Info(message)
-        hostState.showSnackbar(visuals)
-    }
+  /**
+   * Shows a [Snackbar] with the given [message], providing the user information about an error that
+   * has occurred and drawing their attention to it.
+   *
+   * @param message Text to be displayed in the [Snackbar].
+   */
+  suspend fun presentInfo(message: String) {
+    val visuals = OrcaSnackbarVisuals.Info(message)
+    hostState.showSnackbar(visuals)
+  }
 
-    /**
-     * Shows a [Snackbar] with the given [message], providing the user additional information.
-     *
-     * @param message Text to be displayed in the [Snackbar].
-     * @param onRetryListener [OnRetryListener] to be notified when a failed operation is requested
-     * to be performed again.
-     **/
-    suspend fun presentError(message: String, onRetryListener: OnRetryListener) {
-        val visuals = OrcaSnackbarVisuals.Error(message)
-        val result = hostState.showSnackbar(visuals)
-        if (result == SnackbarResult.ActionPerformed) {
-            onRetryListener.onRetry()
-        }
+  /**
+   * Shows a [Snackbar] with the given [message], providing the user additional information.
+   *
+   * @param message Text to be displayed in the [Snackbar].
+   * @param onRetryListener [OnRetryListener] to be notified when a failed operation is requested to
+   *   be performed again.
+   */
+  suspend fun presentError(message: String, onRetryListener: OnRetryListener) {
+    val visuals = OrcaSnackbarVisuals.Error(message)
+    val result = hostState.showSnackbar(visuals)
+    if (result == SnackbarResult.ActionPerformed) {
+      onRetryListener.onRetry()
     }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/top/TopAppBar.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/top/TopAppBar.kt
@@ -37,13 +37,13 @@ import com.jeanbarrossilva.orca.platform.theme.kit.action.button.HoverableIconBu
 import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.top.TopAppBar as _TopAppBar
 import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.top.TopAppBarDefaults as _TopAppBarDefaults
 
-/** Default values of a [TopAppBar][_TopAppBar]. **/
+/** Default values of a [TopAppBar][_TopAppBar]. */
 object TopAppBarDefaults {
-    /** [TopAppBarScrollBehavior] adopted by default by a [TopAppBar][_TopAppBar]. **/
-    val scrollBehavior
-        @Composable
-        @OptIn(ExperimentalMaterial3Api::class)
-        get() = TopAppBarDefaults.enterAlwaysScrollBehavior()
+  /** [TopAppBarScrollBehavior] adopted by default by a [TopAppBar][_TopAppBar]. */
+  val scrollBehavior
+    @Composable
+    @OptIn(ExperimentalMaterial3Api::class)
+    get() = TopAppBarDefaults.enterAlwaysScrollBehavior()
 }
 
 /**
@@ -53,111 +53,107 @@ object TopAppBarDefaults {
  * @param title Short explanation of what's being presented by the overall content.
  * @param modifier [Modifier] to be applied to the underlying [TopAppBar].
  * @param navigationIcon [HoverableIconButton] through which navigation can be performed, usually
- * for popping the back stack.
+ *   for popping the back stack.
  * @param subtitle Contextualizes the [title].
  * @param actions [IconButton]s with actions to be performed in this context.
  * @param scrollBehavior Defines how this [TopAppBar][_TopAppBar] behaves on scroll.
- **/
+ */
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun TopAppBar(
-    title: @Composable () -> Unit,
-    modifier: Modifier = Modifier,
-    navigationIcon: @Composable () -> Unit = { },
-    subtitle: @Composable () -> Unit = { },
-    actions: @Composable RowScope.() -> Unit = { },
-    scrollBehavior: TopAppBarScrollBehavior = _TopAppBarDefaults.scrollBehavior
+  title: @Composable () -> Unit,
+  modifier: Modifier = Modifier,
+  navigationIcon: @Composable () -> Unit = {},
+  subtitle: @Composable () -> Unit = {},
+  actions: @Composable RowScope.() -> Unit = {},
+  scrollBehavior: TopAppBarScrollBehavior = _TopAppBarDefaults.scrollBehavior
 ) {
-    val overlap by remember(scrollBehavior) {
-        derivedStateOf {
-            scrollBehavior.state.overlappedFraction
-        }
-    }
-    val heightOffset by remember(scrollBehavior) {
-        derivedStateOf {
-            scrollBehavior.state.heightOffset
-        }
-    }
-    val isOverlapping = remember(overlap) { overlap > 0f }
-    val idleContainerColor = OrcaTheme.colors.background.container
-    val scrolledContainerColor = OrcaTheme.colors.surface.container
-    val containerColorTransitionFraction = remember(overlap) { if (overlap > 0.01f) 1f else 0f }
-    val containerColor by animateColorAsState(
-        lerp(
-            idleContainerColor,
-            scrolledContainerColor,
-            FastOutLinearInEasing.transform(containerColorTransitionFraction)
-        ),
-        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
-        label = "ContainerColor"
+  val overlap by
+    remember(scrollBehavior) { derivedStateOf { scrollBehavior.state.overlappedFraction } }
+  val heightOffset by
+    remember(scrollBehavior) { derivedStateOf { scrollBehavior.state.heightOffset } }
+  val isOverlapping = remember(overlap) { overlap > 0f }
+  val idleContainerColor = OrcaTheme.colors.background.container
+  val scrolledContainerColor = OrcaTheme.colors.surface.container
+  val containerColorTransitionFraction = remember(overlap) { if (overlap > 0.01f) 1f else 0f }
+  val containerColor by
+    animateColorAsState(
+      lerp(
+        idleContainerColor,
+        scrolledContainerColor,
+        FastOutLinearInEasing.transform(containerColorTransitionFraction)
+      ),
+      animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+      label = "ContainerColor"
     )
-    val spacing = OrcaTheme.spacings.medium
-    val verticalSpacing by animateDpAsState(
-        with(LocalDensity.current) { maxOf(0.dp, spacing + heightOffset.toDp()) },
-        label = "VerticalSpacing"
+  val spacing = OrcaTheme.spacings.medium
+  val verticalSpacing by
+    animateDpAsState(
+      with(LocalDensity.current) { maxOf(0.dp, spacing + heightOffset.toDp()) },
+      label = "VerticalSpacing"
     )
-    val borderStrokeWidth by animateDpAsState(
-        if (isOverlapping) OrcaTheme.borders.default.width else 0.dp,
-        label = "BorderStrokeWidth"
+  val borderStrokeWidth by
+    animateDpAsState(
+      if (isOverlapping) OrcaTheme.borders.default.width else 0.dp,
+      label = "BorderStrokeWidth"
     )
 
-    TopAppBar(
-        title = {
-            Row {
-                Spacer(Modifier.width(spacing))
+  TopAppBar(
+    title = {
+      Row {
+        Spacer(Modifier.width(spacing))
 
-                Column {
-                    ProvideTextStyle(OrcaTheme.typography.titleSmall, subtitle)
-                    ProvideTextStyle(OrcaTheme.typography.headlineLarge, title)
-                }
-            }
-        },
-        modifier
-            .`if`(Borders.areApplicable) {
-                border(OrcaTheme.borders.default.copy(width = borderStrokeWidth))
-            }
-            .background(containerColor)
-            .padding(vertical = verticalSpacing),
-        navigationIcon = {
-            Row {
-                Spacer(Modifier.width(spacing))
-                navigationIcon()
-            }
-        },
-        actions = {
-            Row {
-                actions()
-                Spacer(Modifier.width(spacing))
-            }
-        },
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = idleContainerColor,
-            scrolledContainerColor,
-            actionIconContentColor = OrcaTheme.colors.secondary
-        ),
-        scrollBehavior = scrollBehavior
-    )
+        Column {
+          ProvideTextStyle(OrcaTheme.typography.titleSmall, subtitle)
+          ProvideTextStyle(OrcaTheme.typography.headlineLarge, title)
+        }
+      }
+    },
+    modifier
+      .`if`(Borders.areApplicable) {
+        border(OrcaTheme.borders.default.copy(width = borderStrokeWidth))
+      }
+      .background(containerColor)
+      .padding(vertical = verticalSpacing),
+    navigationIcon = {
+      Row {
+        Spacer(Modifier.width(spacing))
+        navigationIcon()
+      }
+    },
+    actions = {
+      Row {
+        actions()
+        Spacer(Modifier.width(spacing))
+      }
+    },
+    colors =
+      TopAppBarDefaults.topAppBarColors(
+        containerColor = idleContainerColor,
+        scrolledContainerColor,
+        actionIconContentColor = OrcaTheme.colors.secondary
+      ),
+    scrollBehavior = scrollBehavior
+  )
 }
 
-/** Preview of a [TopAppBar][_TopAppBar]. **/
+/** Preview of a [TopAppBar][_TopAppBar]. */
 @Composable
 @MultiThemePreview
 private fun TopAppBarPreview() {
-    OrcaTheme {
-        @OptIn(ExperimentalMaterial3Api::class)
-        _TopAppBar(
-            title = { Text("Title") },
-            navigationIcon = {
-                IconButton(onClick = { }) {
-                    Icon(OrcaTheme.iconography.back, contentDescription = "Back")
-                }
-            },
-            subtitle = { Text("Subtitle") },
-            actions = {
-                HoverableIconButton(onClick = { }) {
-                    Icon(OrcaTheme.iconography.search, contentDescription = "Search")
-                }
-            }
-        )
-    }
+  OrcaTheme {
+    @OptIn(ExperimentalMaterial3Api::class)
+    _TopAppBar(
+      title = { Text("Title") },
+      navigationIcon = {
+        IconButton(onClick = {}) { Icon(OrcaTheme.iconography.back, contentDescription = "Back") }
+      },
+      subtitle = { Text("Subtitle") },
+      actions = {
+        HoverableIconButton(onClick = {}) {
+          Icon(OrcaTheme.iconography.search, contentDescription = "Search")
+        }
+      }
+    )
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/top/TopAppBarWithNavigation.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/top/TopAppBarWithNavigation.kt
@@ -21,25 +21,25 @@ import com.jeanbarrossilva.orca.platform.theme.kit.action.button.HoverableIconBu
  * @param subtitle Contextualizes the [title].
  * @param actions [IconButton]s with actions to be performed in this context.
  * @param scrollBehavior Defines how this [TopAppBar] behaves on scroll.
- **/
+ */
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun TopAppBarWithBackNavigation(
-    onNavigation: () -> Unit,
-    title: @Composable () -> Unit,
-    modifier: Modifier = Modifier,
-    subtitle: @Composable () -> Unit = { },
-    actions: @Composable RowScope.() -> Unit = { },
-    scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.scrollBehavior
+  onNavigation: () -> Unit,
+  title: @Composable () -> Unit,
+  modifier: Modifier = Modifier,
+  subtitle: @Composable () -> Unit = {},
+  actions: @Composable RowScope.() -> Unit = {},
+  scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.scrollBehavior
 ) {
-    TopAppBar(
-        title,
-        modifier,
-        navigationIcon = { BackAction(onClick = onNavigation) },
-        subtitle,
-        actions,
-        scrollBehavior
-    )
+  TopAppBar(
+    title,
+    modifier,
+    navigationIcon = { BackAction(onClick = onNavigation) },
+    subtitle,
+    actions,
+    scrollBehavior
+  )
 }
 
 /**
@@ -47,15 +47,14 @@ fun TopAppBarWithBackNavigation(
  *
  * @param onClick Callback run whenever the [HoverableIconButton] is clicked.
  * @param modifier [Modifier] to the underlying [HoverableIconButton].
- **/
+ */
 @Composable
 fun BackAction(onClick: () -> Unit, modifier: Modifier = Modifier) {
-    HoverableIconButton(onClick, modifier) {
-        Icon(
-            OrcaTheme.iconography.back,
-            contentDescription = stringResource(
-                R.string.platform_ui_top_app_bar_with_back_navigation_action
-            )
-        )
-    }
+  HoverableIconButton(onClick, modifier) {
+    Icon(
+      OrcaTheme.iconography.back,
+      contentDescription =
+        stringResource(R.string.platform_ui_top_app_bar_with_back_navigation_action)
+    )
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/top/text/AutoSizeText.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/top/text/AutoSizeText.kt
@@ -25,43 +25,35 @@ import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.top.text.size.re
  * @param modifier [Modifier] to be applied to the underlying [Text].
  * @param style [TextStyle] with which it will be styled.
  * @param range [AutoSizeRange] within which the font size should be.
- **/
+ */
 @Composable
 fun AutoSizeText(
-    text: String,
-    modifier: Modifier = Modifier,
-    style: TextStyle = LocalTextStyle.current,
-    range: AutoSizeRange = rememberAutoSizeRange(style.fontSize)
+  text: String,
+  modifier: Modifier = Modifier,
+  style: TextStyle = LocalTextStyle.current,
+  range: AutoSizeRange = rememberAutoSizeRange(style.fontSize)
 ) {
-    val density = LocalDensity.current
-    var canBeDrawn by remember { mutableStateOf(false) }
-    val sizer = remember(density, range) { AutoSizer(density, range) }
+  val density = LocalDensity.current
+  var canBeDrawn by remember { mutableStateOf(false) }
+  val sizer = remember(density, range) { AutoSizer(density, range) }
 
-    Text(
-        text,
-        modifier.drawWithContent {
-            if (canBeDrawn) {
-                drawContent()
-            }
-        },
-        fontSize = sizer.size,
-        onTextLayout = {
-            sizer.autoSize(it, canBeDrawn) {
-                canBeDrawn = true
-            }
-        },
-        maxLines = 1,
-        style = style
-    )
+  Text(
+    text,
+    modifier.drawWithContent {
+      if (canBeDrawn) {
+        drawContent()
+      }
+    },
+    fontSize = sizer.size,
+    onTextLayout = { sizer.autoSize(it, canBeDrawn) { canBeDrawn = true } },
+    maxLines = 1,
+    style = style
+  )
 }
 
-/** Preview of an [AutoSizeText]. **/
+/** Preview of an [AutoSizeText]. */
 @Composable
 @MultiThemePreview
 private fun AutoSizeTextPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            AutoSizeText("Text")
-        }
-    }
+  OrcaTheme { Surface(color = OrcaTheme.colors.background.container) { AutoSizeText("Text") } }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/top/text/size/AutoSizeRange.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/top/text/size/AutoSizeRange.extensions.kt
@@ -12,10 +12,10 @@ import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
  * [OrcaTheme.typography]'s [Typography.labelSmall]'s.
  *
  * @param max Maximum, default size.
- **/
+ */
 @Composable
 fun rememberAutoSizeRange(max: TextUnit): AutoSizeRange {
-    return rememberAutoSizeRange(min = OrcaTheme.typography.labelSmall.fontSize, max)
+  return rememberAutoSizeRange(min = OrcaTheme.typography.labelSmall.fontSize, max)
 }
 
 /**
@@ -23,9 +23,9 @@ fun rememberAutoSizeRange(max: TextUnit): AutoSizeRange {
  *
  * @param min Minimum size.
  * @param max Maximum, default size.
- **/
+ */
 @Composable
 fun rememberAutoSizeRange(min: TextUnit, max: TextUnit): AutoSizeRange {
-    val density = LocalDensity.current
-    return remember(density, min, max) { AutoSizeRange(density, min, max) }
+  val density = LocalDensity.current
+  return remember(density, min, max) { AutoSizeRange(density, min, max) }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/top/text/size/AutoSizeRange.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/top/text/size/AutoSizeRange.kt
@@ -10,28 +10,27 @@ import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.top.text.AutoSiz
  * Range within which an [AutoSizeText] should be sized.
  *
  * @param density [Density] through which sizes will be converted from [SP][TextUnitType.Sp] to
- * [Float] and vice-versa.
+ *   [Float] and vice-versa.
  * @param min Minimum size.
  * @param max Maximum, default size.
- **/
+ */
 @Immutable
-data class AutoSizeRange internal constructor(
-    private val density: Density,
-    private val min: TextUnit,
-    private val max: TextUnit
+data class AutoSizeRange
+internal constructor(
+  private val density: Density,
+  private val min: TextUnit,
+  private val max: TextUnit
 ) : ClosedFloatingPointRange<Float> {
-    override val start = with(density) { min.toPx() }
-    override val endInclusive = with(density) { max.toPx() }
+  override val start = with(density) { min.toPx() }
+  override val endInclusive = with(density) { max.toPx() }
 
-    init {
-        require(min.type == max.type) {
-            "Both minimum and maximum sizes should have the same TextUnitType."
-        }
+  init {
+    require(min.type == max.type) {
+      "Both minimum and maximum sizes should have the same TextUnitType."
     }
+  }
 
-    override fun lessThanOrEquals(a: Float, b: Float): Boolean {
-        return with(density) {
-            a.toSp() <= b.toSp()
-        }
-    }
+  override fun lessThanOrEquals(a: Float, b: Float): Boolean {
+    return with(density) { a.toSp() <= b.toSp() }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/top/text/size/AutoSizer.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/kit/scaffold/bar/top/text/size/AutoSizer.kt
@@ -15,55 +15,50 @@ import com.jeanbarrossilva.orca.platform.theme.kit.scaffold.bar.top.text.AutoSiz
  * performed.
  *
  * @param density [Density] through which the step size will be converted from [SP][TextUnitType.Sp]
- * to pixels.
+ *   to pixels.
  * @param range [AutoSizeRange] within which the [AutoSizeText] should be sized.
  * @see autoSize
- **/
+ */
 internal class AutoSizer(private val density: Density, range: AutoSizeRange) {
-    /** Minimum size in pixels. **/
-    private val minSizeInPx = range.start
+  /** Minimum size in pixels. */
+  private val minSizeInPx = range.start
 
-    /** Current size in pixels. **/
-    private var fontSizeInPx by mutableFloatStateOf(range.endInclusive)
+  /** Current size in pixels. */
+  private var fontSizeInPx by mutableFloatStateOf(range.endInclusive)
 
-    /** Current size based on [fontSizeInPx], converted into [SP][TextUnitType.Sp]. **/
-    val size by derivedStateOf {
-        with(density) {
-            fontSizeInPx.toSp()
-        }
+  /** Current size based on [fontSizeInPx], converted into [SP][TextUnitType.Sp]. */
+  val size by derivedStateOf { with(density) { fontSizeInPx.toSp() } }
+
+  /**
+   * Changes the [size] based on the [result] to one that minimally fits into the layout bounds.
+   *
+   * @param result [TextLayoutResult] obtained by laying out the text.
+   * @param canBeDrawn Whether the text can be drawn.
+   * @param onFinish Callback called when it's finished sizing.
+   */
+  fun autoSize(result: TextLayoutResult, canBeDrawn: Boolean, onFinish: () -> Unit) {
+    if (result.didOverflowHeight && !canBeDrawn) {
+      decreaseSize(onFinish)
+    } else {
+      onFinish()
     }
+  }
 
-    /**
-     * Changes the [size] based on the [result] to one that minimally fits into the layout
-     * bounds.
-     *
-     * @param result [TextLayoutResult] obtained by laying out the text.
-     * @param canBeDrawn Whether the text can be drawn.
-     * @param onFinish Callback called when it's finished sizing.
-     **/
-    fun autoSize(result: TextLayoutResult, canBeDrawn: Boolean, onFinish: () -> Unit) {
-        if (result.didOverflowHeight && !canBeDrawn) {
-            decreaseSize(onFinish)
-        } else {
-            onFinish()
-        }
+  /**
+   * Decreases the [size] by 1 [SP][TextUnitType.Sp] until it reaches its minimum value.
+   *
+   * @param onFinish Callback called when it's finished sizing.
+   * @see minSizeInPx
+   */
+  private fun decreaseSize(onFinish: () -> Unit) {
+    val stepInPx = with(density) { 1.sp.toPx() }
+    val nextFontSizeInPx = fontSizeInPx - stepInPx
+    val hasReachedMinSize = nextFontSizeInPx <= minSizeInPx
+    if (hasReachedMinSize) {
+      fontSizeInPx = minSizeInPx
+      onFinish()
+    } else {
+      fontSizeInPx = nextFontSizeInPx
     }
-
-    /**
-     * Decreases the [size] by 1 [SP][TextUnitType.Sp] until it reaches its minimum value.
-     *
-     * @param onFinish Callback called when it's finished sizing.
-     * @see minSizeInPx
-     **/
-    private fun decreaseSize(onFinish: () -> Unit) {
-        val stepInPx = with(density) { 1.sp.toPx() }
-        val nextFontSizeInPx = fontSizeInPx - stepInPx
-        val hasReachedMinSize = nextFontSizeInPx <= minSizeInPx
-        if (hasReachedMinSize) {
-            fontSizeInPx = minSizeInPx
-            onFinish()
-        } else {
-            fontSizeInPx = nextFontSizeInPx
-        }
-    }
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/reactivity/BottomAreaAvailabilityNestedScrollConnection.extensions.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/reactivity/BottomAreaAvailabilityNestedScrollConnection.extensions.kt
@@ -7,12 +7,10 @@ import androidx.compose.runtime.remember
  * Remembers a [BottomAreaAvailabilityNestedScrollConnection].
  *
  * @param listener [OnBottomAreaAvailabilityChangeListener] to be notified.
- **/
+ */
 @Composable
 fun rememberBottomAreaAvailabilityNestedScrollConnection(
-    listener: OnBottomAreaAvailabilityChangeListener
+  listener: OnBottomAreaAvailabilityChangeListener
 ): BottomAreaAvailabilityNestedScrollConnection {
-    return remember(listener) {
-        BottomAreaAvailabilityNestedScrollConnection(listener)
-    }
+  return remember(listener) { BottomAreaAvailabilityNestedScrollConnection(listener) }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/reactivity/BottomAreaAvailabilityNestedScrollConnection.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/reactivity/BottomAreaAvailabilityNestedScrollConnection.kt
@@ -8,27 +8,26 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
  * [NestedScrollConnection] that notifies the [listener] of scroll changes.
  *
  * @param listener [OnBottomAreaAvailabilityChangeListener] to be notified.
- **/
-class BottomAreaAvailabilityNestedScrollConnection internal constructor(
-    private val listener: OnBottomAreaAvailabilityChangeListener
-) : NestedScrollConnection {
-    override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-        val currentOffsetY = listener.getCurrentOffsetY()
-        val heightAsFloat = listener.height.toFloat()
-        val changedOffsetY = (currentOffsetY - available.y).coerceIn(0f, heightAsFloat)
-        listener.onBottomAreaAvailabilityChange(changedOffsetY)
-        return Offset.Zero
-    }
+ */
+class BottomAreaAvailabilityNestedScrollConnection
+internal constructor(private val listener: OnBottomAreaAvailabilityChangeListener) :
+  NestedScrollConnection {
+  override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+    val currentOffsetY = listener.getCurrentOffsetY()
+    val heightAsFloat = listener.height.toFloat()
+    val changedOffsetY = (currentOffsetY - available.y).coerceIn(0f, heightAsFloat)
+    listener.onBottomAreaAvailabilityChange(changedOffsetY)
+    return Offset.Zero
+  }
 
-    companion object {
-        /**
-         * [BottomAreaAvailabilityNestedScrollConnection] with an empty
-         * [OnBottomAreaAvailabilityChangeListener].
-         *
-         * @see OnBottomAreaAvailabilityChangeListener.empty
-         **/
-        val empty = BottomAreaAvailabilityNestedScrollConnection(
-            OnBottomAreaAvailabilityChangeListener.empty
-        )
-    }
+  companion object {
+    /**
+     * [BottomAreaAvailabilityNestedScrollConnection] with an empty
+     * [OnBottomAreaAvailabilityChangeListener].
+     *
+     * @see OnBottomAreaAvailabilityChangeListener.empty
+     */
+    val empty =
+      BottomAreaAvailabilityNestedScrollConnection(OnBottomAreaAvailabilityChangeListener.empty)
+  }
 }

--- a/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/reactivity/OnBottomAreaAvailabilityChangeListener.kt
+++ b/platform/theme/src/main/java/com/jeanbarrossilva/orca/platform/theme/reactivity/OnBottomAreaAvailabilityChangeListener.kt
@@ -1,34 +1,32 @@
 package com.jeanbarrossilva.orca.platform.theme.reactivity
 
-/**
- * Listens to changes on the availability of the utmost bottom portion of the displayed content.
- **/
+/** Listens to changes on the availability of the utmost bottom portion of the displayed content. */
 interface OnBottomAreaAvailabilityChangeListener {
-    /** Provides the height of the UI component in the bottom area.  **/
-    val height: Int
+  /** Provides the height of the UI component in the bottom area. */
+  val height: Int
 
-    /** Provides the current offset in the Y-axis of the UI component in the bottom area. **/
-    fun getCurrentOffsetY(): Float
+  /** Provides the current offset in the Y-axis of the UI component in the bottom area. */
+  fun getCurrentOffsetY(): Float
 
-    /**
-     * Callback run whenever the availability of the bottom area is changed.
-     *
-     * @param offsetY Amount of offset in the Y-axis to be applied to a UI component in the bottom
-     * area.
-     **/
-    fun onBottomAreaAvailabilityChange(offsetY: Float)
+  /**
+   * Callback run whenever the availability of the bottom area is changed.
+   *
+   * @param offsetY Amount of offset in the Y-axis to be applied to a UI component in the bottom
+   *   area.
+   */
+  fun onBottomAreaAvailabilityChange(offsetY: Float)
 
-    companion object {
-        /** No-op [OnBottomAreaAvailabilityChangeListener]. **/
-        val empty = object : OnBottomAreaAvailabilityChangeListener {
-            override val height = 0
+  companion object {
+    /** No-op [OnBottomAreaAvailabilityChangeListener]. */
+    val empty =
+      object : OnBottomAreaAvailabilityChangeListener {
+        override val height = 0
 
-            override fun getCurrentOffsetY(): Float {
-                return 0f
-            }
-
-            override fun onBottomAreaAvailabilityChange(offsetY: Float) {
-            }
+        override fun getCurrentOffsetY(): Float {
+          return 0f
         }
-    }
+
+        override fun onBottomAreaAvailabilityChange(offsetY: Float) {}
+      }
+  }
 }

--- a/platform/ui-test/build.gradle.kts
+++ b/platform/ui-test/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = namespaceFor("platform.ui.test")
-    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.get()
     defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
     buildFeatures {

--- a/platform/ui-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/test/core/test/TestScope.extensions.kt
+++ b/platform/ui-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/test/core/test/TestScope.extensions.kt
@@ -8,15 +8,13 @@ import kotlinx.coroutines.test.runTest
  * Waits until the result of [condition] is `true`.
  *
  * @param condition Returns the expectation to be met.
- **/
+ */
 internal fun waitUntil(condition: () -> Boolean) {
-    runTest {
-        suspendCoroutine {
-            @Suppress("ControlFlowWithEmptyBody")
-            while (!condition()) {
-            }
+  runTest {
+    suspendCoroutine {
+      @Suppress("ControlFlowWithEmptyBody") while (!condition()) {}
 
-            it.resume(Unit)
-        }
+      it.resume(Unit)
     }
+  }
 }

--- a/platform/ui-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/test/core/test/TestSingleFragmentActivity.kt
+++ b/platform/ui-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/test/core/test/TestSingleFragmentActivity.kt
@@ -7,58 +7,56 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 
 internal abstract class TestSingleFragmentActivity : SingleFragmentActivity() {
-    var runNavGraphIntegrityCallback: NavGraphIntegrityCallback? = null
-        private set
+  var runNavGraphIntegrityCallback: NavGraphIntegrityCallback? = null
+    private set
 
-    enum class NavGraphIntegrityCallback {
-        NO_DESTINATION,
-        INEQUIVALENT_DESTINATION_ROUTE,
-        NON_FRAGMENT_DESTINATION,
-        MULTIPLE_DESTINATIONS
-    }
+  enum class NavGraphIntegrityCallback {
+    NO_DESTINATION,
+    INEQUIVALENT_DESTINATION_ROUTE,
+    NON_FRAGMENT_DESTINATION,
+    MULTIPLE_DESTINATIONS
+  }
 
-    override fun onNoDestination() {
-        runNavGraphIntegrityCallback = NavGraphIntegrityCallback.NO_DESTINATION
-        cancelNavGraphIntegrityInsuranceJob()
-    }
+  override fun onNoDestination() {
+    runNavGraphIntegrityCallback = NavGraphIntegrityCallback.NO_DESTINATION
+    cancelNavGraphIntegrityInsuranceJob()
+  }
 
-    override fun onInequivalentDestinationRoute() {
-        runNavGraphIntegrityCallback = NavGraphIntegrityCallback.INEQUIVALENT_DESTINATION_ROUTE
-        cancelNavGraphIntegrityInsuranceJob()
-    }
+  override fun onInequivalentDestinationRoute() {
+    runNavGraphIntegrityCallback = NavGraphIntegrityCallback.INEQUIVALENT_DESTINATION_ROUTE
+    cancelNavGraphIntegrityInsuranceJob()
+  }
 
-    override fun onNonFragmentDestination() {
-        runNavGraphIntegrityCallback = NavGraphIntegrityCallback.NON_FRAGMENT_DESTINATION
-    }
+  override fun onNonFragmentDestination() {
+    runNavGraphIntegrityCallback = NavGraphIntegrityCallback.NON_FRAGMENT_DESTINATION
+  }
 
-    override fun onMultipleDestinations() {
-        runNavGraphIntegrityCallback = NavGraphIntegrityCallback.MULTIPLE_DESTINATIONS
-    }
+  override fun onMultipleDestinations() {
+    runNavGraphIntegrityCallback = NavGraphIntegrityCallback.MULTIPLE_DESTINATIONS
+  }
 
-    private fun cancelNavGraphIntegrityInsuranceJob() {
-        runTest {
-            navGraphIntegrityInsuranceJob?.cancelAndJoin()
+  private fun cancelNavGraphIntegrityInsuranceJob() {
+    runTest { navGraphIntegrityInsuranceJob?.cancelAndJoin() }
+  }
+
+  companion object {
+    /**
+     * Asserts that [expected] is the [NavGraphIntegrityCallback] to get run when this
+     * [TestSingleFragmentActivity] is launched.
+     *
+     * @param expected [NavGraphIntegrityCallback] that's expected to be run.
+     */
+    inline fun <reified T : TestSingleFragmentActivity> assertRunNavGraphCallbackEquals(
+      expected: NavGraphIntegrityCallback
+    ) {
+      var actual: NavGraphIntegrityCallback? = null
+      launchActivity<T>().use { scenario ->
+        scenario.onActivity { activity ->
+          waitUntil { activity.runNavGraphIntegrityCallback != null }
+          actual = activity.runNavGraphIntegrityCallback
         }
+      }
+      assertEquals(expected, actual)
     }
-
-    companion object {
-        /**
-         * Asserts that [expected] is the [NavGraphIntegrityCallback] to get run when this
-         * [TestSingleFragmentActivity] is launched.
-         *
-         * @param expected [NavGraphIntegrityCallback] that's expected to be run.
-         **/
-        inline fun <reified T : TestSingleFragmentActivity> assertRunNavGraphCallbackEquals(
-            expected: NavGraphIntegrityCallback
-        ) {
-            var actual: NavGraphIntegrityCallback? = null
-            launchActivity<T>().use { scenario ->
-                scenario.onActivity { activity ->
-                    waitUntil { activity.runNavGraphIntegrityCallback != null }
-                    actual = activity.runNavGraphIntegrityCallback
-                }
-            }
-            assertEquals(expected, actual)
-        }
-    }
+  }
 }

--- a/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/Assert.extensions.kt
+++ b/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/Assert.extensions.kt
@@ -9,10 +9,10 @@ import org.junit.Assert.assertNotNull
  *
  * @param activity [FragmentActivity] in which the [Fragment] is supposed to be.
  * @param tag Tag of the [Fragment] that's supposed to be the current one.
- **/
+ */
 fun assertIsAtFragment(activity: FragmentActivity, tag: String) {
-    assertNotNull(
-        "Fragment tagged as \"$tag\" not found.",
-        activity.supportFragmentManager.findFragmentByTag(tag)
-    )
+  assertNotNull(
+    "Fragment tagged as \"$tag\" not found.",
+    activity.supportFragmentManager.findFragmentByTag(tag)
+  )
 }

--- a/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/component/timeline/ComposeTestRule.extensions.kt
+++ b/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/component/timeline/ComposeTestRule.extensions.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.TIMELINE_TAG
 
-/** [SemanticsNodeInteraction] of a [Timeline] node. **/
+/** [SemanticsNodeInteraction] of a [Timeline] node. */
 fun ComposeTestRule.onTimeline(): SemanticsNodeInteraction {
-    return onNodeWithTag(TIMELINE_TAG)
+  return onNodeWithTag(TIMELINE_TAG)
 }

--- a/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/component/timeline/toot/ComposeTestRule.extensions.kt
+++ b/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/component/timeline/toot/ComposeTestRule.extensions.kt
@@ -8,12 +8,12 @@ import androidx.compose.ui.test.onNodeWithTag
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.TOOT_PREVIEW_TAG
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.TootPreview
 
-/** [SemanticsNodeInteractionCollection] of [TootPreview] nodes. **/
+/** [SemanticsNodeInteractionCollection] of [TootPreview] nodes. */
 fun ComposeTestRule.onTootPreviews(): SemanticsNodeInteractionCollection {
-    return onAllNodesWithTag(TOOT_PREVIEW_TAG)
+  return onAllNodesWithTag(TOOT_PREVIEW_TAG)
 }
 
-/** [SemanticsNodeInteraction] of a [TootPreview] node. **/
+/** [SemanticsNodeInteraction] of a [TootPreview] node. */
 fun ComposeTestRule.onTootPreview(): SemanticsNodeInteraction {
-    return onNodeWithTag(TOOT_PREVIEW_TAG)
+  return onNodeWithTag(TOOT_PREVIEW_TAG)
 }

--- a/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/component/timeline/toot/headline/ComposeTestRule.extensions.kt
+++ b/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/component/timeline/toot/headline/ComposeTestRule.extensions.kt
@@ -8,12 +8,12 @@ import androidx.compose.ui.test.onNodeWithTag
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.headline.HEADLINE_CARD_TAG
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.headline.HeadlineCard
 
-/** [SemanticsNodeInteraction] of a [HeadlineCard]. **/
+/** [SemanticsNodeInteraction] of a [HeadlineCard]. */
 fun ComposeTestRule.onHeadlineCard(): SemanticsNodeInteraction {
-    return onNodeWithTag(HEADLINE_CARD_TAG)
+  return onNodeWithTag(HEADLINE_CARD_TAG)
 }
 
-/** [SemanticsNodeInteractionCollection] of [HeadlineCard]s. **/
+/** [SemanticsNodeInteractionCollection] of [HeadlineCard]s. */
 fun ComposeTestRule.onHeadlineCards(): SemanticsNodeInteractionCollection {
-    return onAllNodesWithTag(HEADLINE_CARD_TAG)
+  return onAllNodesWithTag(HEADLINE_CARD_TAG)
 }

--- a/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/component/timeline/toot/time/Time4JTestRule.kt
+++ b/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/component/timeline/toot/time/Time4JTestRule.kt
@@ -9,10 +9,10 @@ import org.junit.rules.ExternalResource
  * [ExternalResource] that initializes the Time4J library before each test.
  *
  * @see ApplicationStarter.initialize
- **/
+ */
 class Time4JTestRule : ExternalResource() {
-    override fun before() {
-        val application = ApplicationProvider.getApplicationContext<Application>()
-        ApplicationStarter.initialize(application)
-    }
+  override fun before() {
+    val application = ApplicationProvider.getApplicationContext<Application>()
+    ApplicationStarter.initialize(application)
+  }
 }

--- a/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/core/NavController.extensions.kt
+++ b/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/core/NavController.extensions.kt
@@ -2,11 +2,12 @@ package com.jeanbarrossilva.orca.platform.ui.test.core
 
 import androidx.navigation.NavController
 
-/** Whether this [NavController] has a [graph][NavController.graph]. **/
+/** Whether this [NavController] has a [graph][NavController.graph]. */
 internal val NavController.hasNavGraph
-    get() = try {
-        graph
-        true
+  get() =
+    try {
+      graph
+      true
     } catch (_: IllegalStateException) {
-        false
+      false
     }

--- a/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/core/SingleFragmentActivity.kt
+++ b/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/core/SingleFragmentActivity.kt
@@ -25,291 +25,286 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
-/** [FragmentActivity] that hosts a single [Fragment]. **/
+/** [FragmentActivity] that hosts a single [Fragment]. */
 abstract class SingleFragmentActivity : FragmentActivity() {
-    /**
-     * [ActivitySingleDestinationBinding] through which [View]s from the layout resource file can be
-     * referenced. It's available after this [SingleFragmentActivity] is created and set to
-     * `null` when it's destroyed.
-     *
-     * @see R.layout.activity_single_destination
-     **/
-    private var binding: ActivitySingleDestinationBinding? = null
+  /**
+   * [ActivitySingleDestinationBinding] through which [View]s from the layout resource file can be
+   * referenced. It's available after this [SingleFragmentActivity] is created and set to `null`
+   * when it's destroyed.
+   *
+   * @see R.layout.activity_single_destination
+   */
+  private var binding: ActivitySingleDestinationBinding? = null
 
-    /** [FragmentOnAttachListener] that sets [arguments] as the [Fragment]'s. **/
-    private val fragmentArgumentsSettingOnAttachListener =
-        FragmentOnAttachListener { _, fragment -> fragment.arguments = arguments }
+  /** [FragmentOnAttachListener] that sets [arguments] as the [Fragment]'s. */
+  private val fragmentArgumentsSettingOnAttachListener = FragmentOnAttachListener { _, fragment ->
+    fragment.arguments = arguments
+  }
 
-    /**
-     * [NavController.OnDestinationChangedListener] that ensures the integrity of the [navGraph].
-     *
-     * @see ensureIntegrity
-     **/
-    private val navGraphIntegrityInsuranceOnDestinationChangedListener =
-        NavController.OnDestinationChangedListener { _, _, _ -> ensureIntegrity(navGraph) }
+  /**
+   * [NavController.OnDestinationChangedListener] that ensures the integrity of the [navGraph].
+   *
+   * @see ensureIntegrity
+   */
+  private val navGraphIntegrityInsuranceOnDestinationChangedListener =
+    NavController.OnDestinationChangedListener { _, _, _ -> ensureIntegrity(navGraph) }
 
-    /**
-     * [navHostFragment]'s child [FragmentManager].
-     *
-     * @see NavHostFragment.getChildFragmentManager
-     **/
-    private val navHostChildFragmentManager
-        get() = navHostFragment.childFragmentManager
+  /**
+   * [navHostFragment]'s child [FragmentManager].
+   *
+   * @see NavHostFragment.getChildFragmentManager
+   */
+  private val navHostChildFragmentManager
+    get() = navHostFragment.childFragmentManager
 
-    /**
-     * [NavHostFragment] of [binding]'s
-     * [containerView][ActivitySingleDestinationBinding.containerView].
-     **/
-    private val navHostFragment
-        get() = requireNotNull(binding?.root).getFragment<NavHostFragment>()
+  /**
+   * [NavHostFragment] of [binding]'s
+   * [containerView][ActivitySingleDestinationBinding.containerView].
+   */
+  private val navHostFragment
+    get() = requireNotNull(binding?.root).getFragment<NavHostFragment>()
 
-    /** [NavGraph] to which the [NavDestination] pointing to the [Fragment] is added. **/
-    private var navGraph
-        get() = navController.graph
-        set(navGraph) {
-            ensureIntegrity(navGraph)
-            navGraphIntegrityInsuranceJob?.invokeOnCompletion { cause ->
-                if (cause == null) {
-                    lifecycleScope.launch {
-                        navController.graph = navGraph
-                        onNavGraphChangeListeners
-                            .onEach(OnNavGraphChangeListener::onNavGraphChange)
-                            .clear()
-                    }
-                }
-            }
+  /** [NavGraph] to which the [NavDestination] pointing to the [Fragment] is added. */
+  private var navGraph
+    get() = navController.graph
+    set(navGraph) {
+      ensureIntegrity(navGraph)
+      navGraphIntegrityInsuranceJob?.invokeOnCompletion { cause ->
+        if (cause == null) {
+          lifecycleScope.launch {
+            navController.graph = navGraph
+            onNavGraphChangeListeners.onEach(OnNavGraphChangeListener::onNavGraphChange).clear()
+          }
         }
-
-    /** [Job] that ensures the [navGraph]'s integrity. **/
-    internal var navGraphIntegrityInsuranceJob: Job? = null
-        private set
-
-    /**
-     * [CoroutineScope] in which the [navGraph]'s integrity is ensured.
-     *
-     * @see navGraphIntegrityInsuranceJob
-     **/
-    private val navGraphIntegrityInsuranceScope = CoroutineScope(Dispatchers.Default)
-
-    /** Currently active [OnNavGraphChangeListener]s. **/
-    private val onNavGraphChangeListeners = mutableListOf<OnNavGraphChangeListener>()
-
-    /** [navHostFragment]'s [navController][NavHostFragment.navController]. **/
-    internal val navController
-        get() = navHostFragment.navController
-
-    /**
-     * Arguments to be passed to the [Fragment]. Defaults to this [SingleFragmentActivity]'s
-     * [intent][getIntent]'s [extras][Intent.getExtras].
-     **/
-    protected open val arguments: Bundle?
-        get() = intent.extras
-
-    /** [Route][NavDestination.route] of the [NavDestination]. **/
-    protected abstract val route: String
-
-    /** Listener that's notified whenever the [navGraph] changes. **/
-    internal fun interface OnNavGraphChangeListener {
-        /** Callback run whenever the [navGraph] changes. **/
-        fun onNavGraphChange()
+      }
     }
 
-    /**
-     * [IllegalStateException] thrown if a destination isn't added to this [SingleFragmentActivity].
-     *
-     * @see add
-     **/
-    class NoDestinationException internal constructor() :
-        IllegalStateException("SingleFragmentActivity should have a destination.")
+  /** [Job] that ensures the [navGraph]'s integrity. */
+  internal var navGraphIntegrityInsuranceJob: Job? = null
+    private set
 
-    /**
-     * [IllegalStateException] thrown if the added [NavDestination]'s [route][NavDestination.route]
-     * doesn't match the [SingleFragmentActivity]'s.
-     *
-     * @param route Inequivalent [route][NavDestination.route] that's been assigned to the
-     * [NavDestination].
-     * @see SingleFragmentActivity.route
-     **/
-    class InequivalentDestinationRouteException internal constructor(route: String) :
-        IllegalStateException("Destination route doesn't match SingleFragmentActivity's ($route).")
+  /**
+   * [CoroutineScope] in which the [navGraph]'s integrity is ensured.
+   *
+   * @see navGraphIntegrityInsuranceJob
+   */
+  private val navGraphIntegrityInsuranceScope = CoroutineScope(Dispatchers.Default)
 
-    /**
-     * [IllegalStateException] thrown if the added [NavDestination] doesn't point to a [Fragment].
-     **/
-    class NonFragmentDestinationException internal constructor() : IllegalStateException(
-        "SingleFragmentActivity should have a destination that points to a Fragment."
+  /** Currently active [OnNavGraphChangeListener]s. */
+  private val onNavGraphChangeListeners = mutableListOf<OnNavGraphChangeListener>()
+
+  /** [navHostFragment]'s [navController][NavHostFragment.navController]. */
+  internal val navController
+    get() = navHostFragment.navController
+
+  /**
+   * Arguments to be passed to the [Fragment]. Defaults to this [SingleFragmentActivity]'s
+   * [intent][getIntent]'s [extras][Intent.getExtras].
+   */
+  protected open val arguments: Bundle?
+    get() = intent.extras
+
+  /** [Route][NavDestination.route] of the [NavDestination]. */
+  protected abstract val route: String
+
+  /** Listener that's notified whenever the [navGraph] changes. */
+  internal fun interface OnNavGraphChangeListener {
+    /** Callback run whenever the [navGraph] changes. */
+    fun onNavGraphChange()
+  }
+
+  /**
+   * [IllegalStateException] thrown if a destination isn't added to this [SingleFragmentActivity].
+   *
+   * @see add
+   */
+  class NoDestinationException internal constructor() :
+    IllegalStateException("SingleFragmentActivity should have a destination.")
+
+  /**
+   * [IllegalStateException] thrown if the added [NavDestination]'s [route][NavDestination.route]
+   * doesn't match the [SingleFragmentActivity]'s.
+   *
+   * @param route Inequivalent [route][NavDestination.route] that's been assigned to the
+   *   [NavDestination].
+   * @see SingleFragmentActivity.route
+   */
+  class InequivalentDestinationRouteException internal constructor(route: String) :
+    IllegalStateException("Destination route doesn't match SingleFragmentActivity's ($route).")
+
+  /** [IllegalStateException] thrown if the added [NavDestination] doesn't point to a [Fragment]. */
+  class NonFragmentDestinationException internal constructor() :
+    IllegalStateException(
+      "SingleFragmentActivity should have a destination that points to a Fragment."
     )
 
-    /**
-     * [IllegalStateException] thrown if multiple destinations are added to this
-     * [SingleFragmentActivity].
-     **/
-    class MultipleDestinationsException internal constructor() :
-        IllegalStateException("SingleFragmentActivity should only have one destination.")
+  /**
+   * [IllegalStateException] thrown if multiple destinations are added to this
+   * [SingleFragmentActivity].
+   */
+  class MultipleDestinationsException internal constructor() :
+    IllegalStateException("SingleFragmentActivity should only have one destination.")
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        binding = ActivitySingleDestinationBinding.inflate(layoutInflater)
-        navHostChildFragmentManager
-            .addFragmentOnAttachListener(fragmentArgumentsSettingOnAttachListener)
-        navController
-            .addOnDestinationChangedListener(navGraphIntegrityInsuranceOnDestinationChangedListener)
-        navGraph = navController.createGraph(startDestination = route) { add() }
-        setContentView(binding?.root)
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    binding = ActivitySingleDestinationBinding.inflate(layoutInflater)
+    navHostChildFragmentManager.addFragmentOnAttachListener(
+      fragmentArgumentsSettingOnAttachListener
+    )
+    navController.addOnDestinationChangedListener(
+      navGraphIntegrityInsuranceOnDestinationChangedListener
+    )
+    navGraph = navController.createGraph(startDestination = route) { add() }
+    setContentView(binding?.root)
+  }
+
+  override fun onDestroy() {
+    navGraphIntegrityInsuranceScope.cancel()
+    navController.removeOnDestinationChangedListener(
+      navGraphIntegrityInsuranceOnDestinationChangedListener
+    )
+    navHostChildFragmentManager.removeFragmentOnAttachListener(
+      fragmentArgumentsSettingOnAttachListener
+    )
+    binding = null
+    super.onDestroy()
+  }
+
+  /**
+   * Adds a [FragmentNavigator.Destination] whose [route][FragmentNavigator.Destination.route] is
+   * the same as this [SingleFragmentActivity]'s.
+   *
+   * @see SingleFragmentActivity.route
+   */
+  context(NavGraphBuilder)
+  protected inline fun <reified T : Fragment> fragment() {
+    fragment<T>(this@SingleFragmentActivity.route) {}
+  }
+
+  /**
+   * Adds the [NavDestination] to the [NavGraphBuilder].
+   *
+   * Note that its [route][NavDestination.route] has to be the same as this
+   * [SingleFragmentActivity]'s.
+   *
+   * @see SingleFragmentActivity.route
+   */
+  protected abstract fun NavGraphBuilder.add()
+
+  /**
+   * Callback that's called if no [NavDestination] has been added through [add].
+   *
+   * Throws a [NoDestinationException] by default.
+   */
+  internal open fun onNoDestination() {
+    throw NoDestinationException()
+  }
+
+  /**
+   * Callback that's called if the [NavDestination]'s [route][NavDestination.route] doesn't match
+   * this [SingleFragmentActivity]'s.
+   */
+  internal open fun onInequivalentDestinationRoute() {
+    throw InequivalentDestinationRouteException(route)
+  }
+
+  /**
+   * Callback that's called if multiple [NavDestination]s have been added through [add].
+   *
+   * Throws a [MultipleDestinationsException] by default.
+   */
+  internal open fun onMultipleDestinations() {
+    throw MultipleDestinationsException()
+  }
+
+  /**
+   * Callback that's called if the current [NavDestination] doesn't point to a [Fragment].
+   *
+   * Throws a [NoDestinationException] by default.
+   */
+  internal open fun onNonFragmentDestination() {
+    throw NonFragmentDestinationException()
+  }
+
+  /**
+   * Notifies the [listener] when the [navGraph] is changed.
+   *
+   * @param listener [OnNavGraphChangeListener] to be notified.
+   */
+  internal fun doOnNavGraphChange(listener: OnNavGraphChangeListener) {
+    if (navController.hasNavGraph) {
+      listener.onNavGraphChange()
+    } else {
+      onNavGraphChangeListeners.add(listener)
     }
+  }
 
-    override fun onDestroy() {
-        navGraphIntegrityInsuranceScope.cancel()
-        navController.removeOnDestinationChangedListener(
-            navGraphIntegrityInsuranceOnDestinationChangedListener
-        )
-        navHostChildFragmentManager
-            .removeFragmentOnAttachListener(fragmentArgumentsSettingOnAttachListener)
-        binding = null
-        super.onDestroy()
-    }
-
-    /**
-     * Adds a [FragmentNavigator.Destination] whose [route][FragmentNavigator.Destination.route] is
-     * the same as this [SingleFragmentActivity]'s.
-     *
-     * @see SingleFragmentActivity.route
-     **/
-    context(NavGraphBuilder)
-    protected inline fun <reified T : Fragment> fragment() {
-        fragment<T>(this@SingleFragmentActivity.route) {
+  /**
+   * Ensures that the state in which the [navGraph] currently is is an integral one.
+   *
+   * All operations are run in the [navGraphIntegrityInsuranceScope].
+   *
+   * @param navGraph [NavGraph] to perform the insurance on.
+   * @throws NoDestinationException If no [NavDestination] has been added through [add].
+   * @throws MultipleDestinationsException If multiple [NavDestination]s have been added through
+   *   [add].
+   * @throws NonFragmentDestinationException If the [NavDestination] doesn't point to a [Fragment].
+   */
+  private fun ensureIntegrity(navGraph: NavGraph) {
+    navGraphIntegrityInsuranceJob =
+      navGraphIntegrityInsuranceScope
+        .launch {
+          ensureHasSingleDestination(navGraph)
+          ensureDestinationRouteIsEquivalent(navGraph)
+          ensureDestinationPointsToFragment(navGraph)
         }
-    }
+        .also { it.invokeOnCompletion { navGraphIntegrityInsuranceJob = null } }
+  }
 
-    /**
-     * Adds the [NavDestination] to the [NavGraphBuilder].
-     *
-     * Note that its [route][NavDestination.route] has to be the same as this
-     * [SingleFragmentActivity]'s.
-     *
-     * @see SingleFragmentActivity.route
-     **/
-    protected abstract fun NavGraphBuilder.add()
-
-    /**
-     * Callback that's called if no [NavDestination] has been added through [add].
-     *
-     * Throws a [NoDestinationException] by default.
-     **/
-    internal open fun onNoDestination() {
-        throw NoDestinationException()
+  /**
+   * Ensures that the [navGraph] has exactly one [NavDestination].
+   *
+   * @param navGraph [NavGraph] to perform the insurance on.
+   * @throws NoDestinationException If no [NavDestination] has been added through [add].
+   * @throws MultipleDestinationsException If multiple [NavDestination]s have been added through
+   *   [add].
+   */
+  private fun ensureHasSingleDestination(navGraph: NavGraph) {
+    val destinationCount = navGraph.count()
+    if (destinationCount == 0) {
+      onNoDestination()
+    } else if (destinationCount != 1) {
+      onMultipleDestinations()
     }
+  }
 
-    /**
-     * Callback that's called if the [NavDestination]'s [route][NavDestination.route] doesn't match
-     * this [SingleFragmentActivity]'s.
-     **/
-    internal open fun onInequivalentDestinationRoute() {
-        throw InequivalentDestinationRouteException(route)
+  /**
+   * Ensures that [navGraph]'s [NavDestination]'s [route][NavDestination.route] matches this
+   * [SingleFragmentActivity]'s.
+   *
+   * @throws InequivalentDestinationRouteException If the [NavDestination]'s
+   *   [route][NavDestination.route] doesn't match this [SingleFragmentActivity]'s.
+   * @see SingleFragmentActivity.route
+   */
+  private fun ensureDestinationRouteIsEquivalent(navGraph: NavGraph) {
+    val destination = navGraph.findNode(route)
+    val isRouteInequivalent = destination == null
+    if (isRouteInequivalent) {
+      onInequivalentDestinationRoute()
     }
+  }
 
-    /**
-     * Callback that's called if multiple [NavDestination]s have been added through [add].
-     *
-     * Throws a [MultipleDestinationsException] by default.
-     **/
-    internal open fun onMultipleDestinations() {
-        throw MultipleDestinationsException()
+  /**
+   * Ensures that [navGraph]'s [NavDestination] points to a [Fragment].
+   *
+   * @param navGraph [NavGraph] to perform the insurance on.
+   * @throws NonFragmentDestinationException If the [NavDestination] doesn't point to a [Fragment].
+   */
+  private fun ensureDestinationPointsToFragment(navGraph: NavGraph) {
+    val destination = navGraph[navGraph.startDestinationId]
+    val isNotPointingToFragment = destination.navigatorName != "fragment"
+    if (isNotPointingToFragment) {
+      onNonFragmentDestination()
     }
-
-    /**
-     * Callback that's called if the current [NavDestination] doesn't point to a [Fragment].
-     *
-     * Throws a [NoDestinationException] by default.
-     **/
-    internal open fun onNonFragmentDestination() {
-        throw NonFragmentDestinationException()
-    }
-
-    /**
-     * Notifies the [listener] when the [navGraph] is changed.
-     *
-     * @param listener [OnNavGraphChangeListener] to be notified.
-     **/
-    internal fun doOnNavGraphChange(listener: OnNavGraphChangeListener) {
-        if (navController.hasNavGraph) {
-            listener.onNavGraphChange()
-        } else {
-            onNavGraphChangeListeners.add(listener)
-        }
-    }
-
-    /**
-     * Ensures that the state in which the [navGraph] currently is is an integral one.
-     *
-     * All operations are run in the [navGraphIntegrityInsuranceScope].
-     *
-     * @param navGraph [NavGraph] to perform the insurance on.
-     * @throws NoDestinationException If no [NavDestination] has been added through [add].
-     * @throws MultipleDestinationsException If multiple [NavDestination]s have been added through
-     * [add].
-     * @throws NonFragmentDestinationException If the [NavDestination] doesn't point to a
-     * [Fragment].
-     **/
-    private fun ensureIntegrity(navGraph: NavGraph) {
-        navGraphIntegrityInsuranceJob = navGraphIntegrityInsuranceScope
-            .launch {
-                ensureHasSingleDestination(navGraph)
-                ensureDestinationRouteIsEquivalent(navGraph)
-                ensureDestinationPointsToFragment(navGraph)
-            }
-            .also {
-                it.invokeOnCompletion {
-                    navGraphIntegrityInsuranceJob = null
-                }
-            }
-    }
-
-    /**
-     * Ensures that the [navGraph] has exactly one [NavDestination].
-     *
-     * @param navGraph [NavGraph] to perform the insurance on.
-     * @throws NoDestinationException If no [NavDestination] has been added through [add].
-     * @throws MultipleDestinationsException If multiple [NavDestination]s have been added through
-     * [add].
-     **/
-    private fun ensureHasSingleDestination(navGraph: NavGraph) {
-        val destinationCount = navGraph.count()
-        if (destinationCount == 0) {
-            onNoDestination()
-        } else if (destinationCount != 1) {
-            onMultipleDestinations()
-        }
-    }
-
-    /**
-     * Ensures that [navGraph]'s [NavDestination]'s [route][NavDestination.route] matches this
-     * [SingleFragmentActivity]'s.
-     *
-     * @throws InequivalentDestinationRouteException If the [NavDestination]'s [route][NavDestination.route]
-     * doesn't match this [SingleFragmentActivity]'s.
-     * @see SingleFragmentActivity.route
-     **/
-    private fun ensureDestinationRouteIsEquivalent(navGraph: NavGraph) {
-        val destination = navGraph.findNode(route)
-        val isRouteInequivalent = destination == null
-        if (isRouteInequivalent) {
-            onInequivalentDestinationRoute()
-        }
-    }
-
-    /**
-     * Ensures that [navGraph]'s [NavDestination] points to a [Fragment].
-     *
-     * @param navGraph [NavGraph] to perform the insurance on.
-     * @throws NonFragmentDestinationException If the [NavDestination] doesn't point to a
-     * [Fragment].
-     **/
-    private fun ensureDestinationPointsToFragment(navGraph: NavGraph) {
-        val destination = navGraph[navGraph.startDestinationId]
-        val isNotPointingToFragment = destination.navigatorName != "fragment"
-        if (isNotPointingToFragment) {
-            onNonFragmentDestination()
-        }
-    }
+  }
 }

--- a/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/core/lifecycle/state/Assert.extensions.kt
+++ b/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/core/lifecycle/state/Assert.extensions.kt
@@ -10,10 +10,7 @@ import org.junit.Assert.assertTrue
  * @param expected [CompleteLifecycleState] that [actual] should at least be.
  * @param actual [CompleteLifecycleState] to be compared to the [expected] one.
  * @see CompleteLifecycleState.isAtLeast
- **/
-fun assertIsAtLeast(
-    expected: CompleteLifecycleState,
-    actual: CompleteLifecycleState?
-) {
-    assertTrue("$actual is < $expected.", actual.isAtLeast(expected))
+ */
+fun assertIsAtLeast(expected: CompleteLifecycleState, actual: CompleteLifecycleState?) {
+  assertTrue("$actual is < $expected.", actual.isAtLeast(expected))
 }

--- a/platform/ui/build.gradle.kts
+++ b/platform/ui/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     buildFeatures.compose = true
-    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.get()
     packagingOptions.resources.excludes +=
         arrayOf("META-INF/LICENSE.md", "META-INF/LICENSE-notice.md")
 

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/avatar/LargeAvatarTests.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/avatar/LargeAvatarTests.kt
@@ -13,50 +13,37 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class LargeAvatarTests {
-    @get:Rule
-    val composeRule = createComposeRule()
+  @get:Rule val composeRule = createComposeRule()
 
-    @Test
-    fun isTaggedWhenEmpty() {
-        composeRule.setContent {
-            OrcaTheme {
-                LargeAvatar()
-            }
-        }
-        composeRule.onNodeWithTag(AVATAR_TAG).assertExists()
-    }
+  @Test
+  fun isTaggedWhenEmpty() {
+    composeRule.setContent { OrcaTheme { LargeAvatar() } }
+    composeRule.onNodeWithTag(AVATAR_TAG).assertExists()
+  }
 
-    @Test
-    fun isLoadingWhenEmpty() {
-        composeRule.setContent {
-            OrcaTheme {
-                LargeAvatar()
-            }
-        }
-        composeRule.onNodeWithTag(AVATAR_TAG).assertIsLoading()
-    }
+  @Test
+  fun isLoadingWhenEmpty() {
+    composeRule.setContent { OrcaTheme { LargeAvatar() } }
+    composeRule.onNodeWithTag(AVATAR_TAG).assertIsLoading()
+  }
 
-    @Test
-    fun isTaggedWhenPopulated() {
-        composeRule.setContent {
-            OrcaTheme {
-                LargeAvatar(
-                    Avatar.sample.name,
-                    Avatar.sample.url,
-                    imageLoader = TestImageLoader
-                )
-            }
-        }
-        composeRule.onNodeWithTag(AVATAR_TAG).assertExists()
+  @Test
+  fun isTaggedWhenPopulated() {
+    composeRule.setContent {
+      OrcaTheme {
+        LargeAvatar(Avatar.sample.name, Avatar.sample.url, imageLoader = TestImageLoader)
+      }
     }
+    composeRule.onNodeWithTag(AVATAR_TAG).assertExists()
+  }
 
-    @Test
-    fun isLoadedWhenPopulated() {
-        composeRule.setContent {
-            OrcaTheme {
-                LargeAvatar(Avatar.sample.name, Avatar.sample.url, imageLoader = TestImageLoader)
-            }
-        }
-        composeRule.onNodeWithTag(AVATAR_TAG).assertIsNotLoading()
+  @Test
+  fun isLoadedWhenPopulated() {
+    composeRule.setContent {
+      OrcaTheme {
+        LargeAvatar(Avatar.sample.name, Avatar.sample.url, imageLoader = TestImageLoader)
+      }
     }
+    composeRule.onNodeWithTag(AVATAR_TAG).assertIsNotLoading()
+  }
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/avatar/SmallAvatarTests.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/avatar/SmallAvatarTests.kt
@@ -13,54 +13,37 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class SmallAvatarTests {
-    @get:Rule
-    val composeRule = createComposeRule()
+  @get:Rule val composeRule = createComposeRule()
 
-    @Test
-    fun isTaggedWhenEmpty() {
-        composeRule.setContent {
-            OrcaTheme {
-                SmallAvatar()
-            }
-        }
-        composeRule.onNodeWithTag(AVATAR_TAG).assertExists()
-    }
+  @Test
+  fun isTaggedWhenEmpty() {
+    composeRule.setContent { OrcaTheme { SmallAvatar() } }
+    composeRule.onNodeWithTag(AVATAR_TAG).assertExists()
+  }
 
-    @Test
-    fun isLoadingWhenEmpty() {
-        composeRule.setContent {
-            OrcaTheme {
-                SmallAvatar()
-            }
-        }
-        composeRule.onNodeWithTag(AVATAR_TAG).assertIsLoading()
-    }
+  @Test
+  fun isLoadingWhenEmpty() {
+    composeRule.setContent { OrcaTheme { SmallAvatar() } }
+    composeRule.onNodeWithTag(AVATAR_TAG).assertIsLoading()
+  }
 
-    @Test
-    fun isTaggedWhenPopulated() {
-        composeRule.setContent {
-            OrcaTheme {
-                SmallAvatar(
-                    Avatar.sample.name,
-                    Avatar.sample.url,
-                    imageLoader = TestImageLoader
-                )
-            }
-        }
-        composeRule.onNodeWithTag(AVATAR_TAG).assertExists()
+  @Test
+  fun isTaggedWhenPopulated() {
+    composeRule.setContent {
+      OrcaTheme {
+        SmallAvatar(Avatar.sample.name, Avatar.sample.url, imageLoader = TestImageLoader)
+      }
     }
+    composeRule.onNodeWithTag(AVATAR_TAG).assertExists()
+  }
 
-    @Test
-    fun isLoadedWhenPopulated() {
-        composeRule.setContent {
-            OrcaTheme {
-                SmallAvatar(
-                    Avatar.sample.name,
-                    Avatar.sample.url,
-                    imageLoader = TestImageLoader
-                )
-            }
-        }
-        composeRule.onNodeWithTag(AVATAR_TAG).assertIsNotLoading()
+  @Test
+  fun isLoadedWhenPopulated() {
+    composeRule.setContent {
+      OrcaTheme {
+        SmallAvatar(Avatar.sample.name, Avatar.sample.url, imageLoader = TestImageLoader)
+      }
     }
+    composeRule.onNodeWithTag(AVATAR_TAG).assertIsNotLoading()
+  }
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/stat/ActivateableStatIconTests.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/stat/ActivateableStatIconTests.kt
@@ -10,32 +10,30 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class ActivateableStatIconTests {
-    @get:Rule
-    val composeRule = createComposeRule()
+  @get:Rule val composeRule = createComposeRule()
 
-    @Test
-    fun isUnselectedWhenInactive() {
-        composeRule.setContent { TestActivateableStatIcon(isActive = false) }
-        composeRule.onActivateableStatIcon().assertIsNotSelected()
-    }
+  @Test
+  fun isUnselectedWhenInactive() {
+    composeRule.setContent { TestActivateableStatIcon(isActive = false) }
+    composeRule.onActivateableStatIcon().assertIsNotSelected()
+  }
 
-    @Test
-    fun isSelectedWhenActive() {
-        composeRule.setContent { TestActivateableStatIcon(isActive = true) }
-        composeRule.onActivateableStatIcon().assertIsSelected()
-    }
+  @Test
+  fun isSelectedWhenActive() {
+    composeRule.setContent { TestActivateableStatIcon(isActive = true) }
+    composeRule.onActivateableStatIcon().assertIsSelected()
+  }
 
-    @Test
-    fun receivesInteractionWhenInteractive() {
-        var hasBeenInteractedWith = false
-        composeRule.setContent {
-            TestActivateableStatIcon(
-                interactiveness = ActivateableStatIconInteractiveness.Interactive {
-                    hasBeenInteractedWith = true
-                }
-            )
-        }
-        composeRule.onActivateableStatIcon().performClick()
-        assertTrue(hasBeenInteractedWith)
+  @Test
+  fun receivesInteractionWhenInteractive() {
+    var hasBeenInteractedWith = false
+    composeRule.setContent {
+      TestActivateableStatIcon(
+        interactiveness =
+          ActivateableStatIconInteractiveness.Interactive { hasBeenInteractedWith = true }
+      )
     }
+    composeRule.onActivateableStatIcon().performClick()
+    assertTrue(hasBeenInteractedWith)
+  }
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/stat/TestActivateableStatIcon.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/stat/TestActivateableStatIcon.kt
@@ -8,16 +8,16 @@ import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
 @Composable
 @Suppress("TestFunctionName")
 internal fun TestActivateableStatIcon(
-    modifier: Modifier = Modifier,
-    isActive: Boolean = false,
-    interactiveness: ActivateableStatIconInteractiveness = ActivateableStatIconInteractiveness.Still
+  modifier: Modifier = Modifier,
+  isActive: Boolean = false,
+  interactiveness: ActivateableStatIconInteractiveness = ActivateableStatIconInteractiveness.Still
 ) {
-    ActivateableStatIcon(
-        OrcaTheme.iconography.forward,
-        contentDescription = "Proceed",
-        isActive,
-        interactiveness,
-        ActivateableStatIconColors(LocalContentColor.current, LocalContentColor.current),
-        modifier
-    )
+  ActivateableStatIcon(
+    OrcaTheme.iconography.forward,
+    contentDescription = "Proceed",
+    isActive,
+    interactiveness,
+    ActivateableStatIconColors(LocalContentColor.current, LocalContentColor.current),
+    modifier
+  )
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/test/ComposeTestRule.extensions.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/test/ComposeTestRule.extensions.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import com.jeanbarrossilva.orca.platform.ui.component.stat.ACTIVATEABLE_STAT_ICON_TAG
 import com.jeanbarrossilva.orca.platform.ui.component.stat.ActivateableStatIconDefaults
 
-/** [SemanticsNodeInteraction] of an [ActivateableStatIconDefaults]. **/
+/** [SemanticsNodeInteraction] of an [ActivateableStatIconDefaults]. */
 internal fun ComposeTestRule.onActivateableStatIcon(): SemanticsNodeInteraction {
-    return onNodeWithTag(ACTIVATEABLE_STAT_ICON_TAG)
+  return onNodeWithTag(ACTIVATEABLE_STAT_ICON_TAG)
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/TimelineTests.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/TimelineTests.kt
@@ -18,66 +18,53 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class TimelineTests {
-    @get:Rule
-    val time4JRule = Time4JTestRule()
+  @get:Rule val time4JRule = Time4JTestRule()
 
-    @get:Rule
-    val composeRule = createComposeRule()
+  @get:Rule val composeRule = createComposeRule()
 
-    @Test
-    fun showsEmptyMessageWhenListLoadableIsEmpty() {
-        composeRule.setContent {
-            OrcaTheme {
-                Timeline(ListLoadable.Empty())
-            }
-        }
-        composeRule.onNodeWithTag(EMPTY_TIMELINE_MESSAGE_TAG).assertIsDisplayed()
+  @Test
+  fun showsEmptyMessageWhenListLoadableIsEmpty() {
+    composeRule.setContent { OrcaTheme { Timeline(ListLoadable.Empty()) } }
+    composeRule.onNodeWithTag(EMPTY_TIMELINE_MESSAGE_TAG).assertIsDisplayed()
+  }
+
+  @Test
+  fun showsDividerWhenHeaderIsNotAddedOnTootPreviewBeforeLastOne() {
+    composeRule.setContent {
+      OrcaTheme { PopulatedTimeline(tootPreviews = TootPreview.samples.take(2)) }
     }
+    composeRule
+      .onNodeWithTag(TIMELINE_TAG)
+      .onChildren()
+      .onFirst()
+      .onSiblings()
+      .filter(hasTestTag(TIMELINE_DIVIDER_TAG))
+      .assertCountEquals(0)
+  }
 
-    @Test
-    fun showsDividerWhenHeaderIsNotAddedOnTootPreviewBeforeLastOne() {
-        composeRule.setContent {
-            OrcaTheme {
-                PopulatedTimeline(tootPreviews = TootPreview.samples.take(2))
-            }
-        }
-        composeRule
-            .onNodeWithTag(TIMELINE_TAG)
-            .onChildren()
-            .onFirst()
-            .onSiblings()
-            .filter(hasTestTag(TIMELINE_DIVIDER_TAG))
-            .assertCountEquals(0)
+  @Test
+  fun showsDividersWhenHeaderIsAddedOnTootPreviewBeforeLastOne() {
+    composeRule.setContent {
+      OrcaTheme { PopulatedTimeline(tootPreviews = TootPreview.samples.take(2)) {} }
     }
+    composeRule
+      .onNodeWithTag(TIMELINE_TAG)
+      .onChildren()[1]
+      .onSiblings()
+      .filter(hasTestTag(TIMELINE_DIVIDER_TAG))
+      .assertCountEquals(1)
+  }
 
-    @Test
-    fun showsDividersWhenHeaderIsAddedOnTootPreviewBeforeLastOne() {
-        composeRule.setContent {
-            OrcaTheme {
-                PopulatedTimeline(tootPreviews = TootPreview.samples.take(2)) {
-                }
-            }
-        }
-        composeRule
-            .onNodeWithTag(TIMELINE_TAG)
-            .onChildren()[1]
-            .onSiblings()
-            .filter(hasTestTag(TIMELINE_DIVIDER_TAG))
-            .assertCountEquals(1)
+  @Test
+  fun doesNotShowDividersOnLastTootPreview() {
+    composeRule.setContent {
+      OrcaTheme { PopulatedTimeline(tootPreviews = TootPreview.samples.take(1)) }
     }
-
-    @Test
-    fun doesNotShowDividersOnLastTootPreview() {
-        composeRule.setContent {
-            OrcaTheme {
-                PopulatedTimeline(tootPreviews = TootPreview.samples.take(1))
-            }
-        }
-        composeRule
-            .onNodeWithTag(TIMELINE_TAG)
-            .onChild()
-            .onSiblings()
-            .filter(hasTestTag(TIMELINE_DIVIDER_TAG))
-            .assertCountEquals(0)
-    }
+    composeRule
+      .onNodeWithTag(TIMELINE_TAG)
+      .onChild()
+      .onSiblings()
+      .filter(hasTestTag(TIMELINE_DIVIDER_TAG))
+      .assertCountEquals(0)
+  }
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/TootPreviewTests.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/TootPreviewTests.kt
@@ -23,186 +23,125 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class TootPreviewTests {
-    @get:Rule
-    val composeRule = createComposeRule()
+  @get:Rule val composeRule = createComposeRule()
 
-    private val sampleTootPreview
-        get() = TootPreview.getSample(
-            Colors.getDefault(InstrumentationRegistry.getInstrumentation().context)
-        )
+  private val sampleTootPreview
+    get() =
+      TootPreview.getSample(Colors.getDefault(InstrumentationRegistry.getInstrumentation().context))
 
-    @Test
-    fun isShownWhenLoading() {
-        composeRule.setContent {
-            OrcaTheme {
-                TootPreview()
-            }
-        }
-        composeRule.onTootPreview().assertIsDisplayed()
+  @Test
+  fun isShownWhenLoading() {
+    composeRule.setContent { OrcaTheme { TootPreview() } }
+    composeRule.onTootPreview().assertIsDisplayed()
+  }
+
+  @Test
+  fun isShownWhenLoaded() {
+    composeRule.setContent { OrcaTheme { TestTootPreview() } }
+    composeRule.onTootPreview().assertIsDisplayed()
+  }
+
+  @Test
+  fun nameIsLoadingWhenLoading() {
+    composeRule.setContent { OrcaTheme { TootPreview() } }
+    composeRule.onTootPreviewName().assertIsLoading()
+  }
+
+  @Test
+  fun nameIsShownWhenLoaded() {
+    composeRule.setContent { OrcaTheme { TestTootPreview() } }
+    composeRule.onTootPreviewName().assertIsNotLoading()
+    composeRule.onTootPreviewName().assertTextEquals(sampleTootPreview.name)
+  }
+
+  @Test
+  fun metadataIsLoadingWhenLoading() {
+    composeRule.setContent { OrcaTheme { TootPreview() } }
+    composeRule.onTootPreviewMetadata().assertIsLoading()
+  }
+
+  @Test
+  fun metadataIsShownWhenLoaded() {
+    val relativeTimeProvider = TestRelativeTimeProvider()
+    composeRule.setContent {
+      OrcaTheme { TestTootPreview(relativeTimeProvider = relativeTimeProvider) }
     }
+    composeRule.onTootPreviewMetadata().assertIsNotLoading()
+    composeRule
+      .onTootPreviewMetadata()
+      .assertTextEquals(sampleTootPreview.getMetadata(relativeTimeProvider))
+  }
 
-    @Test
-    fun isShownWhenLoaded() {
-        composeRule.setContent {
-            OrcaTheme {
-                TestTootPreview()
-            }
-        }
-        composeRule.onTootPreview().assertIsDisplayed()
-    }
+  @Test
+  fun bodyIsLoadingWhenLoading() {
+    composeRule.setContent { OrcaTheme { TootPreview() } }
+    composeRule.onTootPreviewBody().assertIsLoading()
+  }
 
-    @Test
-    fun nameIsLoadingWhenLoading() {
-        composeRule.setContent {
-            OrcaTheme {
-                TootPreview()
-            }
-        }
-        composeRule.onTootPreviewName().assertIsLoading()
-    }
+  @Test
+  fun bodyIsShownWhenLoaded() {
+    composeRule.setContent { OrcaTheme { TestTootPreview() } }
+    composeRule.onTootPreviewBody().assertIsNotLoading()
+    composeRule.onTootPreviewBody().assertTextEquals(sampleTootPreview.text.text)
+  }
 
-    @Test
-    fun nameIsShownWhenLoaded() {
-        composeRule.setContent {
-            OrcaTheme {
-                TestTootPreview()
-            }
-        }
-        composeRule.onTootPreviewName().assertIsNotLoading()
-        composeRule.onTootPreviewName().assertTextEquals(sampleTootPreview.name)
-    }
+  @Test
+  fun commentCountStatIsNonexistentWhenLoading() {
+    composeRule.setContent { OrcaTheme { TootPreview() } }
+    composeRule.onTootPreviewCommentCountStat().assertDoesNotExist()
+  }
 
-    @Test
-    fun metadataIsLoadingWhenLoading() {
-        composeRule.setContent {
-            OrcaTheme {
-                TootPreview()
-            }
-        }
-        composeRule.onTootPreviewMetadata().assertIsLoading()
-    }
+  @Test
+  fun commentCountStatIsShownWhenLoaded() {
+    composeRule.setContent { OrcaTheme { TestTootPreview() } }
+    composeRule.onTootPreviewCommentCountStat().assertIsDisplayed()
+    composeRule
+      .onTootPreviewCommentCountStat()
+      .onStatLabel()
+      .assertTextEquals(sampleTootPreview.formattedCommentCount)
+  }
 
-    @Test
-    fun metadataIsShownWhenLoaded() {
-        val relativeTimeProvider = TestRelativeTimeProvider()
-        composeRule.setContent {
-            OrcaTheme {
-                TestTootPreview(relativeTimeProvider = relativeTimeProvider)
-            }
-        }
-        composeRule.onTootPreviewMetadata().assertIsNotLoading()
-        composeRule.onTootPreviewMetadata().assertTextEquals(
-            sampleTootPreview.getMetadata(relativeTimeProvider)
-        )
-    }
+  @Test
+  fun favoriteCountStatIsNonexistentWhenLoading() {
+    composeRule.setContent { OrcaTheme { TootPreview() } }
+    composeRule.onTootPreviewFavoriteCountStat().assertDoesNotExist()
+  }
 
-    @Test
-    fun bodyIsLoadingWhenLoading() {
-        composeRule.setContent {
-            OrcaTheme {
-                TootPreview()
-            }
-        }
-        composeRule.onTootPreviewBody().assertIsLoading()
-    }
+  @Test
+  fun favoriteCountStatIsShownWhenLoaded() {
+    composeRule.setContent { OrcaTheme { TestTootPreview() } }
+    composeRule.onTootPreviewFavoriteCountStat().assertIsDisplayed()
+    composeRule
+      .onTootPreviewFavoriteCountStat()
+      .onStatLabel()
+      .assertTextEquals(sampleTootPreview.formattedFavoriteCount)
+  }
 
-    @Test
-    fun bodyIsShownWhenLoaded() {
-        composeRule.setContent {
-            OrcaTheme {
-                TestTootPreview()
-            }
-        }
-        composeRule.onTootPreviewBody().assertIsNotLoading()
-        composeRule.onTootPreviewBody().assertTextEquals(sampleTootPreview.text.text)
-    }
+  @Test
+  fun reblogCountStatIsNonexistentWhenLoading() {
+    composeRule.setContent { OrcaTheme { TootPreview() } }
+    composeRule.onTootPreviewReblogCountStat().assertDoesNotExist()
+  }
 
-    @Test
-    fun commentCountStatIsNonexistentWhenLoading() {
-        composeRule.setContent {
-            OrcaTheme {
-                TootPreview()
-            }
-        }
-        composeRule.onTootPreviewCommentCountStat().assertDoesNotExist()
-    }
+  @Test
+  fun reblogCountStatIsShownWhenLoaded() {
+    composeRule.setContent { OrcaTheme { TestTootPreview() } }
+    composeRule.onTootPreviewReblogCountStat().assertIsDisplayed()
+    composeRule
+      .onTootPreviewReblogCountStat()
+      .onStatLabel()
+      .assertTextEquals(sampleTootPreview.formattedReblogCount)
+  }
 
-    @Test
-    fun commentCountStatIsShownWhenLoaded() {
-        composeRule.setContent {
-            OrcaTheme {
-                TestTootPreview()
-            }
-        }
-        composeRule.onTootPreviewCommentCountStat().assertIsDisplayed()
-        composeRule.onTootPreviewCommentCountStat().onStatLabel().assertTextEquals(
-            sampleTootPreview.formattedCommentCount
-        )
-    }
+  @Test
+  fun shareActionIsNonexistentWhenLoading() {
+    composeRule.setContent { OrcaTheme { TootPreview() } }
+    composeRule.onTootPreviewShareAction().assertDoesNotExist()
+  }
 
-    @Test
-    fun favoriteCountStatIsNonexistentWhenLoading() {
-        composeRule.setContent {
-            OrcaTheme {
-                TootPreview()
-            }
-        }
-        composeRule.onTootPreviewFavoriteCountStat().assertDoesNotExist()
-    }
-
-    @Test
-    fun favoriteCountStatIsShownWhenLoaded() {
-        composeRule.setContent {
-            OrcaTheme {
-                TestTootPreview()
-            }
-        }
-        composeRule.onTootPreviewFavoriteCountStat().assertIsDisplayed()
-        composeRule.onTootPreviewFavoriteCountStat().onStatLabel().assertTextEquals(
-            sampleTootPreview.formattedFavoriteCount
-        )
-    }
-
-    @Test
-    fun reblogCountStatIsNonexistentWhenLoading() {
-        composeRule.setContent {
-            OrcaTheme {
-                TootPreview()
-            }
-        }
-        composeRule.onTootPreviewReblogCountStat().assertDoesNotExist()
-    }
-
-    @Test
-    fun reblogCountStatIsShownWhenLoaded() {
-        composeRule.setContent {
-            OrcaTheme {
-                TestTootPreview()
-            }
-        }
-        composeRule.onTootPreviewReblogCountStat().assertIsDisplayed()
-        composeRule.onTootPreviewReblogCountStat().onStatLabel().assertTextEquals(
-            sampleTootPreview.formattedReblogCount
-        )
-    }
-
-    @Test
-    fun shareActionIsNonexistentWhenLoading() {
-        composeRule.setContent {
-            OrcaTheme {
-                TootPreview()
-            }
-        }
-        composeRule.onTootPreviewShareAction().assertDoesNotExist()
-    }
-
-    @Test
-    fun shareActionIsShownWhenLoaded() {
-        composeRule.setContent {
-            OrcaTheme {
-                TestTootPreview()
-            }
-        }
-        composeRule.onTootPreviewShareAction().assertIsDisplayed()
-    }
+  @Test
+  fun shareActionIsShownWhenLoaded() {
+    composeRule.setContent { OrcaTheme { TestTootPreview() } }
+    composeRule.onTootPreviewShareAction().assertIsDisplayed()
+  }
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/headline/HeadlineCardTests.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/headline/HeadlineCardTests.kt
@@ -9,18 +9,13 @@ import org.junit.Rule
 import org.junit.Test
 
 internal class HeadlineCardTests {
-    @get:Rule
-    val composeRule = createComposeRule()
+  @get:Rule val composeRule = createComposeRule()
 
-    @Test
-    fun runsCallbackWhenClicked() {
-        var hasCallbackBeenRun = false
-        composeRule.setContent {
-            OrcaTheme {
-                HeadlineCard(onClick = { hasCallbackBeenRun = true })
-            }
-        }
-        composeRule.onHeadlineCard().performClick()
-        assertTrue(hasCallbackBeenRun)
-    }
+  @Test
+  fun runsCallbackWhenClicked() {
+    var hasCallbackBeenRun = false
+    composeRule.setContent { OrcaTheme { HeadlineCard(onClick = { hasCallbackBeenRun = true }) } }
+    composeRule.onHeadlineCard().performClick()
+    assertTrue(hasCallbackBeenRun)
+  }
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/test/ComposeTestRule.extensions.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/test/ComposeTestRule.extensions.kt
@@ -12,37 +12,37 @@ import com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.TOOT_PREVIEW
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.TootPreview
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.stat.TOOT_PREVIEW_FAVORITE_STAT_TAG
 
-/** [SemanticsNodeInteraction] of [TootPreview]'s body node. **/
+/** [SemanticsNodeInteraction] of [TootPreview]'s body node. */
 internal fun ComposeTestRule.onTootPreviewBody(): SemanticsNodeInteraction {
-    return onNodeWithTag(TOOT_PREVIEW_BODY_TAG, useUnmergedTree = true)
+  return onNodeWithTag(TOOT_PREVIEW_BODY_TAG, useUnmergedTree = true)
 }
 
-/** [SemanticsNodeInteraction] of [TootPreview]'s comment count stat node. **/
+/** [SemanticsNodeInteraction] of [TootPreview]'s comment count stat node. */
 internal fun ComposeTestRule.onTootPreviewCommentCountStat(): SemanticsNodeInteraction {
-    return onNodeWithTag(TOOT_PREVIEW_COMMENT_COUNT_STAT_TAG, useUnmergedTree = true)
+  return onNodeWithTag(TOOT_PREVIEW_COMMENT_COUNT_STAT_TAG, useUnmergedTree = true)
 }
 
-/** [SemanticsNodeInteraction] of [TootPreview]'s favorite count stat node. **/
+/** [SemanticsNodeInteraction] of [TootPreview]'s favorite count stat node. */
 internal fun ComposeTestRule.onTootPreviewFavoriteCountStat(): SemanticsNodeInteraction {
-    return onNodeWithTag(TOOT_PREVIEW_FAVORITE_STAT_TAG, useUnmergedTree = true)
+  return onNodeWithTag(TOOT_PREVIEW_FAVORITE_STAT_TAG, useUnmergedTree = true)
 }
 
-/** [SemanticsNodeInteraction] of [TootPreview]'s metadata node. **/
+/** [SemanticsNodeInteraction] of [TootPreview]'s metadata node. */
 internal fun ComposeTestRule.onTootPreviewMetadata(): SemanticsNodeInteraction {
-    return onNodeWithTag(TOOT_PREVIEW_METADATA_TAG, useUnmergedTree = true)
+  return onNodeWithTag(TOOT_PREVIEW_METADATA_TAG, useUnmergedTree = true)
 }
 
-/** [SemanticsNodeInteraction] of [TootPreview]'s name node. **/
+/** [SemanticsNodeInteraction] of [TootPreview]'s name node. */
 internal fun ComposeTestRule.onTootPreviewName(): SemanticsNodeInteraction {
-    return onNodeWithTag(TOOT_PREVIEW_NAME_TAG, useUnmergedTree = true)
+  return onNodeWithTag(TOOT_PREVIEW_NAME_TAG, useUnmergedTree = true)
 }
 
-/** [SemanticsNodeInteraction] of [TootPreview]'s reblog count stat node. **/
+/** [SemanticsNodeInteraction] of [TootPreview]'s reblog count stat node. */
 internal fun ComposeTestRule.onTootPreviewReblogCountStat(): SemanticsNodeInteraction {
-    return onNodeWithTag(TOOT_PREVIEW_REBLOG_COUNT_STAT_TAG, useUnmergedTree = true)
+  return onNodeWithTag(TOOT_PREVIEW_REBLOG_COUNT_STAT_TAG, useUnmergedTree = true)
 }
 
-/** [SemanticsNodeInteraction] of [TootPreview]'s share action node. **/
+/** [SemanticsNodeInteraction] of [TootPreview]'s share action node. */
 internal fun ComposeTestRule.onTootPreviewShareAction(): SemanticsNodeInteraction {
-    return onNodeWithTag(TOOT_PREVIEW_SHARE_ACTION_TAG, useUnmergedTree = true)
+  return onNodeWithTag(TOOT_PREVIEW_SHARE_ACTION_TAG, useUnmergedTree = true)
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/test/SemanticsNodeInteraction.extensions.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/test/SemanticsNodeInteraction.extensions.kt
@@ -3,7 +3,7 @@ package com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.test
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.onChildAt
 
-/** [SemanticsNodeInteraction] of this [Stat]'s label node. **/
+/** [SemanticsNodeInteraction] of this [Stat]'s label node. */
 internal fun SemanticsNodeInteraction.onStatLabel(): SemanticsNodeInteraction {
-    return onChildAt(1)
+  return onChildAt(1)
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/test/TestTootPreview.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/test/TestTootPreview.kt
@@ -10,18 +10,18 @@ import com.jeanbarrossilva.orca.std.imageloader.test.TestImageLoader
 @Composable
 @Suppress("TestFunctionName")
 internal fun TestTootPreview(
-    modifier: Modifier = Modifier,
-    relativeTimeProvider: RelativeTimeProvider = rememberTestRelativeTimeProvider()
+  modifier: Modifier = Modifier,
+  relativeTimeProvider: RelativeTimeProvider = rememberTestRelativeTimeProvider()
 ) {
-    TootPreview(
-        TootPreview.sample,
-        onHighlightClick = { },
-        onFavorite = { },
-        onReblog = { },
-        onShare = { },
-        onClick = { },
-        modifier,
-        TestImageLoader,
-        relativeTimeProvider
-    )
+  TootPreview(
+    TootPreview.sample,
+    onHighlightClick = {},
+    onFavorite = {},
+    onReblog = {},
+    onShare = {},
+    onClick = {},
+    modifier,
+    TestImageLoader,
+    relativeTimeProvider
+  )
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/time/test/TestRelativeTimeProvider.extensions.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/time/test/TestRelativeTimeProvider.extensions.kt
@@ -3,8 +3,8 @@ package com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.time.test
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 
-/** [Remember][remember]s a [TestRelativeTimeProvider]. **/
+/** [Remember][remember]s a [TestRelativeTimeProvider]. */
 @Composable
 internal fun rememberTestRelativeTimeProvider(): TestRelativeTimeProvider {
-    return remember(::TestRelativeTimeProvider)
+  return remember(::TestRelativeTimeProvider)
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/time/test/TestRelativeTimeProvider.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/time/test/TestRelativeTimeProvider.kt
@@ -5,9 +5,9 @@ import java.time.ZonedDateTime
 
 /**
  * [RelativeTimeProvider] that provides the [String] representation of the given [ZonedDateTime].
- **/
+ */
 internal class TestRelativeTimeProvider : RelativeTimeProvider() {
-    override fun provide(dateTime: ZonedDateTime): String {
-        return dateTime.toString()
-    }
+  override fun provide(dateTime: ZonedDateTime): String {
+    return dateTime.toString()
+  }
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/core/ActivityStarterTests.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/core/ActivityStarterTests.kt
@@ -7,13 +7,13 @@ import io.mockk.verify
 import org.junit.Test
 
 internal class ActivityStarterTests {
-    class TestActivity : Activity()
+  class TestActivity : Activity()
 
-    @Test
-    fun startsActivity() {
-        val context = InstrumentationRegistry.getInstrumentation().context
-        val spiedContext = spyk(context)
-        spiedContext.on<TestActivity>().asNewTask().start()
-        verify { spiedContext.startActivity(any()) }
-    }
+  @Test
+  fun startsActivity() {
+    val context = InstrumentationRegistry.getInstrumentation().context
+    val spiedContext = spyk(context)
+    spiedContext.on<TestActivity>().asNewTask().start()
+    verify { spiedContext.startActivity(any()) }
+  }
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/core/lifecycle/LifecycleActivityTests.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/core/lifecycle/LifecycleActivityTests.kt
@@ -8,77 +8,75 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class LifecycleActivityTests {
-    @Test
-    fun completeLifecycleStateIsCreatedWhenActivityIsCreated() {
-        launchActivity<CompleteLifecycleActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                try { activity.onCreate(null, null) } catch (_: IllegalStateException) { }
-                assertEquals(CompleteLifecycleState.CREATED, activity.completeLifecycleState)
-            }
-        }
+  @Test
+  fun completeLifecycleStateIsCreatedWhenActivityIsCreated() {
+    launchActivity<CompleteLifecycleActivity>().use { scenario ->
+      scenario.onActivity { activity ->
+        try {
+          activity.onCreate(null, null)
+        } catch (_: IllegalStateException) {}
+        assertEquals(CompleteLifecycleState.CREATED, activity.completeLifecycleState)
+      }
     }
+  }
 
-    @Test
-    fun completeLifecycleStateIsStartedWhenActivityIsStarted() {
-        launchActivity<CompleteLifecycleActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                activity.callOnStart()
-                assertEquals(CompleteLifecycleState.STARTED, activity.completeLifecycleState)
-            }
-        }
+  @Test
+  fun completeLifecycleStateIsStartedWhenActivityIsStarted() {
+    launchActivity<CompleteLifecycleActivity>().use { scenario ->
+      scenario.onActivity { activity ->
+        activity.callOnStart()
+        assertEquals(CompleteLifecycleState.STARTED, activity.completeLifecycleState)
+      }
     }
+  }
 
-    @Test
-    fun completeLifecycleStateIsResumedWhenActivityIsResumed() {
-        launchActivity<CompleteLifecycleActivity>().use { scenario ->
-            scenario.moveToState(Lifecycle.State.RESUMED)
-            scenario.onActivity { activity ->
-                assertEquals(CompleteLifecycleState.RESUMED, activity.completeLifecycleState)
-            }
-        }
+  @Test
+  fun completeLifecycleStateIsResumedWhenActivityIsResumed() {
+    launchActivity<CompleteLifecycleActivity>().use { scenario ->
+      scenario.moveToState(Lifecycle.State.RESUMED)
+      scenario.onActivity { activity ->
+        assertEquals(CompleteLifecycleState.RESUMED, activity.completeLifecycleState)
+      }
     }
+  }
 
-    @Test
-    fun completeLifecycleStateIsPausedWhenActivityIsPaused() {
-        launchActivity<CompleteLifecycleActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                activity.callOnPause()
-                assertEquals(CompleteLifecycleState.PAUSED, activity.completeLifecycleState)
-            }
-        }
+  @Test
+  fun completeLifecycleStateIsPausedWhenActivityIsPaused() {
+    launchActivity<CompleteLifecycleActivity>().use { scenario ->
+      scenario.onActivity { activity ->
+        activity.callOnPause()
+        assertEquals(CompleteLifecycleState.PAUSED, activity.completeLifecycleState)
+      }
     }
+  }
 
-    @Test
-    fun completeLifecycleStateIsStoppedWhenActivityIsStopped() {
-        launchActivity<CompleteLifecycleActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                activity.callOnStop()
-                assertEquals(CompleteLifecycleState.STOPPED, activity.completeLifecycleState)
-            }
-        }
+  @Test
+  fun completeLifecycleStateIsStoppedWhenActivityIsStopped() {
+    launchActivity<CompleteLifecycleActivity>().use { scenario ->
+      scenario.onActivity { activity ->
+        activity.callOnStop()
+        assertEquals(CompleteLifecycleState.STOPPED, activity.completeLifecycleState)
+      }
     }
+  }
 
-    @Test
-    fun completeLifecycleStateIsDestroyedWhenActivityIsDestroyed() {
-        var state: CompleteLifecycleState? = null
-        launchActivity<CompleteLifecycleActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                activity.doOnDestroy {
-                    state = completeLifecycleState
-                }
-            }
-            scenario.moveToState(Lifecycle.State.DESTROYED)
-        }
-        assertEquals(CompleteLifecycleState.DESTROYED, state)
+  @Test
+  fun completeLifecycleStateIsDestroyedWhenActivityIsDestroyed() {
+    var state: CompleteLifecycleState? = null
+    launchActivity<CompleteLifecycleActivity>().use { scenario ->
+      scenario.onActivity { activity -> activity.doOnDestroy { state = completeLifecycleState } }
+      scenario.moveToState(Lifecycle.State.DESTROYED)
     }
+    assertEquals(CompleteLifecycleState.DESTROYED, state)
+  }
 
-    @Test
-    fun destroysActivityWhenItIsFinished() {
-        launchActivity<CompleteLifecycleActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                activity.finish()
-                assertEquals(CompleteLifecycleState.DESTROYED, activity.completeLifecycleState)
-            }
-        }
+  @Test
+  fun destroysActivityWhenItIsFinished() {
+    launchActivity<CompleteLifecycleActivity>().use { scenario ->
+      scenario.onActivity { activity ->
+        activity.finish()
+        assertEquals(CompleteLifecycleState.DESTROYED, activity.completeLifecycleState)
+      }
     }
+  }
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/core/lifecycle/test/Activity.extensions.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/core/lifecycle/test/Activity.extensions.kt
@@ -8,34 +8,27 @@ import android.os.Bundle
  * Runs the [action] when this [Activity] is destroyed.
  *
  * @param action Operation to be performed when this [Activity] is destroyed.
- **/
+ */
 internal fun <T : Activity> T.doOnDestroy(action: T.() -> Unit) {
-    registerActivityLifecycleCallbacks(
-        object : Application.ActivityLifecycleCallbacks {
-            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-            }
+  registerActivityLifecycleCallbacks(
+    object : Application.ActivityLifecycleCallbacks {
+      override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
 
-            override fun onActivityStarted(activity: Activity) {
-            }
+      override fun onActivityStarted(activity: Activity) {}
 
-            override fun onActivityResumed(activity: Activity) {
-            }
+      override fun onActivityResumed(activity: Activity) {}
 
-            override fun onActivityPaused(activity: Activity) {
-            }
+      override fun onActivityPaused(activity: Activity) {}
 
-            override fun onActivityStopped(activity: Activity) {
-            }
+      override fun onActivityStopped(activity: Activity) {}
 
-            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
-            }
+      override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
 
-            override fun onActivityDestroyed(activity: Activity) {
-                @Suppress("UNCHECKED_CAST")
-                (activity as T).action()
+      override fun onActivityDestroyed(activity: Activity) {
+        @Suppress("UNCHECKED_CAST") (activity as T).action()
 
-                unregisterActivityLifecycleCallbacks(this)
-            }
-        }
-    )
+        unregisterActivityLifecycleCallbacks(this)
+      }
+    }
+  )
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/NavigationActivityTests.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/NavigationActivityTests.kt
@@ -9,78 +9,72 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 internal class NavigationActivityTests {
-    class NoFragmentContainerViewActivity : NavigationActivity()
+  class NoFragmentContainerViewActivity : NavigationActivity()
 
-    class UnidentifiedFragmentContainerViewActivity : NavigationActivity() {
-        var view: FragmentContainerView? = null
+  class UnidentifiedFragmentContainerViewActivity : NavigationActivity() {
+    var view: FragmentContainerView? = null
 
-        override fun onCreate(savedInstanceState: Bundle?) {
-            super.onCreate(savedInstanceState)
-            view = FragmentContainerView(this)
-            setContentView(view)
-        }
-
-        override fun onDestroy() {
-            super.onDestroy()
-            view = null
-        }
+    override fun onCreate(savedInstanceState: Bundle?) {
+      super.onCreate(savedInstanceState)
+      view = FragmentContainerView(this)
+      setContentView(view)
     }
 
-    class EphemeralFragmentContainerViewActivity : NavigationActivity() {
-        private var view: FrameLayout? = null
+    override fun onDestroy() {
+      super.onDestroy()
+      view = null
+    }
+  }
 
-        override fun onCreate(savedInstanceState: Bundle?) {
-            super.onCreate(savedInstanceState)
-            view = FrameLayout(this).apply { addView(FragmentContainerView(context)) }
-            setContentView(view)
-            navigator
-        }
+  class EphemeralFragmentContainerViewActivity : NavigationActivity() {
+    private var view: FrameLayout? = null
 
-        override fun onStart() {
-            super.onStart()
-            view?.removeAllViews()
-        }
-
-        override fun onDestroy() {
-            super.onDestroy()
-            view = null
-        }
+    override fun onCreate(savedInstanceState: Bundle?) {
+      super.onCreate(savedInstanceState)
+      view = FrameLayout(this).apply { addView(FragmentContainerView(context)) }
+      setContentView(view)
+      navigator
     }
 
-    @Test(expected = IllegalStateException::class)
-    fun throwsWhenNavigatorGetterIsCalledOnAnActivityWithoutFragmentContainerView() {
-        launchActivity<NoFragmentContainerViewActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                activity.navigator
-            }
-        }
+    override fun onStart() {
+      super.onStart()
+      view?.removeAllViews()
     }
 
-    @Test(expected = IllegalStateException::class)
-    fun throwsWhenNavigatorGetterIsCalledOnAnActivityWithFragmentContainerViewAndAgainWithoutIt() {
-        launchActivity<EphemeralFragmentContainerViewActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                activity.navigator
-            }
-        }
+    override fun onDestroy() {
+      super.onDestroy()
+      view = null
     }
+  }
 
-    @Test
-    fun identifiesFragmentContainerViewIfNotIdentifiedWhenNavigatorGetterIsCalled() {
-        launchActivity<UnidentifiedFragmentContainerViewActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                activity.navigator
-                assertNotEquals(View.NO_ID, activity.view?.id)
-            }
-        }
+  @Test(expected = IllegalStateException::class)
+  fun throwsWhenNavigatorGetterIsCalledOnAnActivityWithoutFragmentContainerView() {
+    launchActivity<NoFragmentContainerViewActivity>().use { scenario ->
+      scenario.onActivity { activity -> activity.navigator }
     }
+  }
 
-    @Test
-    fun returnsNavigatorWhenItsGetterIsCalledOnAnActivityWithFragmentContainerView() {
-        launchActivity<UnidentifiedFragmentContainerViewActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                activity.navigator
-            }
-        }
+  @Test(expected = IllegalStateException::class)
+  fun throwsWhenNavigatorGetterIsCalledOnAnActivityWithFragmentContainerViewAndAgainWithoutIt() {
+    launchActivity<EphemeralFragmentContainerViewActivity>().use { scenario ->
+      scenario.onActivity { activity -> activity.navigator }
     }
+  }
+
+  @Test
+  fun identifiesFragmentContainerViewIfNotIdentifiedWhenNavigatorGetterIsCalled() {
+    launchActivity<UnidentifiedFragmentContainerViewActivity>().use { scenario ->
+      scenario.onActivity { activity ->
+        activity.navigator
+        assertNotEquals(View.NO_ID, activity.view?.id)
+      }
+    }
+  }
+
+  @Test
+  fun returnsNavigatorWhenItsGetterIsCalledOnAnActivityWithFragmentContainerView() {
+    launchActivity<UnidentifiedFragmentContainerViewActivity>().use { scenario ->
+      scenario.onActivity { activity -> activity.navigator }
+    }
+  }
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/NavigatorTests.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/NavigatorTests.kt
@@ -13,103 +13,99 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class NavigatorTests {
-    class TestNavigationActivity : NavigationActivity() {
-        override fun onCreate(savedInstanceState: Bundle?) {
-            super.onCreate(savedInstanceState)
-            setContentView(FragmentContainerView(this))
-        }
+  class TestNavigationActivity : NavigationActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+      super.onCreate(savedInstanceState)
+      setContentView(FragmentContainerView(this))
     }
+  }
 
-    class FirstDestinationFragment : Fragment() {
-        companion object {
-            const val ROUTE = "first-destination"
-        }
+  class FirstDestinationFragment : Fragment() {
+    companion object {
+      const val ROUTE = "first-destination"
     }
+  }
 
-    class SecondDestinationFragment : Fragment() {
-        companion object {
-            const val ROUTE = "second-destination"
-        }
+  class SecondDestinationFragment : Fragment() {
+    companion object {
+      const val ROUTE = "second-destination"
     }
+  }
 
-    @Test
-    fun navigatesSuddenly() {
-        launchActivity<TestNavigationActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                activity.navigator.navigate(suddenly()) {
-                    to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
-                }
-                assertIsAtFragment(activity, FirstDestinationFragment.ROUTE)
-            }
+  @Test
+  fun navigatesSuddenly() {
+    launchActivity<TestNavigationActivity>().use { scenario ->
+      scenario.onActivity { activity ->
+        activity.navigator.navigate(suddenly()) {
+          to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
         }
+        assertIsAtFragment(activity, FirstDestinationFragment.ROUTE)
+      }
     }
+  }
 
-    @Test
-    fun navigatesWithOpeningTransition() {
-        launchActivity<TestNavigationActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                activity.navigator.navigate(opening()) {
-                    to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
-                }
-                assertIsAtFragment(activity, FirstDestinationFragment.ROUTE)
-            }
+  @Test
+  fun navigatesWithOpeningTransition() {
+    launchActivity<TestNavigationActivity>().use { scenario ->
+      scenario.onActivity { activity ->
+        activity.navigator.navigate(opening()) {
+          to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
         }
+        assertIsAtFragment(activity, FirstDestinationFragment.ROUTE)
+      }
     }
+  }
 
-    @Test
-    fun navigatesWithClosingTransition() {
-        launchActivity<TestNavigationActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                activity.navigator.navigate(closing()) {
-                    to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
-                }
-                assertIsAtFragment(activity, FirstDestinationFragment.ROUTE)
-            }
+  @Test
+  fun navigatesWithClosingTransition() {
+    launchActivity<TestNavigationActivity>().use { scenario ->
+      scenario.onActivity { activity ->
+        activity.navigator.navigate(closing()) {
+          to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
         }
+        assertIsAtFragment(activity, FirstDestinationFragment.ROUTE)
+      }
     }
+  }
 
-    @Test
-    fun navigatesTwiceWhenDuplicationIsAllowed() {
-        launchActivity<TestNavigationActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                repeat(2) {
-                    activity.navigator.navigate(suddenly()) {
-                        to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
-                    }
-                }
-                assertEquals(2, activity.supportFragmentManager.fragments.size)
-            }
+  @Test
+  fun navigatesTwiceWhenDuplicationIsAllowed() {
+    launchActivity<TestNavigationActivity>().use { scenario ->
+      scenario.onActivity { activity ->
+        repeat(2) {
+          activity.navigator.navigate(suddenly()) {
+            to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
+          }
         }
+        assertEquals(2, activity.supportFragmentManager.fragments.size)
+      }
     }
+  }
 
-    @Test
-    fun navigatesOnceWhenDuplicationIsDisallowed() {
-        launchActivity<TestNavigationActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                repeat(2) {
-                    activity.navigator.navigate(suddenly(), disallowingDuplication()) {
-                        to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
-                    }
-                }
-                assertEquals(1, activity.supportFragmentManager.fragments.size)
-            }
+  @Test
+  fun navigatesOnceWhenDuplicationIsDisallowed() {
+    launchActivity<TestNavigationActivity>().use { scenario ->
+      scenario.onActivity { activity ->
+        repeat(2) {
+          activity.navigator.navigate(suddenly(), disallowingDuplication()) {
+            to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
+          }
         }
+        assertEquals(1, activity.supportFragmentManager.fragments.size)
+      }
     }
+  }
 
-    @Test
-    fun navigatesSequentially() {
-        launchActivity<TestNavigationActivity>().use { scenario ->
-            scenario.onActivity { activity ->
-                with(activity.navigator) {
-                    navigate(suddenly()) {
-                        to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment)
-                    }
-                    navigate(suddenly()) {
-                        to(SecondDestinationFragment.ROUTE, ::SecondDestinationFragment)
-                    }
-                }
-                assertIsAtFragment(activity, SecondDestinationFragment.ROUTE)
-            }
+  @Test
+  fun navigatesSequentially() {
+    launchActivity<TestNavigationActivity>().use { scenario ->
+      scenario.onActivity { activity ->
+        with(activity.navigator) {
+          navigate(suddenly()) { to(FirstDestinationFragment.ROUTE, ::FirstDestinationFragment) }
+          navigate(suddenly()) { to(SecondDestinationFragment.ROUTE, ::SecondDestinationFragment) }
         }
+        assertIsAtFragment(activity, SecondDestinationFragment.ROUTE)
+      }
     }
+  }
 }

--- a/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/ViewExtensionsTests.kt
+++ b/platform/ui/src/androidTest/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/ViewExtensionsTests.kt
@@ -13,54 +13,54 @@ import org.junit.Assert.assertSame
 import org.junit.Test
 
 internal class ViewExtensionsTests {
-    private val context
-        get() = InstrumentationRegistry.getInstrumentation().context
+  private val context
+    get() = InstrumentationRegistry.getInstrumentation().context
 
-    @Test
-    fun identifiesUnidentifiedView() {
-        val view = View(context).apply(View::identify)
-        assertNotEquals(View.NO_ID, view.id)
-    }
+  @Test
+  fun identifiesUnidentifiedView() {
+    val view = View(context).apply(View::identify)
+    assertNotEquals(View.NO_ID, view.id)
+  }
 
-    @Test
-    fun doesNotIdentifyIdentifiedView() {
-        val id = View.generateViewId()
-        val view = View(context).apply { this.id = id }.also(View::identify)
-        assertEquals(id, view.id)
-    }
+  @Test
+  fun doesNotIdentifyIdentifiedView() {
+    val id = View.generateViewId()
+    val view = View(context).apply { this.id = id }.also(View::identify)
+    assertEquals(id, view.id)
+  }
 
-    @Test
-    fun findsViewWhenSearchingForItFromItselfInclusively() {
-        val view = LinearLayout(context).apply {
-            addView(LinearLayout(context))
-            addView(TextView(context))
+  @Test
+  fun findsViewWhenSearchingForItFromItselfInclusively() {
+    val view =
+      LinearLayout(context).apply {
+        addView(LinearLayout(context))
+        addView(TextView(context))
+      }
+    assertSame(view, view.get<LinearLayout>())
+  }
+
+  @Test
+  fun doesNotFindViewWhenSearchingForItFromItselfExclusively() {
+    val view =
+      LinearLayout(context).apply {
+        addView(LinearLayout(context))
+        addView(ImageView(context))
+      }
+    assertNotSame(view, view.get<LinearLayout>(isInclusive = false))
+  }
+
+  @Test
+  fun findsNestedView() {
+    val view = TextView(context).apply { text = "🥸" }
+    assertSame(
+      view,
+      FrameLayout(context)
+        .apply {
+          addView(
+            LinearLayout(context).apply { addView(FrameLayout(context).apply { addView(view) }) }
+          )
         }
-        assertSame(view, view.get<LinearLayout>())
-    }
-
-    @Test
-    fun doesNotFindViewWhenSearchingForItFromItselfExclusively() {
-        val view = LinearLayout(context).apply {
-            addView(LinearLayout(context))
-            addView(ImageView(context))
-        }
-        assertNotSame(view, view.get<LinearLayout>(isInclusive = false))
-    }
-
-    @Test
-    fun findsNestedView() {
-        val view = TextView(context).apply { text = "🥸" }
-        assertSame(
-            view,
-            FrameLayout(context)
-                .apply {
-                    addView(
-                        LinearLayout(context).apply {
-                            addView(FrameLayout(context).apply { addView(view) })
-                        }
-                    )
-                }
-                .get<TextView>()
-        )
-    }
+        .get<TextView>()
+    )
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/AccountFormatter.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/AccountFormatter.kt
@@ -2,10 +2,10 @@ package com.jeanbarrossilva.orca.platform.ui
 
 import com.jeanbarrossilva.orca.core.feed.profile.account.Account
 
-/** Deals with [Account]-related formatting. **/
+/** Deals with [Account]-related formatting. */
 object AccountFormatter {
-    /** Formats the [account]'s [username][Account.username] so that it is displayable. **/
-    fun username(account: Account): String {
-        return "@${account.username}"
-    }
+  /** Formats the [account]'s [username][Account.username] so that it is displayable. */
+  fun username(account: Account): String {
+    return "@${account.username}"
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/Samples.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/Samples.kt
@@ -3,8 +3,8 @@ package com.jeanbarrossilva.orca.platform.ui
 import java.net.URL
 
 internal object Samples {
-    const val NAME = "Jean Silva"
+  const val NAME = "Jean Silva"
 
-    val avatarURL =
-        URL("https://en.gravatar.com/userimage/153558542/08942ba9443ce68bf66345a2e6db656e.png")
+  val avatarURL =
+    URL("https://en.gravatar.com/userimage/153558542/08942ba9443ce68bf66345a2e6db656e.png")
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/Avatar.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/Avatar.kt
@@ -23,105 +23,83 @@ private val smallSize = 42.dp
 private val largeSize = 128.dp
 
 private val smallShape
-    @Composable get() = OrcaTheme.shapes.small
+  @Composable get() = OrcaTheme.shapes.small
 private val largeShape
-    @Composable get() = OrcaTheme.shapes.large
+  @Composable get() = OrcaTheme.shapes.large
 
 data class Avatar(val name: String, val url: URL) : Serializable {
-    companion object {
-        val sample = Avatar(Samples.NAME, Samples.avatarURL)
-    }
+  companion object {
+    val sample = Avatar(Samples.NAME, Samples.avatarURL)
+  }
 }
 
 @Composable
 fun SmallAvatar(modifier: Modifier = Modifier) {
-    Placeholder(
-        modifier
-            .requiredSize(smallSize)
-            .testTag(AVATAR_TAG),
-        shape = smallShape
-    )
+  Placeholder(modifier.requiredSize(smallSize).testTag(AVATAR_TAG), shape = smallShape)
 }
 
 @Composable
 fun SmallAvatar(
-    name: String,
-    url: URL,
-    modifier: Modifier = Modifier,
-    imageLoader: ImageLoader = rememberImageLoader()
+  name: String,
+  url: URL,
+  modifier: Modifier = Modifier,
+  imageLoader: ImageLoader = rememberImageLoader()
 ) {
-    Image(
-        url,
-        contentDescriptionFor(name),
-        modifier
-            .requiredSize(smallSize)
-            .testTag(AVATAR_TAG),
-        imageLoader,
-        smallShape
-    )
+  Image(
+    url,
+    contentDescriptionFor(name),
+    modifier.requiredSize(smallSize).testTag(AVATAR_TAG),
+    imageLoader,
+    smallShape
+  )
 }
 
 @Composable
 fun LargeAvatar(modifier: Modifier = Modifier) {
-    Placeholder(
-        modifier
-            .requiredSize(largeSize)
-            .testTag(AVATAR_TAG),
-        shape = largeShape
-    )
+  Placeholder(modifier.requiredSize(largeSize).testTag(AVATAR_TAG), shape = largeShape)
 }
 
 @Composable
 fun LargeAvatar(
-    name: String,
-    url: URL,
-    modifier: Modifier = Modifier,
-    imageLoader: ImageLoader = rememberImageLoader()
+  name: String,
+  url: URL,
+  modifier: Modifier = Modifier,
+  imageLoader: ImageLoader = rememberImageLoader()
 ) {
-    Image(
-        url,
-        contentDescriptionFor(name),
-        modifier
-            .requiredSize(largeSize)
-            .testTag(AVATAR_TAG),
-        imageLoader,
-        largeShape
-    )
+  Image(
+    url,
+    contentDescriptionFor(name),
+    modifier.requiredSize(largeSize).testTag(AVATAR_TAG),
+    imageLoader,
+    largeShape
+  )
 }
 
 @Composable
 private fun contentDescriptionFor(name: String): String {
-    return stringResource(R.string.platform_ui_avatar, name)
+  return stringResource(R.string.platform_ui_avatar, name)
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadingLargeAvatarPreview() {
-    OrcaTheme {
-        LargeAvatar()
-    }
+  OrcaTheme { LargeAvatar() }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadedLargeAvatarPreview() {
-    OrcaTheme {
-        LargeAvatar(Avatar.sample.name, Avatar.sample.url)
-    }
+  OrcaTheme { LargeAvatar(Avatar.sample.name, Avatar.sample.url) }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadingSmallAvatarPreview() {
-    OrcaTheme {
-        SmallAvatar()
-    }
+  OrcaTheme { SmallAvatar() }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadedSmallAvatarPreview() {
-    OrcaTheme {
-        SmallAvatar(Avatar.sample.name, Avatar.sample.url)
-    }
+  OrcaTheme { SmallAvatar(Avatar.sample.name, Avatar.sample.url) }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/stat/ActivateableStatIconDefaults.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/stat/ActivateableStatIconDefaults.kt
@@ -26,144 +26,141 @@ import androidx.compose.ui.unit.dp
 import com.jeanbarrossilva.orca.platform.theme.MultiThemePreview
 import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
 
-/** Tag for identifying an [ActivateableStatIconDefaults] for testing purposes. **/
+/** Tag for identifying an [ActivateableStatIconDefaults] for testing purposes. */
 const val ACTIVATEABLE_STAT_ICON_TAG = "activateable-stat-icon"
 
-/** Default values of an [ActivateableStatIconDefaults]. **/
+/** Default values of an [ActivateableStatIconDefaults]. */
 internal object ActivateableStatIconDefaults {
-    /** Default size of an [ActivateableStatIconDefaults]. **/
-    val Size = 18.dp
+  /** Default size of an [ActivateableStatIconDefaults]. */
+  val Size = 18.dp
 }
 
-/** Determines whether a [ActivateableStatIconDefaults] is interactive. **/
+/** Determines whether a [ActivateableStatIconDefaults] is interactive. */
 sealed class ActivateableStatIconInteractiveness {
-    /** Mode of non-interactivity. **/
-    object Still : ActivateableStatIconInteractiveness() {
-        override fun onInteraction(isActive: Boolean) {
-        }
-    }
+  /** Mode of non-interactivity. */
+  object Still : ActivateableStatIconInteractiveness() {
+    override fun onInteraction(isActive: Boolean) {}
+  }
 
-    /**
-     * Mode of interactivity in which the [ActivateableStatIconDefaults] can be toggled.
-     *
-     * @param onInteraction Callback run whenever it's clicked, signalling a request for the state this
-     * [ActivateableStatIconDefaults] represents to be switched.
-     **/
-    class Interactive(private val onInteraction: (isActive: Boolean) -> Unit) :
-        ActivateableStatIconInteractiveness() {
-        override fun onInteraction(isActive: Boolean) {
-            onInteraction.invoke(isActive)
-        }
+  /**
+   * Mode of interactivity in which the [ActivateableStatIconDefaults] can be toggled.
+   *
+   * @param onInteraction Callback run whenever it's clicked, signalling a request for the state
+   *   this [ActivateableStatIconDefaults] represents to be switched.
+   */
+  class Interactive(private val onInteraction: (isActive: Boolean) -> Unit) :
+    ActivateableStatIconInteractiveness() {
+    override fun onInteraction(isActive: Boolean) {
+      onInteraction.invoke(isActive)
     }
+  }
 
-    /**
-     * Performs an action based on the received interaction.
-     *
-     * @param isActive Whether the [ActivateableStatIconDefaults] is active.
-     **/
-    internal abstract fun onInteraction(isActive: Boolean)
+  /**
+   * Performs an action based on the received interaction.
+   *
+   * @param isActive Whether the [ActivateableStatIconDefaults] is active.
+   */
+  internal abstract fun onInteraction(isActive: Boolean)
 }
 
 /**
  * Provides [Color]s for coloring a [ActivateableStatIconDefaults].
  *
- * @param inactiveColor [Color] by which the [ActivateableStatIconDefaults] is colored when it's inactive.
- * @param activeColor [Color] by which the [ActivateableStatIconDefaults] is colored when it's active.
- **/
+ * @param inactiveColor [Color] by which the [ActivateableStatIconDefaults] is colored when it's
+ *   inactive.
+ * @param activeColor [Color] by which the [ActivateableStatIconDefaults] is colored when it's
+ *   active.
+ */
 @Immutable
-class ActivateableStatIconColors internal constructor(
-    private val inactiveColor: Color,
-    private val activeColor: Color
-) {
-    /**
-     * Provides the [Color] that matches the activeness of the [ActivateableStatIconDefaults] represented by
-     * [isActive].
-     *
-     * @param isActive Whether the [ActivateableStatIconDefaults] is active.
-     **/
-    internal fun color(isActive: Boolean): Color {
-        return if (isActive) activeColor else inactiveColor
-    }
+class ActivateableStatIconColors
+internal constructor(private val inactiveColor: Color, private val activeColor: Color) {
+  /**
+   * Provides the [Color] that matches the activeness of the [ActivateableStatIconDefaults]
+   * represented by [isActive].
+   *
+   * @param isActive Whether the [ActivateableStatIconDefaults] is active.
+   */
+  internal fun color(isActive: Boolean): Color {
+    return if (isActive) activeColor else inactiveColor
+  }
 }
 
 /**
  * A stat [Icon] that can be in an active state.
  *
  * @param vector [ImageVector] that's the icon to be displayed.
- * @param contentDescription Shortly describes the operation this [ActivateableStatIconDefaults] represents.
+ * @param contentDescription Shortly describes the operation this [ActivateableStatIconDefaults]
+ *   represents.
  * @param isActive Whether the state it represents is enabled.
  * @param interactiveness [ActivateableStatIconInteractiveness] that indicates whether this
- * [ActivateableStatIconDefaults] can be interacted with.
+ *   [ActivateableStatIconDefaults] can be interacted with.
  * @param colors [ActivateableStatIconColors] that defines the [Color]s to color it.
  * @param modifier [Modifier] to be applied to the underlying [Icon].
- **/
+ */
 @Composable
 internal fun ActivateableStatIcon(
-    vector: ImageVector,
-    contentDescription: String,
-    isActive: Boolean,
-    interactiveness: ActivateableStatIconInteractiveness,
-    colors: ActivateableStatIconColors,
-    modifier: Modifier = Modifier
+  vector: ImageVector,
+  contentDescription: String,
+  isActive: Boolean,
+  interactiveness: ActivateableStatIconInteractiveness,
+  colors: ActivateableStatIconColors,
+  modifier: Modifier = Modifier
 ) {
-    var isPressed by remember { mutableStateOf(false) }
-    val scale by animateFloatAsState(
-        if (isPressed) 1.5f else 1f,
-        spring(Spring.DampingRatioMediumBouncy),
-        label = "Scale"
+  var isPressed by remember { mutableStateOf(false) }
+  val scale by
+    animateFloatAsState(
+      if (isPressed) 1.5f else 1f,
+      spring(Spring.DampingRatioMediumBouncy),
+      label = "Scale"
     )
-    val tint by animateColorAsState(colors.color(isActive), label = "Tint")
+  val tint by animateColorAsState(colors.color(isActive), label = "Tint")
 
-    Icon(
-        vector,
-        contentDescription,
-        modifier
-            .pointerInput(isActive) {
-                detectTapGestures(
-                    onPress = {
-                        isPressed = true
-                        tryAwaitRelease()
-                        isPressed = false
-                    }
-                ) {
-                    interactiveness.onInteraction(!isActive)
-                }
-            }
-            .scale(scale)
-            .size(ActivateableStatIconDefaults.Size)
-            .testTag(ACTIVATEABLE_STAT_ICON_TAG)
-            .semantics { selected = isActive },
-        tint
-    )
+  Icon(
+    vector,
+    contentDescription,
+    modifier
+      .pointerInput(isActive) {
+        detectTapGestures(
+          onPress = {
+            isPressed = true
+            tryAwaitRelease()
+            isPressed = false
+          }
+        ) {
+          interactiveness.onInteraction(!isActive)
+        }
+      }
+      .scale(scale)
+      .size(ActivateableStatIconDefaults.Size)
+      .testTag(ACTIVATEABLE_STAT_ICON_TAG)
+      .semantics { selected = isActive },
+    tint
+  )
 }
 
 @Composable
 @MultiThemePreview
 private fun InactiveActivateableStatIconPreview() {
-    OrcaTheme {
-        ActivateableStatIcon(isActive = false)
-    }
+  OrcaTheme { ActivateableStatIcon(isActive = false) }
 }
 
 @Composable
 @MultiThemePreview
 private fun ActiveActivateableStatIconPreview() {
-    OrcaTheme {
-        ActivateableStatIcon(isActive = true)
-    }
+  OrcaTheme { ActivateableStatIcon(isActive = true) }
 }
 
 @Composable
 private fun ActivateableStatIcon(isActive: Boolean, modifier: Modifier = Modifier) {
-    ActivateableStatIcon(
-        OrcaTheme.iconography.link,
-        contentDescription = "Disconnect",
-        isActive,
-        ActivateableStatIconInteractiveness.Still,
-        ActivateableStatIconColors(
-            inactiveColor = LocalContentColor.current,
-            activeColor = OrcaTheme.colors.link
-        ),
-        modifier
-    )
+  ActivateableStatIcon(
+    OrcaTheme.iconography.link,
+    contentDescription = "Disconnect",
+    isActive,
+    ActivateableStatIconInteractiveness.Still,
+    ActivateableStatIconColors(
+      inactiveColor = LocalContentColor.current,
+      activeColor = OrcaTheme.colors.link
+    ),
+    modifier
+  )
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/stat/favorite/FavoriteStatIcon.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/stat/favorite/FavoriteStatIcon.kt
@@ -15,24 +15,24 @@ import com.jeanbarrossilva.orca.platform.ui.component.stat.ActivateableStatIconC
 import com.jeanbarrossilva.orca.platform.ui.component.stat.ActivateableStatIconDefaults
 import com.jeanbarrossilva.orca.platform.ui.component.stat.ActivateableStatIconInteractiveness
 
-/** Tag that identifies a [FavoriteStatIcon] for testing purposes. **/
+/** Tag that identifies a [FavoriteStatIcon] for testing purposes. */
 const val FAVORITE_STAT_ICON_TAG = "favorite-stat-icon"
 
-/** Default values of a [FavoriteStatIcon]. **/
+/** Default values of a [FavoriteStatIcon]. */
 object FavoriteStatIconDefaults {
-    /**
-     * [ActivateableStatIconColors] by which a [FavoriteStatIcon] is colored by default.
-     *
-     * @param inactiveColor [Color] to color it with when it's inactive.
-     * @param activeColor [Color] to color it with when it's active.
-     **/
-    @Composable
-    fun colors(
-        inactiveColor: Color = LocalContentColor.current,
-        activeColor: Color = OrcaTheme.colors.activation.favorite
-    ): ActivateableStatIconColors {
-        return ActivateableStatIconColors(inactiveColor, activeColor)
-    }
+  /**
+   * [ActivateableStatIconColors] by which a [FavoriteStatIcon] is colored by default.
+   *
+   * @param inactiveColor [Color] to color it with when it's inactive.
+   * @param activeColor [Color] to color it with when it's active.
+   */
+  @Composable
+  fun colors(
+    inactiveColor: Color = LocalContentColor.current,
+    activeColor: Color = OrcaTheme.colors.activation.favorite
+  ): ActivateableStatIconColors {
+    return ActivateableStatIconColors(inactiveColor, activeColor)
+  }
 }
 
 /**
@@ -40,47 +40,47 @@ object FavoriteStatIconDefaults {
  *
  * @param isActive Whether the state it represents is enabled.
  * @param interactiveness [ActivateableStatIconInteractiveness] that indicates whether this
- * [ActivateableStatIconDefaults] can be interacted with.
+ *   [ActivateableStatIconDefaults] can be interacted with.
  * @param colors [ActivateableStatIconColors] that defines the [Color]s to color it.
  * @param modifier [Modifier] to be applied to the underlying [ActivateableStatIconDefaults].
- **/
+ */
 @Composable
 fun FavoriteStatIcon(
-    isActive: Boolean,
-    interactiveness: ActivateableStatIconInteractiveness,
-    modifier: Modifier = Modifier,
-    colors: ActivateableStatIconColors = FavoriteStatIconDefaults.colors()
+  isActive: Boolean,
+  interactiveness: ActivateableStatIconInteractiveness,
+  modifier: Modifier = Modifier,
+  colors: ActivateableStatIconColors = FavoriteStatIconDefaults.colors()
 ) {
-    ActivateableStatIcon(
-        if (isActive) {
-            OrcaTheme.iconography.favorite.filled
-        } else {
-            OrcaTheme.iconography.favorite.outlined
-        },
-        contentDescription = stringResource(R.string.platform_ui_favorite_stat),
-        isActive,
-        interactiveness,
-        colors,
-        modifier.testTag(FAVORITE_STAT_ICON_TAG)
-    )
+  ActivateableStatIcon(
+    if (isActive) {
+      OrcaTheme.iconography.favorite.filled
+    } else {
+      OrcaTheme.iconography.favorite.outlined
+    },
+    contentDescription = stringResource(R.string.platform_ui_favorite_stat),
+    isActive,
+    interactiveness,
+    colors,
+    modifier.testTag(FAVORITE_STAT_ICON_TAG)
+  )
 }
 
 @Composable
 @MultiThemePreview
 private fun InactiveFavoriteStatIconPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            FavoriteStatIcon(isActive = false, ActivateableStatIconInteractiveness.Still)
-        }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) {
+      FavoriteStatIcon(isActive = false, ActivateableStatIconInteractiveness.Still)
     }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun ActiveFavoriteStatIconPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            FavoriteStatIcon(isActive = true, ActivateableStatIconInteractiveness.Still)
-        }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) {
+      FavoriteStatIcon(isActive = true, ActivateableStatIconInteractiveness.Still)
     }
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/stat/reblog/ReblogStatIcon.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/stat/reblog/ReblogStatIcon.kt
@@ -15,24 +15,24 @@ import com.jeanbarrossilva.orca.platform.ui.component.stat.ActivateableStatIconC
 import com.jeanbarrossilva.orca.platform.ui.component.stat.ActivateableStatIconDefaults
 import com.jeanbarrossilva.orca.platform.ui.component.stat.ActivateableStatIconInteractiveness
 
-/** Tag that identifies a [ReblogStatIcon] for testing purposes. **/
+/** Tag that identifies a [ReblogStatIcon] for testing purposes. */
 const val REBLOG_STAT_ICON_TAG = "reblog-stat-icon"
 
-/** Default values of a [ReblogStatIcon]. **/
+/** Default values of a [ReblogStatIcon]. */
 object ReblogStatIconDefaults {
-    /**
-     * [ActivateableStatIconColors] by which a [ReblogStatIcon] is colored by default.
-     *
-     * @param inactiveColor [Color] to color it with when it's inactive.
-     * @param activeColor [Color] to color it with when it's active.
-     **/
-    @Composable
-    fun colors(
-        inactiveColor: Color = LocalContentColor.current,
-        activeColor: Color = OrcaTheme.colors.activation.reblog
-    ): ActivateableStatIconColors {
-        return ActivateableStatIconColors(inactiveColor, activeColor)
-    }
+  /**
+   * [ActivateableStatIconColors] by which a [ReblogStatIcon] is colored by default.
+   *
+   * @param inactiveColor [Color] to color it with when it's inactive.
+   * @param activeColor [Color] to color it with when it's active.
+   */
+  @Composable
+  fun colors(
+    inactiveColor: Color = LocalContentColor.current,
+    activeColor: Color = OrcaTheme.colors.activation.reblog
+  ): ActivateableStatIconColors {
+    return ActivateableStatIconColors(inactiveColor, activeColor)
+  }
 }
 
 /**
@@ -40,43 +40,43 @@ object ReblogStatIconDefaults {
  *
  * @param isActive Whether the state it represents is enabled.
  * @param interactiveness [ActivateableStatIconInteractiveness] that indicates whether this
- * [ActivateableStatIconDefaults] can be interacted with.
+ *   [ActivateableStatIconDefaults] can be interacted with.
  * @param colors [ActivateableStatIconColors] that defines the [Color]s to color it.
  * @param modifier [Modifier] to be applied to the underlying [ActivateableStatIconDefaults].
- **/
+ */
 @Composable
 fun ReblogStatIcon(
-    isActive: Boolean,
-    interactiveness: ActivateableStatIconInteractiveness,
-    modifier: Modifier = Modifier,
-    colors: ActivateableStatIconColors = ReblogStatIconDefaults.colors()
+  isActive: Boolean,
+  interactiveness: ActivateableStatIconInteractiveness,
+  modifier: Modifier = Modifier,
+  colors: ActivateableStatIconColors = ReblogStatIconDefaults.colors()
 ) {
-    ActivateableStatIcon(
-        OrcaTheme.iconography.reblog,
-        contentDescription = stringResource(R.string.platform_ui_reblog_stat),
-        isActive,
-        interactiveness,
-        colors,
-        modifier.testTag(REBLOG_STAT_ICON_TAG)
-    )
+  ActivateableStatIcon(
+    OrcaTheme.iconography.reblog,
+    contentDescription = stringResource(R.string.platform_ui_reblog_stat),
+    isActive,
+    interactiveness,
+    colors,
+    modifier.testTag(REBLOG_STAT_ICON_TAG)
+  )
 }
 
 @Composable
 @MultiThemePreview
 private fun InactiveReblogStatIconPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            ReblogStatIcon(isActive = false, ActivateableStatIconInteractiveness.Still)
-        }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) {
+      ReblogStatIcon(isActive = false, ActivateableStatIconInteractiveness.Still)
     }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun ActiveReblogStatIconPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            ReblogStatIcon(isActive = true, ActivateableStatIconInteractiveness.Still)
-        }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) {
+      ReblogStatIcon(isActive = true, ActivateableStatIconInteractiveness.Still)
     }
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/Timeline.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/Timeline.kt
@@ -38,25 +38,22 @@ import com.jeanbarrossilva.orca.platform.ui.R
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.TootPreview
 import java.net.URL
 
-/** Tag that identifies an [EmptyTimelineMessage] for testing purposes. **/
+/** Tag that identifies an [EmptyTimelineMessage] for testing purposes. */
 internal const val EMPTY_TIMELINE_MESSAGE_TAG = "empty-timeline-tag"
 
-/** Tag that identifies dividers between [TootPreview]s in a [Timeline] for testing purposes. **/
+/** Tag that identifies dividers between [TootPreview]s in a [Timeline] for testing purposes. */
 internal const val TIMELINE_DIVIDER_TAG = "timeline-divider"
 
-/** Tag that identifies a [Timeline] for testing purposes. **/
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
-const val TIMELINE_TAG = "timeline"
+/** Tag that identifies a [Timeline] for testing purposes. */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) const val TIMELINE_TAG = "timeline"
 
-/**
- * [Timeline] content types for Compose to reuse the [Composable]s while lazily displaying them.
- **/
+/** [Timeline] content types for Compose to reuse the [Composable]s while lazily displaying them. */
 private enum class TimelineContentType {
-    /** Content type for the header. **/
-    HEADER,
+  /** Content type for the header. */
+  HEADER,
 
-    /** Content type for [TootPreview]s. **/
-    TOOT_PREVIEW
+  /** Content type for [TootPreview]s. */
+  TOOT_PREVIEW
 }
 
 /**
@@ -64,56 +61,53 @@ private enum class TimelineContentType {
  *
  * @param tootPreviewsLoadable [ListLoadable] of [TootPreview]s to be lazily shown.
  * @param onHighlightClick Callback run whenever the [TootPreview]'s [TootPreview.highlight] is
- * clicked.
+ *   clicked.
  * @param onFavorite Callback run whenever the [TootPreview] associated to the given ID requests the
- * [Toot] to have its "favorited" state toggled.
+ *   [Toot] to have its "favorited" state toggled.
  * @param onReblog Callback run whenever the [TootPreview] associated to the given ID requests the
- * [Toot] to have its "reblogged" state toggled.
+ *   [Toot] to have its "reblogged" state toggled.
  * @param onShare Callback run whenever a [TootPreview] requests the [Toot]'s [URL] is requested to
- * be shared.
+ *   be shared.
  * @param onClick Callback run whenever the [TootPreview] associated to the given ID is clicked.
  * @param onNext Callback run whenever the user reaches the bottom.
  * @param modifier [Modifier] to be applied to the underlying [LazyColumn].
  * @param state [LazyListState] through which scroll will be observed.
  * @param contentPadding [PaddingValues] to pad the content with.
  * @param header [Composable] to be shown above the [TootPreview]s.
- **/
+ */
 @Composable
 fun Timeline(
-    tootPreviewsLoadable: ListLoadable<TootPreview>,
-    onHighlightClick: (URL) -> Unit,
-    onFavorite: (id: String) -> Unit,
-    onReblog: (id: String) -> Unit,
-    onShare: (URL) -> Unit,
-    onClick: (id: String) -> Unit,
-    onNext: (index: Int) -> Unit,
-    modifier: Modifier = Modifier,
-    state: LazyListState = rememberLazyListState(),
-    contentPadding: PaddingValues = PaddingValues(),
-    header: (@Composable LazyItemScope.() -> Unit)? = null
+  tootPreviewsLoadable: ListLoadable<TootPreview>,
+  onHighlightClick: (URL) -> Unit,
+  onFavorite: (id: String) -> Unit,
+  onReblog: (id: String) -> Unit,
+  onShare: (URL) -> Unit,
+  onClick: (id: String) -> Unit,
+  onNext: (index: Int) -> Unit,
+  modifier: Modifier = Modifier,
+  state: LazyListState = rememberLazyListState(),
+  contentPadding: PaddingValues = PaddingValues(),
+  header: (@Composable LazyItemScope.() -> Unit)? = null
 ) {
-    when (tootPreviewsLoadable) {
-        is ListLoadable.Empty ->
-            EmptyTimelineMessage(header, contentPadding, modifier)
-        is ListLoadable.Loading ->
-            Timeline(modifier, contentPadding, header)
-        is ListLoadable.Populated ->
-            Timeline(
-                tootPreviewsLoadable.content,
-                onHighlightClick,
-                onFavorite,
-                onReblog,
-                onShare,
-                onClick,
-                onNext,
-                modifier,
-                state,
-                contentPadding,
-                header
-            )
-        is ListLoadable.Failed ->
-            Unit
-    }
+  when (tootPreviewsLoadable) {
+    is ListLoadable.Empty -> EmptyTimelineMessage(header, contentPadding, modifier)
+    is ListLoadable.Loading -> Timeline(modifier, contentPadding, header)
+    is ListLoadable.Populated ->
+      Timeline(
+        tootPreviewsLoadable.content,
+        onHighlightClick,
+        onFavorite,
+        onReblog,
+        onShare,
+        onClick,
+        onNext,
+        modifier,
+        state,
+        contentPadding,
+        header
+      )
+    is ListLoadable.Failed -> Unit
+  }
 }
 
 /**
@@ -122,18 +116,16 @@ fun Timeline(
  * @param header [Composable] to be shown above the [TootPreview]s.
  * @param modifier [Modifier] to be applied to the underlying [LazyColumn].
  * @param contentPadding [PaddingValues] to pad the content with.
- **/
+ */
 @Composable
 fun Timeline(
-    modifier: Modifier = Modifier,
-    contentPadding: PaddingValues = PaddingValues(),
-    header: @Composable (LazyItemScope.() -> Unit)? = null
+  modifier: Modifier = Modifier,
+  contentPadding: PaddingValues = PaddingValues(),
+  header: @Composable (LazyItemScope.() -> Unit)? = null
 ) {
-    Timeline(onNext = { }, header, modifier, contentPadding = contentPadding) {
-        items(128) {
-            TootPreview()
-        }
-    }
+  Timeline(onNext = {}, header, modifier, contentPadding = contentPadding) {
+    items(128) { TootPreview() }
+  }
 }
 
 /**
@@ -141,58 +133,58 @@ fun Timeline(
  *
  * @param tootPreviews [TootPreview]s to be lazily shown.
  * @param onHighlightClick Callback run whenever the [TootPreview]'s [TootPreview.highlight] is
- * clicked.
+ *   clicked.
  * @param onFavorite Callback run whenever the [TootPreview] associated to the given ID requests the
- * [Toot] to have its "favorited" state toggled.
+ *   [Toot] to have its "favorited" state toggled.
  * @param onReblog Callback run whenever the [TootPreview] associated to the given ID requests the
- * [Toot] to have its "reblogged" state toggled.
+ *   [Toot] to have its "reblogged" state toggled.
  * @param onShare Callback run whenever a [TootPreview] requests the [Toot]'s [URL] is requested to
- * be shared.
+ *   be shared.
  * @param onClick Callback run whenever the [TootPreview] associated to the given ID is clicked.
  * @param onNext Callback run whenever the user reaches the bottom.
  * @param modifier [Modifier] to be applied to the underlying [LazyColumn].
  * @param state [LazyListState] through which scroll will be observed.
  * @param contentPadding [PaddingValues] to pad the content with.
  * @param header [Composable] to be shown above the [TootPreview]s.
- **/
+ */
 @Composable
 fun Timeline(
-    tootPreviews: List<TootPreview>,
-    onHighlightClick: (URL) -> Unit,
-    onFavorite: (id: String) -> Unit,
-    onReblog: (id: String) -> Unit,
-    onShare: (URL) -> Unit,
-    onClick: (id: String) -> Unit,
-    onNext: (index: Int) -> Unit,
-    modifier: Modifier = Modifier,
-    state: LazyListState = rememberLazyListState(),
-    contentPadding: PaddingValues = PaddingValues(),
-    header: (@Composable LazyItemScope.() -> Unit)? = null
+  tootPreviews: List<TootPreview>,
+  onHighlightClick: (URL) -> Unit,
+  onFavorite: (id: String) -> Unit,
+  onReblog: (id: String) -> Unit,
+  onShare: (URL) -> Unit,
+  onClick: (id: String) -> Unit,
+  onNext: (index: Int) -> Unit,
+  modifier: Modifier = Modifier,
+  state: LazyListState = rememberLazyListState(),
+  contentPadding: PaddingValues = PaddingValues(),
+  header: (@Composable LazyItemScope.() -> Unit)? = null
 ) {
-    if (tootPreviews.isEmpty()) {
-        EmptyTimelineMessage(header, contentPadding, modifier)
-    } else {
-        Timeline(onNext, header, modifier, state, contentPadding) {
-            itemsIndexed(
-                tootPreviews,
-                key = { _, preview -> preview.id },
-                contentType = { _, _ -> TimelineContentType.TOOT_PREVIEW }
-            ) { index, preview ->
-                if (index == 0 && header != null || index != 0 && index != tootPreviews.lastIndex) {
-                    Divider(Modifier.testTag(TIMELINE_DIVIDER_TAG))
-                }
-
-                TootPreview(
-                    preview,
-                    onHighlightClick = { preview.highlight?.url?.run(onHighlightClick) },
-                    onFavorite = { onFavorite(preview.id) },
-                    onReblog = { onReblog(preview.id) },
-                    onShare = { onShare(preview.url) },
-                    onClick = { onClick(preview.id) }
-                )
-            }
+  if (tootPreviews.isEmpty()) {
+    EmptyTimelineMessage(header, contentPadding, modifier)
+  } else {
+    Timeline(onNext, header, modifier, state, contentPadding) {
+      itemsIndexed(
+        tootPreviews,
+        key = { _, preview -> preview.id },
+        contentType = { _, _ -> TimelineContentType.TOOT_PREVIEW }
+      ) { index, preview ->
+        if (index == 0 && header != null || index != 0 && index != tootPreviews.lastIndex) {
+          Divider(Modifier.testTag(TIMELINE_DIVIDER_TAG))
         }
+
+        TootPreview(
+          preview,
+          onHighlightClick = { preview.highlight?.url?.run(onHighlightClick) },
+          onFavorite = { onFavorite(preview.id) },
+          onReblog = { onReblog(preview.id) },
+          onShare = { onShare(preview.url) },
+          onClick = { onClick(preview.id) }
+        )
+      }
     }
+  }
 }
 
 /**
@@ -203,19 +195,19 @@ fun Timeline(
  */
 @Composable
 internal fun Timeline(
-    tootPreviewsLoadable: ListLoadable<TootPreview>,
-    modifier: Modifier = Modifier
+  tootPreviewsLoadable: ListLoadable<TootPreview>,
+  modifier: Modifier = Modifier
 ) {
-    Timeline(
-        tootPreviewsLoadable,
-        onHighlightClick = { },
-        onFavorite = { },
-        onReblog = { },
-        onShare = { },
-        onClick = { },
-        onNext = { },
-        modifier
-    )
+  Timeline(
+    tootPreviewsLoadable,
+    onHighlightClick = {},
+    onFavorite = {},
+    onReblog = {},
+    onShare = {},
+    onClick = {},
+    onNext = {},
+    modifier
+  )
 }
 
 /**
@@ -228,21 +220,21 @@ internal fun Timeline(
  */
 @Composable
 internal fun PopulatedTimeline(
-    modifier: Modifier = Modifier,
-    tootPreviews: List<TootPreview> = TootPreview.samples,
-    header: @Composable (LazyItemScope.() -> Unit)? = null
+  modifier: Modifier = Modifier,
+  tootPreviews: List<TootPreview> = TootPreview.samples,
+  header: @Composable (LazyItemScope.() -> Unit)? = null
 ) {
-    Timeline(
-        tootPreviews,
-        onHighlightClick = { },
-        onFavorite = { },
-        onReblog = { },
-        onShare = { },
-        onClick = { },
-        onNext = { },
-        modifier,
-        header = header
-    )
+  Timeline(
+    tootPreviews,
+    onHighlightClick = {},
+    onFavorite = {},
+    onReblog = {},
+    onShare = {},
+    onClick = {},
+    onNext = {},
+    modifier,
+    header = header
+  )
 }
 
 /**
@@ -254,35 +246,29 @@ internal fun PopulatedTimeline(
  * @param state [LazyListState] through which scroll will be observed.
  * @param contentPadding [PaddingValues] to pad the contents ([header] + [content]) with.
  * @param content Content to be lazily shown below the [header].
- **/
+ */
 @Composable
 private fun Timeline(
-    onNext: (index: Int) -> Unit,
-    header: (@Composable LazyItemScope.() -> Unit)?,
-    modifier: Modifier = Modifier,
-    state: LazyListState = rememberLazyListState(),
-    contentPadding: PaddingValues = PaddingValues(),
-    content: LazyListScope.() -> Unit
+  onNext: (index: Int) -> Unit,
+  header: (@Composable LazyItemScope.() -> Unit)?,
+  modifier: Modifier = Modifier,
+  state: LazyListState = rememberLazyListState(),
+  contentPadding: PaddingValues = PaddingValues(),
+  content: LazyListScope.() -> Unit
 ) {
-    val shouldLoad = remember(state) { !state.canScrollForward }
-    var index by remember { mutableIntStateOf(0) }
+  val shouldLoad = remember(state) { !state.canScrollForward }
+  var index by remember { mutableIntStateOf(0) }
 
-    DisposableEffect(shouldLoad) {
-        onNext(index++)
-        onDispose { }
-    }
+  DisposableEffect(shouldLoad) {
+    onNext(index++)
+    onDispose {}
+  }
 
-    LazyColumn(
-        modifier.testTag(TIMELINE_TAG),
-        state,
-        contentPadding
-    ) {
-        header?.let {
-            item(contentType = { TimelineContentType.HEADER }, content = it)
-        }
+  LazyColumn(modifier.testTag(TIMELINE_TAG), state, contentPadding) {
+    header?.let { item(contentType = { TimelineContentType.HEADER }, content = it) }
 
-        content()
-    }
+    content()
+  }
 }
 
 /**
@@ -291,108 +277,94 @@ private fun Timeline(
  * @param header [Composable] to be shown above the message.
  * @param contentPadding [PaddingValues] to pad the contents with.
  * @param modifier [Modifier] to be applied to the underlying [Column].
- **/
+ */
 @Composable
 private fun EmptyTimelineMessage(
-    header: (@Composable LazyItemScope.() -> Unit)?,
-    contentPadding: PaddingValues,
-    modifier: Modifier = Modifier
+  header: (@Composable LazyItemScope.() -> Unit)?,
+  contentPadding: PaddingValues,
+  modifier: Modifier = Modifier
 ) {
-    val spacing = OrcaTheme.spacings.large
+  val spacing = OrcaTheme.spacings.large
 
-    LazyColumn(
-        modifier
-            .testTag(EMPTY_TIMELINE_MESSAGE_TAG)
-            .fillMaxSize(),
-        contentPadding = contentPadding,
-        verticalArrangement = Arrangement.spacedBy(spacing),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        header?.let {
-            item(content = it)
-        }
+  LazyColumn(
+    modifier.testTag(EMPTY_TIMELINE_MESSAGE_TAG).fillMaxSize(),
+    contentPadding = contentPadding,
+    verticalArrangement = Arrangement.spacedBy(spacing),
+    horizontalAlignment = Alignment.CenterHorizontally
+  ) {
+    header?.let { item(content = it) }
 
-        item {
-            Icon(
-                OrcaTheme.iconography.empty,
-                contentDescription = stringResource(R.string.platform_ui_timeline_empty),
-                Modifier
-                    .padding(start = spacing, top = spacing, end = spacing)
-                    .size(32.dp),
-                tint = OrcaTheme.colors.secondary
-            )
-        }
-
-        item {
-            Text(
-                stringResource(R.string.platform_ui_timeline_empty_message),
-                Modifier.padding(start = spacing, end = spacing, bottom = spacing),
-                textAlign = TextAlign.Center,
-                style = OrcaTheme.typography.headlineMedium
-            )
-        }
+    item {
+      Icon(
+        OrcaTheme.iconography.empty,
+        contentDescription = stringResource(R.string.platform_ui_timeline_empty),
+        Modifier.padding(start = spacing, top = spacing, end = spacing).size(32.dp),
+        tint = OrcaTheme.colors.secondary
+      )
     }
+
+    item {
+      Text(
+        stringResource(R.string.platform_ui_timeline_empty_message),
+        Modifier.padding(start = spacing, end = spacing, bottom = spacing),
+        textAlign = TextAlign.Center,
+        style = OrcaTheme.typography.headlineMedium
+      )
+    }
+  }
 }
 
-/** Preview of a loading [Timeline]. **/
+/** Preview of a loading [Timeline]. */
 @Composable
 @MultiThemePreview
 private fun LoadingTimelinePreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            Timeline()
-        }
-    }
+  OrcaTheme { Surface(color = OrcaTheme.colors.background.container) { Timeline() } }
 }
 
-/** Preview of an empty [Timeline]. **/
+/** Preview of an empty [Timeline]. */
 @Composable
 @MultiThemePreview
 private fun EmptyTimelinePreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            Timeline(
-                ListLoadable.Empty(),
-                onHighlightClick = { },
-                onFavorite = { },
-                onReblog = { },
-                onShare = { },
-                onClick = { },
-                onNext = { }
-            )
-        }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) {
+      Timeline(
+        ListLoadable.Empty(),
+        onHighlightClick = {},
+        onFavorite = {},
+        onReblog = {},
+        onShare = {},
+        onClick = {},
+        onNext = {}
+      )
     }
+  }
 }
 
-/** Preview of a populated [Timeline]. **/
+/** Preview of a populated [Timeline]. */
 @Composable
 @MultiThemePreview
 private fun PopulatedTimelinePreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            PopulatedTimeline()
-        }
-    }
+  OrcaTheme { Surface(color = OrcaTheme.colors.background.container) { PopulatedTimeline() } }
 }
 
-/** Preview of a populated [Timeline] with a header. **/
+/** Preview of a populated [Timeline] with a header. */
 @Composable
 @MultiThemePreview
 private fun PopulatedTimelineWithHeaderPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            PopulatedTimeline {
-                AutoSizeText(
-                    "Header",
-                    Modifier.padding(
-                        start = OrcaTheme.spacings.large,
-                        top = OrcaTheme.spacings.large,
-                        end = OrcaTheme.spacings.large,
-                        bottom = OrcaTheme.spacings.medium
-                    ),
-                    style = OrcaTheme.typography.displayLarge
-                )
-            }
-        }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) {
+      PopulatedTimeline {
+        AutoSizeText(
+          "Header",
+          Modifier.padding(
+            start = OrcaTheme.spacings.large,
+            top = OrcaTheme.spacings.large,
+            end = OrcaTheme.spacings.large,
+            bottom = OrcaTheme.spacings.medium
+          ),
+          style = OrcaTheme.typography.displayLarge
+        )
+      }
     }
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/Int.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/Int.extensions.kt
@@ -3,8 +3,8 @@ package com.jeanbarrossilva.orca.platform.ui.component.timeline.toot
 import android.icu.text.CompactDecimalFormat
 import java.util.Locale
 
-/** Formats this [Int] so that it is more user-friendly. **/
+/** Formats this [Int] so that it is more user-friendly. */
 val Int.formatted: String
-    get() = CompactDecimalFormat
-        .getInstance(Locale.getDefault(), CompactDecimalFormat.CompactStyle.SHORT)
-        .format(this)
+  get() =
+    CompactDecimalFormat.getInstance(Locale.getDefault(), CompactDecimalFormat.CompactStyle.SHORT)
+      .format(this)

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/Toot.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/Toot.extensions.kt
@@ -12,59 +12,59 @@ import kotlinx.coroutines.flow.combine
  * Converts this [Toot] into a [Flow] of [TootPreview].
  *
  * @param colors [Colors] by which the emitted [TootPreview]s' [TootPreview.text] can be colored.
- **/
+ */
 fun Toot.toTootPreviewFlow(colors: Colors): Flow<TootPreview> {
-    val body = content.text.toAnnotatedString(colors)
-    return combine(
-        comment.countFlow,
-        favorite.isEnabledFlow,
-        favorite.countFlow,
-        reblog.isEnabledFlow,
-        reblog.countFlow
-    ) { commentCount, isFavorite, favoriteCount, isReblogged, reblogCount ->
-        TootPreview(
-            id,
-            author.avatarURL,
-            author.name,
-            author.account,
-            body,
-            content.highlight,
-            publicationDateTime,
-            commentCount,
-            isFavorite,
-            favoriteCount,
-            isReblogged,
-            reblogCount,
-            url
-        )
-    }
+  val body = content.text.toAnnotatedString(colors)
+  return combine(
+    comment.countFlow,
+    favorite.isEnabledFlow,
+    favorite.countFlow,
+    reblog.isEnabledFlow,
+    reblog.countFlow
+  ) { commentCount, isFavorite, favoriteCount, isReblogged, reblogCount ->
+    TootPreview(
+      id,
+      author.avatarURL,
+      author.name,
+      author.account,
+      body,
+      content.highlight,
+      publicationDateTime,
+      commentCount,
+      isFavorite,
+      favoriteCount,
+      isReblogged,
+      reblogCount,
+      url
+    )
+  }
 }
 
-/** Converts this [Toot] into a [TootPreview]. **/
+/** Converts this [Toot] into a [TootPreview]. */
 @Composable
 internal fun Toot.toTootPreview(): TootPreview {
-    return toTootPreview(OrcaTheme.colors)
+  return toTootPreview(OrcaTheme.colors)
 }
 
 /**
  * Converts this [Toot] into a [TootPreview].
  *
  * @param colors [Colors] by which the resulting [TootPreview]'s [TootPreview.text] can be colored.
- **/
+ */
 internal fun Toot.toTootPreview(colors: Colors): TootPreview {
-    return TootPreview(
-        id,
-        author.avatarURL,
-        author.name,
-        author.account,
-        content.text.toAnnotatedString(colors),
-        content.highlight,
-        publicationDateTime,
-        comment.count,
-        favorite.isEnabled,
-        favorite.count,
-        reblog.isEnabled,
-        reblog.count,
-        url
-    )
+  return TootPreview(
+    id,
+    author.avatarURL,
+    author.name,
+    author.account,
+    content.text.toAnnotatedString(colors),
+    content.highlight,
+    publicationDateTime,
+    comment.count,
+    favorite.isEnabled,
+    favorite.count,
+    reblog.isEnabled,
+    reblog.count,
+    url
+  )
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/TootPreview.Stat.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/TootPreview.Stat.kt
@@ -24,110 +24,99 @@ import com.jeanbarrossilva.orca.platform.theme.kit.action.Hoverable
 import com.jeanbarrossilva.orca.platform.ui.component.stat.ActivateableStatIconDefaults
 
 internal object StatDefaults {
-    val IconSize = ActivateableStatIconDefaults.Size
+  val IconSize = ActivateableStatIconDefaults.Size
 }
 
 internal enum class StatPosition {
-    LEADING {
-        override val padding
-            @Composable get() = PaddingValues(end = OrcaTheme.spacings.small)
-    },
-    SUBSEQUENT {
-        override val padding
-            @Composable get() = PaddingValues(horizontal = OrcaTheme.spacings.small)
-    },
-    TRAILING {
-        override val padding
-            @Composable get() = PaddingValues(start = OrcaTheme.spacings.small)
-    };
+  LEADING {
+    override val padding
+      @Composable get() = PaddingValues(end = OrcaTheme.spacings.small)
+  },
+  SUBSEQUENT {
+    override val padding
+      @Composable get() = PaddingValues(horizontal = OrcaTheme.spacings.small)
+  },
+  TRAILING {
+    override val padding
+      @Composable get() = PaddingValues(start = OrcaTheme.spacings.small)
+  };
 
-    @get:Composable
-    abstract val padding: PaddingValues
+  @get:Composable abstract val padding: PaddingValues
 }
 
 @Composable
 internal fun Stat(
-    position: StatPosition,
-    vector: ImageVector,
-    contentDescription: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    label: @Composable () -> Unit = { }
+  position: StatPosition,
+  vector: ImageVector,
+  contentDescription: String,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  label: @Composable () -> Unit = {}
 ) {
-    Stat(position, onClick, modifier) {
-        Icon(vector, contentDescription, Modifier.size(StatDefaults.IconSize))
-        label()
-    }
+  Stat(position, onClick, modifier) {
+    Icon(vector, contentDescription, Modifier.size(StatDefaults.IconSize))
+    label()
+  }
 }
 
 @Composable
 internal fun Stat(
-    position: StatPosition,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable RowScope.() -> Unit
+  position: StatPosition,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  content: @Composable RowScope.() -> Unit
 ) {
-    val spacing = OrcaTheme.spacings.small
-    val contentColor = OrcaTheme.colors.secondary
+  val spacing = OrcaTheme.spacings.small
+  val contentColor = OrcaTheme.colors.secondary
 
-    Hoverable(
-        modifier
-            .padding(position.padding)
-            .clickable(role = Role.Button, onClick = onClick)
+  Hoverable(modifier.padding(position.padding).clickable(role = Role.Button, onClick = onClick)) {
+    Row(
+      horizontalArrangement = Arrangement.spacedBy(spacing),
+      verticalAlignment = Alignment.CenterVertically
     ) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(spacing),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            CompositionLocalProvider(
-                LocalContentColor provides contentColor,
-                LocalTextStyle provides OrcaTheme.typography.bodySmall.copy(color = contentColor)
-            ) {
-                content()
-            }
-        }
+      CompositionLocalProvider(
+        LocalContentColor provides contentColor,
+        LocalTextStyle provides OrcaTheme.typography.bodySmall.copy(color = contentColor)
+      ) {
+        content()
+      }
     }
+  }
 }
 
 @Composable
 @MultiThemePreview
 internal fun LeadingStatPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            Stat(StatPosition.LEADING)
-        }
-    }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) { Stat(StatPosition.LEADING) }
+  }
 }
 
 @Composable
 @MultiThemePreview
 internal fun SubsequentStatPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            Stat(StatPosition.SUBSEQUENT)
-        }
-    }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) { Stat(StatPosition.SUBSEQUENT) }
+  }
 }
 
 @Composable
 @MultiThemePreview
 internal fun TrailingStatPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            Stat(StatPosition.TRAILING)
-        }
-    }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) { Stat(StatPosition.TRAILING) }
+  }
 }
 
 @Composable
 private fun Stat(position: StatPosition, modifier: Modifier = Modifier) {
-    Stat(
-        position,
-        OrcaTheme.iconography.comment.outlined,
-        contentDescription = "Comment",
-        onClick = { },
-        modifier
-    ) {
-        Text("8")
-    }
+  Stat(
+    position,
+    OrcaTheme.iconography.comment.outlined,
+    contentDescription = "Comment",
+    onClick = {},
+    modifier
+  ) {
+    Text("8")
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/TootPreview.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/TootPreview.kt
@@ -52,34 +52,34 @@ import java.io.Serializable
 import java.net.URL
 import java.time.ZonedDateTime
 
-/** Tag that identifies a [TootPreview]'s name for testing purposes. **/
+/** Tag that identifies a [TootPreview]'s name for testing purposes. */
 internal const val TOOT_PREVIEW_NAME_TAG = "toot-preview-name"
 
-/** Tag that identifies [TootPreview]'s metadata for testing purposes. **/
+/** Tag that identifies [TootPreview]'s metadata for testing purposes. */
 internal const val TOOT_PREVIEW_METADATA_TAG = "toot-preview-metadata"
 
-/** Tag that identifies a [TootPreview]'s body for testing purposes. **/
+/** Tag that identifies a [TootPreview]'s body for testing purposes. */
 internal const val TOOT_PREVIEW_BODY_TAG = "toot-preview-body"
 
-/** Tag that identifies a [TootPreview]'s comment count stat for testing purposes. **/
+/** Tag that identifies a [TootPreview]'s comment count stat for testing purposes. */
 internal const val TOOT_PREVIEW_COMMENT_COUNT_STAT_TAG = "toot-preview-comments-stat"
 
-/** Tag that identifies a [TootPreview]'s reblog count stat for testing purposes. **/
+/** Tag that identifies a [TootPreview]'s reblog count stat for testing purposes. */
 internal const val TOOT_PREVIEW_REBLOG_COUNT_STAT_TAG = "toot-preview-reblogs-stat"
 
-/** Tag that identifies a [TootPreview]'s share action for testing purposes. **/
+/** Tag that identifies a [TootPreview]'s share action for testing purposes. */
 internal const val TOOT_PREVIEW_SHARE_ACTION_TAG = "toot-preview-share-action"
 
-/** Tag that identifies a [TootPreview] for testing purposes. **/
+/** Tag that identifies a [TootPreview] for testing purposes. */
 const val TOOT_PREVIEW_TAG = "toot-preview"
 
-/** [Modifier] to be applied to a [TootPreview]'s name. **/
+/** [Modifier] to be applied to a [TootPreview]'s name. */
 private val nameModifier = Modifier.testTag(TOOT_PREVIEW_NAME_TAG)
 
-/** [Modifier] to be applied to [TootPreview]'s metadata. **/
+/** [Modifier] to be applied to [TootPreview]'s metadata. */
 private val metadataModifier = Modifier.testTag(TOOT_PREVIEW_METADATA_TAG)
 
-/** [Modifier] to be applied to a [TootPreview]'s body. **/
+/** [Modifier] to be applied to a [TootPreview]'s body. */
 private val bodyModifier = Modifier.testTag(TOOT_PREVIEW_BODY_TAG)
 
 /**
@@ -98,241 +98,227 @@ private val bodyModifier = Modifier.testTag(TOOT_PREVIEW_BODY_TAG)
  * @param isReblogged Whether it's reblogged.
  * @param reblogCount Amount of times it's been reblogged.
  * @param url [URL] that leads to the [Toot].
- **/
+ */
 @Immutable
 data class TootPreview(
-    val id: String,
-    val avatarURL: URL,
-    val name: String,
-    private val account: Account,
-    val text: AnnotatedString,
-    val highlight: Highlight?,
-    private val publicationDateTime: ZonedDateTime,
-    private val commentCount: Int,
-    val isFavorite: Boolean,
-    private val favoriteCount: Int,
-    val isReblogged: Boolean,
-    private val reblogCount: Int,
-    internal val url: URL
+  val id: String,
+  val avatarURL: URL,
+  val name: String,
+  private val account: Account,
+  val text: AnnotatedString,
+  val highlight: Highlight?,
+  private val publicationDateTime: ZonedDateTime,
+  private val commentCount: Int,
+  val isFavorite: Boolean,
+  private val favoriteCount: Int,
+  val isReblogged: Boolean,
+  private val reblogCount: Int,
+  internal val url: URL
 ) : Serializable {
-    /** Formatted, displayable version of [commentCount]. **/
-    val formattedCommentCount = commentCount.formatted
+  /** Formatted, displayable version of [commentCount]. */
+  val formattedCommentCount = commentCount.formatted
 
-    /** Formatted, displayable version of [favoriteCount]. **/
-    val formattedFavoriteCount = favoriteCount.formatted
+  /** Formatted, displayable version of [favoriteCount]. */
+  val formattedFavoriteCount = favoriteCount.formatted
 
-    /** Formatted, displayable version of [reblogCount]. **/
-    val formattedReblogCount = reblogCount.formatted
+  /** Formatted, displayable version of [reblogCount]. */
+  val formattedReblogCount = reblogCount.formatted
 
-    /**
-     * Gets information about the author and how much time it's been since it was published.
-     *
-     * @param relativeTimeProvider [RelativeTimeProvider] for providing relative time of
-     * publication.
-     **/
-    fun getMetadata(relativeTimeProvider: RelativeTimeProvider): String {
-        val username = AccountFormatter.username(account)
-        val timeSincePublication = relativeTimeProvider.provide(publicationDateTime)
-        return "$username • $timeSincePublication"
+  /**
+   * Gets information about the author and how much time it's been since it was published.
+   *
+   * @param relativeTimeProvider [RelativeTimeProvider] for providing relative time of publication.
+   */
+  fun getMetadata(relativeTimeProvider: RelativeTimeProvider): String {
+    val username = AccountFormatter.username(account)
+    val timeSincePublication = relativeTimeProvider.provide(publicationDateTime)
+    return "$username • $timeSincePublication"
+  }
+
+  companion object {
+    /** [TootPreview] sample. */
+    val sample
+      @Composable get() = getSample(OrcaTheme.colors)
+
+    /** [TootPreview] samples. */
+    val samples
+      @Composable get() = Toot.samples.map { it.toTootPreview() }
+
+    /** Gets a sample [TootPreview]. */
+    fun getSample(colors: Colors): TootPreview {
+      return TootPreview(
+        Toot.sample.id,
+        Toot.sample.author.avatarURL,
+        Toot.sample.author.name,
+        Toot.sample.author.account,
+        Toot.sample.content.text.toAnnotatedString(colors),
+        Toot.sample.content.highlight,
+        Toot.sample.publicationDateTime,
+        Toot.sample.comment.count,
+        Toot.sample.favorite.isEnabled,
+        Toot.sample.favorite.count,
+        Toot.sample.reblog.isEnabled,
+        Toot.sample.reblog.count,
+        Toot.sample.url
+      )
     }
-
-    companion object {
-        /** [TootPreview] sample. **/
-        val sample
-            @Composable get() = getSample(OrcaTheme.colors)
-
-        /** [TootPreview] samples. **/
-        val samples
-            @Composable get() = Toot.samples.map { it.toTootPreview() }
-
-        /** Gets a sample [TootPreview]. **/
-        fun getSample(colors: Colors): TootPreview {
-            return TootPreview(
-                Toot.sample.id,
-                Toot.sample.author.avatarURL,
-                Toot.sample.author.name,
-                Toot.sample.author.account,
-                Toot.sample.content.text.toAnnotatedString(colors),
-                Toot.sample.content.highlight,
-                Toot.sample.publicationDateTime,
-                Toot.sample.comment.count,
-                Toot.sample.favorite.isEnabled,
-                Toot.sample.favorite.count,
-                Toot.sample.reblog.isEnabled,
-                Toot.sample.reblog.count,
-                Toot.sample.url
-            )
-        }
-    }
+  }
 }
 
 @Composable
 fun TootPreview(modifier: Modifier = Modifier) {
-    TootPreview(
-        avatar = { SmallAvatar() },
-        name = { SmallTextualPlaceholder(nameModifier) },
-        metadata = { MediumTextualPlaceholder(metadataModifier) },
-        content = {
-            Column(
-                bodyModifier.semantics { set(SemanticsProperties.Loading, true) },
-                Arrangement.spacedBy(OrcaTheme.spacings.extraSmall)
-            ) {
-                repeat(3) { LargeTextualPlaceholder() }
-                MediumTextualPlaceholder()
-            }
-        },
-        stats = { },
-        onClick = null,
-        modifier
-    )
+  TootPreview(
+    avatar = { SmallAvatar() },
+    name = { SmallTextualPlaceholder(nameModifier) },
+    metadata = { MediumTextualPlaceholder(metadataModifier) },
+    content = {
+      Column(
+        bodyModifier.semantics { set(SemanticsProperties.Loading, true) },
+        Arrangement.spacedBy(OrcaTheme.spacings.extraSmall)
+      ) {
+        repeat(3) { LargeTextualPlaceholder() }
+        MediumTextualPlaceholder()
+      }
+    },
+    stats = {},
+    onClick = null,
+    modifier
+  )
 }
 
 @Composable
 fun TootPreview(
-    preview: TootPreview,
-    onHighlightClick: () -> Unit,
-    onFavorite: () -> Unit,
-    onReblog: () -> Unit,
-    onShare: () -> Unit,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    imageLoader: ImageLoader = rememberImageLoader(),
-    relativeTimeProvider: RelativeTimeProvider = rememberRelativeTimeProvider()
+  preview: TootPreview,
+  onHighlightClick: () -> Unit,
+  onFavorite: () -> Unit,
+  onReblog: () -> Unit,
+  onShare: () -> Unit,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  imageLoader: ImageLoader = rememberImageLoader(),
+  relativeTimeProvider: RelativeTimeProvider = rememberRelativeTimeProvider()
 ) {
-    val metadata = remember(preview, relativeTimeProvider) {
-        preview.getMetadata(relativeTimeProvider)
-    }
+  val metadata =
+    remember(preview, relativeTimeProvider) { preview.getMetadata(relativeTimeProvider) }
 
-    TootPreview(
-        avatar = { SmallAvatar(preview.name, preview.avatarURL, imageLoader = imageLoader) },
-        name = { Text(preview.name, nameModifier) },
-        metadata = { Text(metadata, metadataModifier) },
-        content = {
-            Column(verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.medium)) {
-                Text(preview.text, bodyModifier)
+  TootPreview(
+    avatar = { SmallAvatar(preview.name, preview.avatarURL, imageLoader = imageLoader) },
+    name = { Text(preview.name, nameModifier) },
+    metadata = { Text(metadata, metadataModifier) },
+    content = {
+      Column(verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.medium)) {
+        Text(preview.text, bodyModifier)
 
-                preview.highlight?.headline?.let {
-                    HeadlineCard(it, onHighlightClick)
-                }
-            }
-        },
-        stats = {
-            Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween) {
-                Stat(
-                    StatPosition.LEADING,
-                    OrcaTheme.iconography.comment.outlined,
-                    contentDescription = stringResource(R.string.platform_ui_toot_preview_comments),
-                    onClick = { },
-                    Modifier.testTag(TOOT_PREVIEW_COMMENT_COUNT_STAT_TAG)
-                ) {
-                    Text(preview.formattedCommentCount)
-                }
+        preview.highlight?.headline?.let { HeadlineCard(it, onHighlightClick) }
+      }
+    },
+    stats = {
+      Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween) {
+        Stat(
+          StatPosition.LEADING,
+          OrcaTheme.iconography.comment.outlined,
+          contentDescription = stringResource(R.string.platform_ui_toot_preview_comments),
+          onClick = {},
+          Modifier.testTag(TOOT_PREVIEW_COMMENT_COUNT_STAT_TAG)
+        ) {
+          Text(preview.formattedCommentCount)
+        }
 
-                FavoriteStat(StatPosition.SUBSEQUENT, preview, onClick = onFavorite)
-                ReblogStat(StatPosition.SUBSEQUENT, preview, onClick = onReblog)
+        FavoriteStat(StatPosition.SUBSEQUENT, preview, onClick = onFavorite)
+        ReblogStat(StatPosition.SUBSEQUENT, preview, onClick = onReblog)
 
-                Stat(
-                    StatPosition.TRAILING,
-                    OrcaTheme.iconography.share.outlined,
-                    contentDescription = stringResource(R.string.platform_ui_toot_preview_share),
-                    onClick = onShare,
-                    Modifier.testTag(TOOT_PREVIEW_SHARE_ACTION_TAG)
-                )
-            }
-        },
-        onClick,
-        modifier
-    )
+        Stat(
+          StatPosition.TRAILING,
+          OrcaTheme.iconography.share.outlined,
+          contentDescription = stringResource(R.string.platform_ui_toot_preview_share),
+          onClick = onShare,
+          Modifier.testTag(TOOT_PREVIEW_SHARE_ACTION_TAG)
+        )
+      }
+    },
+    onClick,
+    modifier
+  )
 }
 
 @Composable
 private fun TootPreview(
-    avatar: @Composable () -> Unit,
-    name: @Composable () -> Unit,
-    metadata: @Composable () -> Unit,
-    content: @Composable () -> Unit,
-    stats: @Composable () -> Unit,
-    onClick: (() -> Unit)?,
-    modifier: Modifier = Modifier
+  avatar: @Composable () -> Unit,
+  name: @Composable () -> Unit,
+  metadata: @Composable () -> Unit,
+  content: @Composable () -> Unit,
+  stats: @Composable () -> Unit,
+  onClick: (() -> Unit)?,
+  modifier: Modifier = Modifier
 ) {
-    val interactionSource = remember(onClick) {
-        onClick
-            ?.let { IgnoringMutableInteractionSource(HoverInteraction::class) }
-            ?: EmptyMutableInteractionSource()
+  val interactionSource =
+    remember(onClick) {
+      onClick?.let { IgnoringMutableInteractionSource(HoverInteraction::class) }
+        ?: EmptyMutableInteractionSource()
     }
-    val spacing = OrcaTheme.spacings.medium
+  val spacing = OrcaTheme.spacings.medium
 
-    @OptIn(ExperimentalMaterial3Api::class)
-    Card(
-        onClick ?: { },
-        modifier.testTag(TOOT_PREVIEW_TAG),
-        shape = RectangleShape,
-        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
-        interactionSource = interactionSource
-    ) {
-        Column(
-            Modifier.padding(spacing),
-            Arrangement.spacedBy(spacing)
-        ) {
-            Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
-                avatar()
+  @OptIn(ExperimentalMaterial3Api::class)
+  Card(
+    onClick ?: {},
+    modifier.testTag(TOOT_PREVIEW_TAG),
+    shape = RectangleShape,
+    colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+    interactionSource = interactionSource
+  ) {
+    Column(Modifier.padding(spacing), Arrangement.spacedBy(spacing)) {
+      Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+        avatar()
 
-                Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
-                    Column(
-                        verticalArrangement = Arrangement
-                            .spacedBy(OrcaTheme.spacings.extraSmall)
-                    ) {
-                        ProvideTextStyle(OrcaTheme.typography.bodyLarge, name)
-                        ProvideTextStyle(OrcaTheme.typography.bodySmall, metadata)
-                    }
+        Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
+          Column(verticalArrangement = Arrangement.spacedBy(OrcaTheme.spacings.extraSmall)) {
+            ProvideTextStyle(OrcaTheme.typography.bodyLarge, name)
+            ProvideTextStyle(OrcaTheme.typography.bodySmall, metadata)
+          }
 
-                    content()
-                    stats()
-                }
-            }
+          content()
+          stats()
         }
+      }
     }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadingTootPreviewPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            TootPreview()
-        }
-    }
+  OrcaTheme { Surface(color = OrcaTheme.colors.background.container) { TootPreview() } }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadedInactiveTootPreviewPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            TootPreview(TootPreview.sample.copy(isFavorite = false, isReblogged = false))
-        }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) {
+      TootPreview(TootPreview.sample.copy(isFavorite = false, isReblogged = false))
     }
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun LoadedActiveTootPreviewPreview() {
-    OrcaTheme {
-        Surface(color = OrcaTheme.colors.background.container) {
-            TootPreview(TootPreview.sample.copy(isFavorite = true, isReblogged = true))
-        }
+  OrcaTheme {
+    Surface(color = OrcaTheme.colors.background.container) {
+      TootPreview(TootPreview.sample.copy(isFavorite = true, isReblogged = true))
     }
+  }
 }
 
 @Composable
 private fun TootPreview(preview: TootPreview, modifier: Modifier = Modifier) {
-    TootPreview(
-        preview,
-        onHighlightClick = { },
-        onFavorite = { },
-        onReblog = { },
-        onShare = { },
-        onClick = { },
-        modifier
-    )
+  TootPreview(
+    preview,
+    onHighlightClick = {},
+    onFavorite = {},
+    onReblog = {},
+    onShare = {},
+    onClick = {},
+    modifier
+  )
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/headline/HeadlineCard.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/headline/HeadlineCard.kt
@@ -30,68 +30,60 @@ import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
 import com.jeanbarrossilva.orca.std.imageloader.compose.Image
 import com.jeanbarrossilva.orca.std.imageloader.compose.rememberImageLoader
 
-/** Tag that identifies a [HeadlineCard] for testing purposes. **/
+/** Tag that identifies a [HeadlineCard] for testing purposes. */
 const val HEADLINE_CARD_TAG = "headline-card"
 
 @Composable
 fun HeadlineCard(
-    headline: Headline,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    imageLoader: ImageLoader = rememberImageLoader()
+  headline: Headline,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  imageLoader: ImageLoader = rememberImageLoader()
 ) {
-    val shape = OrcaTheme.shapes.large
-    val interactionSource = remember(::MutableInteractionSource)
+  val shape = OrcaTheme.shapes.large
+  val interactionSource = remember(::MutableInteractionSource)
 
-    Hoverable(
-        modifier
-            .border(shape)
-            .clip(shape)
-            .clickable(interactionSource, LocalIndication.current, onClick = onClick)
-            .background(OrcaTheme.colors.surface.container)
-            .testTag(HEADLINE_CARD_TAG)
-    ) {
-        Column {
-            Image(
-                headline.coverURL,
-                contentDescription = stringResource(
-                    R.string.platform_ui_headline_card_cover,
-                    headline.title
-                ),
-                Modifier
-                    .aspectRatio(16f / 9f)
-                    .fillMaxWidth(),
-                imageLoader,
-                contentScale = ContentScale.Crop
-            )
+  Hoverable(
+    modifier
+      .border(shape)
+      .clip(shape)
+      .clickable(interactionSource, LocalIndication.current, onClick = onClick)
+      .background(OrcaTheme.colors.surface.container)
+      .testTag(HEADLINE_CARD_TAG)
+  ) {
+    Column {
+      Image(
+        headline.coverURL,
+        contentDescription =
+          stringResource(R.string.platform_ui_headline_card_cover, headline.title),
+        Modifier.aspectRatio(16f / 9f).fillMaxWidth(),
+        imageLoader,
+        contentScale = ContentScale.Crop
+      )
 
-            Column(
-                Modifier.padding(OrcaTheme.spacings.medium),
-                Arrangement.spacedBy(OrcaTheme.spacings.small)
-            ) {
-                ProvideTextStyle(OrcaTheme.typography.bodyLarge) {
-                    Text(headline.title)
-                }
+      Column(
+        Modifier.padding(OrcaTheme.spacings.medium),
+        Arrangement.spacedBy(OrcaTheme.spacings.small)
+      ) {
+        ProvideTextStyle(OrcaTheme.typography.bodyLarge) { Text(headline.title) }
 
-                headline.subtitle?.let {
-                    ProvideTextStyle(OrcaTheme.typography.bodySmall) {
-                        Text(it, overflow = TextOverflow.Ellipsis, maxLines = 4)
-                    }
-                }
-            }
+        headline.subtitle?.let {
+          ProvideTextStyle(OrcaTheme.typography.bodySmall) {
+            Text(it, overflow = TextOverflow.Ellipsis, maxLines = 4)
+          }
         }
+      }
     }
+  }
 }
 
 @Composable
-internal fun HeadlineCard(modifier: Modifier = Modifier, onClick: () -> Unit = { }) {
-    HeadlineCard(Headline.sample, onClick, modifier)
+internal fun HeadlineCard(modifier: Modifier = Modifier, onClick: () -> Unit = {}) {
+  HeadlineCard(Headline.sample, onClick, modifier)
 }
 
 @Composable
 @MultiThemePreview
 private fun HeadlineCardPreview() {
-    OrcaTheme {
-        HeadlineCard()
-    }
+  OrcaTheme { HeadlineCard() }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/stat/TootPreview.Stat.Favorite.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/stat/TootPreview.Stat.Favorite.kt
@@ -18,54 +18,47 @@ import com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.StatDefaults
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.StatPosition
 import com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.TootPreview
 
-/** Tag that identifies a [TootPreview]'s favorite count stat for testing purposes. **/
+/** Tag that identifies a [TootPreview]'s favorite count stat for testing purposes. */
 const val TOOT_PREVIEW_FAVORITE_STAT_TAG = "toot-preview-favorites-stat"
 
 @Composable
 internal fun FavoriteStat(
-    position: StatPosition,
-    preview: TootPreview,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
+  position: StatPosition,
+  preview: TootPreview,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier
 ) {
-    val isActive = remember(preview) { preview.isFavorite }
+  val isActive = remember(preview) { preview.isFavorite }
 
-    Stat(position, onClick, modifier.testTag(TOOT_PREVIEW_FAVORITE_STAT_TAG)) {
-        val contentColor by animateColorAsState(
-            if (isActive) OrcaTheme.colors.activation.favorite else LocalContentColor.current,
-            label = "ContentColor"
-        )
+  Stat(position, onClick, modifier.testTag(TOOT_PREVIEW_FAVORITE_STAT_TAG)) {
+    val contentColor by
+      animateColorAsState(
+        if (isActive) OrcaTheme.colors.activation.favorite else LocalContentColor.current,
+        label = "ContentColor"
+      )
 
-        FavoriteStatIcon(
-            isActive,
-            ActivateableStatIconInteractiveness.Interactive { onClick() },
-            Modifier.size(StatDefaults.IconSize)
-        )
+    FavoriteStatIcon(
+      isActive,
+      ActivateableStatIconInteractiveness.Interactive { onClick() },
+      Modifier.size(StatDefaults.IconSize)
+    )
 
-        Text(preview.formattedFavoriteCount, color = contentColor)
-    }
+    Text(preview.formattedFavoriteCount, color = contentColor)
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun InactiveFavoriteStatPreview() {
-    OrcaTheme {
-        FavoriteStat(
-            StatPosition.SUBSEQUENT,
-            TootPreview.sample.copy(isFavorite = false),
-            onClick = { }
-        )
-    }
+  OrcaTheme {
+    FavoriteStat(StatPosition.SUBSEQUENT, TootPreview.sample.copy(isFavorite = false), onClick = {})
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun ActiveFavoriteStatPreview() {
-    OrcaTheme {
-        FavoriteStat(
-            StatPosition.SUBSEQUENT,
-            TootPreview.sample.copy(isFavorite = true),
-            onClick = { }
-        )
-    }
+  OrcaTheme {
+    FavoriteStat(StatPosition.SUBSEQUENT, TootPreview.sample.copy(isFavorite = true), onClick = {})
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/stat/TootPreview.Stat.Reblog.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/stat/TootPreview.Stat.Reblog.kt
@@ -20,48 +20,38 @@ import com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.TootPreview
 
 @Composable
 internal fun ReblogStat(
-    position: StatPosition,
-    preview: TootPreview,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
+  position: StatPosition,
+  preview: TootPreview,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier
 ) {
-    val isActive = remember(preview, preview::isReblogged)
+  val isActive = remember(preview, preview::isReblogged)
 
-    Stat(position, onClick, modifier.testTag(TOOT_PREVIEW_REBLOG_COUNT_STAT_TAG)) {
-        val contentColor by animateColorAsState(
-            if (isActive) Color(0xFF81C784) else LocalContentColor.current,
-            label = "ContentColor"
-        )
+  Stat(position, onClick, modifier.testTag(TOOT_PREVIEW_REBLOG_COUNT_STAT_TAG)) {
+    val contentColor by
+      animateColorAsState(
+        if (isActive) Color(0xFF81C784) else LocalContentColor.current,
+        label = "ContentColor"
+      )
 
-        ReblogStatIcon(
-            isActive,
-            ActivateableStatIconInteractiveness.Interactive { onClick() }
-        )
+    ReblogStatIcon(isActive, ActivateableStatIconInteractiveness.Interactive { onClick() })
 
-        Text(preview.formattedReblogCount, color = contentColor)
-    }
+    Text(preview.formattedReblogCount, color = contentColor)
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun InactiveReblogStatPreview() {
-    OrcaTheme {
-        ReblogStat(
-            StatPosition.SUBSEQUENT,
-            TootPreview.sample.copy(isReblogged = false),
-            onClick = { }
-        )
-    }
+  OrcaTheme {
+    ReblogStat(StatPosition.SUBSEQUENT, TootPreview.sample.copy(isReblogged = false), onClick = {})
+  }
 }
 
 @Composable
 @MultiThemePreview
 private fun ActiveReblogStatPreview() {
-    OrcaTheme {
-        ReblogStat(
-            StatPosition.SUBSEQUENT,
-            TootPreview.sample.copy(isReblogged = true),
-            onClick = { }
-        )
-    }
+  OrcaTheme {
+    ReblogStat(StatPosition.SUBSEQUENT, TootPreview.sample.copy(isReblogged = true), onClick = {})
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/time/RelativeTimeProvider.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/time/RelativeTimeProvider.extensions.kt
@@ -3,8 +3,8 @@ package com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.time
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 
-/** [Remember][remember]s a [RelativeTimeProvider]. **/
+/** [Remember][remember]s a [RelativeTimeProvider]. */
 @Composable
 internal fun rememberRelativeTimeProvider(): RelativeTimeProvider {
-    return remember(::Time4JRelativeTimeProvider)
+  return remember(::Time4JRelativeTimeProvider)
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/time/RelativeTimeProvider.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/time/RelativeTimeProvider.kt
@@ -2,12 +2,12 @@ package com.jeanbarrossilva.orca.platform.ui.component.timeline.toot.time
 
 import java.time.ZonedDateTime
 
-/** Provides a relative version of a [ZonedDateTime]. **/
+/** Provides a relative version of a [ZonedDateTime]. */
 abstract class RelativeTimeProvider {
-    /**
-     * Provides the relative version of [dateTime].
-     *
-     * @param dateTime [ZonedDateTime] whose relative version will be provided.
-     **/
-    internal abstract fun provide(dateTime: ZonedDateTime): String
+  /**
+   * Provides the relative version of [dateTime].
+   *
+   * @param dateTime [ZonedDateTime] whose relative version will be provided.
+   */
+  internal abstract fun provide(dateTime: ZonedDateTime): String
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/time/Time4JRelativeTimeProvider.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/component/timeline/toot/time/Time4JRelativeTimeProvider.kt
@@ -6,25 +6,25 @@ import java.util.Locale
 import net.time4j.PrettyTime
 import net.time4j.base.UnixTime
 
-/** [RelativeTimeProvider] that provides relative time with Time4J. **/
+/** [RelativeTimeProvider] that provides relative time with Time4J. */
 internal class Time4JRelativeTimeProvider : RelativeTimeProvider() {
-    override fun provide(dateTime: ZonedDateTime): String {
-        val locale = Locale.getDefault()
-        val unixTime = dateTime.toUnixTime()
-        val timeZoneID = ZoneId.systemDefault().id
-        return PrettyTime.of(locale).printRelative(unixTime, timeZoneID)
-    }
+  override fun provide(dateTime: ZonedDateTime): String {
+    val locale = Locale.getDefault()
+    val unixTime = dateTime.toUnixTime()
+    val timeZoneID = ZoneId.systemDefault().id
+    return PrettyTime.of(locale).printRelative(unixTime, timeZoneID)
+  }
 
-    /** Converts this [ZonedDateTime] into a [UnixTime]. **/
-    private fun ZonedDateTime.toUnixTime(): UnixTime {
-        return object : UnixTime {
-            override fun getPosixTime(): Long {
-                return toEpochSecond()
-            }
+  /** Converts this [ZonedDateTime] into a [UnixTime]. */
+  private fun ZonedDateTime.toUnixTime(): UnixTime {
+    return object : UnixTime {
+      override fun getPosixTime(): Long {
+        return toEpochSecond()
+      }
 
-            override fun getNanosecond(): Int {
-                return nano
-            }
-        }
+      override fun getNanosecond(): Int {
+        return nano
+      }
     }
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/ActivityStarter.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/ActivityStarter.kt
@@ -11,51 +11,44 @@ import kotlin.reflect.KClass
  * @param T [Activity] to be started.
  * @param context [Context] from which the [Activity] will be started.
  * @param activityClass [KClass] of the [Activity].
- **/
-class ActivityStarter<T : Activity> @PublishedApi internal constructor(
-    private val context: Context,
-    private val activityClass: KClass<T>
-) {
-    /** Arguments to be passed to the [Intent]'s [extras][Intent.getExtras]. **/
-    private val args = hashMapOf<String, Any?>()
+ */
+class ActivityStarter<T : Activity>
+@PublishedApi
+internal constructor(private val context: Context, private val activityClass: KClass<T>) {
+  /** Arguments to be passed to the [Intent]'s [extras][Intent.getExtras]. */
+  private val args = hashMapOf<String, Any?>()
 
-    /** [Intent]'s [flags][Intent.getFlags]. **/
-    private var flags = 0
+  /** [Intent]'s [flags][Intent.getFlags]. */
+  private var flags = 0
 
-    /**
-     * Defines the [Activity] as the first task of a new [Activity] group to be created. Useful for
-     * when it isn't started from another [Activity].
-     *
-     * @see Intent.FLAG_ACTIVITY_NEW_TASK
-     **/
-    fun asNewTask(): ActivityStarter<T> {
-        return apply {
-            flags = flags or Intent.FLAG_ACTIVITY_NEW_TASK
-        }
-    }
+  /**
+   * Defines the [Activity] as the first task of a new [Activity] group to be created. Useful for
+   * when it isn't started from another [Activity].
+   *
+   * @see Intent.FLAG_ACTIVITY_NEW_TASK
+   */
+  fun asNewTask(): ActivityStarter<T> {
+    return apply { flags = flags or Intent.FLAG_ACTIVITY_NEW_TASK }
+  }
 
-    /**
-     * Defines the arguments to be passed to the [Intent]'s [extras][Intent.getExtras].
-     *
-     * @param args Key-value [Pair]s representing the arguments for the [Activity].
-     **/
-    fun with(vararg args: Pair<String, Any?>): ActivityStarter<T> {
-        return apply {
-            args.forEach {
-                this.args[it.first] = it.second
-            }
-        }
-    }
+  /**
+   * Defines the arguments to be passed to the [Intent]'s [extras][Intent.getExtras].
+   *
+   * @param args Key-value [Pair]s representing the arguments for the [Activity].
+   */
+  fun with(vararg args: Pair<String, Any?>): ActivityStarter<T> {
+    return apply { args.forEach { this.args[it.first] = it.second } }
+  }
 
-    /**
-     * Starts the [Activity].
-     *
-     * @see Context.startActivity
-     **/
-    fun start() {
-        val argsAsArray = args.map { (key, value) -> key to value }.toTypedArray()
-        val extras = bundleOf(*argsAsArray)
-        val intent = Intent(context, activityClass.java).putExtras(extras).addFlags(flags)
-        context.startActivity(intent)
-    }
+  /**
+   * Starts the [Activity].
+   *
+   * @see Context.startActivity
+   */
+  fun start() {
+    val argsAsArray = args.map { (key, value) -> key to value }.toTypedArray()
+    val extras = bundleOf(*argsAsArray)
+    val intent = Intent(context, activityClass.java).putExtras(extras).addFlags(flags)
+    context.startActivity(intent)
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Bundle.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Bundle.extensions.kt
@@ -8,9 +8,9 @@ import androidx.core.os.bundleOf
  *
  * @param pairs Elements to be put into the resulting [Bundle].
  * @return [Bundle], or `null` if [pairs] is empty.
- **/
+ */
 @PublishedApi
 internal fun bundleOf(vararg pairs: Pair<String, Any?>): Bundle? {
-    val hasArgs = pairs.isNotEmpty()
-    return if (hasArgs) bundleOf(*pairs) else null
+  val hasArgs = pairs.isNotEmpty()
+  return if (hasArgs) bundleOf(*pairs) else null
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Context.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Context.extensions.kt
@@ -11,18 +11,18 @@ import java.net.URL
  *
  * @param T [Activity] whose start-up may be configured.
  * @see ActivityStarter.start
- **/
+ */
 inline fun <reified T : Activity> Context.on(): ActivityStarter<T> {
-    return ActivityStarter(this, T::class)
+  return ActivityStarter(this, T::class)
 }
 
 /**
  * Browses to the [url].
  *
  * @param url [URL] to browse to.
- **/
+ */
 fun Context.browseTo(url: URL) {
-    val uri = Uri.parse("$url")
-    val intent = Intent(Intent.ACTION_VIEW, uri).apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK }
-    startActivity(intent)
+  val uri = Uri.parse("$url")
+  val intent = Intent(Intent.ACTION_VIEW, uri).apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK }
+  startActivity(intent)
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Flow.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Flow.extensions.kt
@@ -14,9 +14,9 @@ import kotlinx.coroutines.flow.runningFold
  * receive an emission.
  *
  * @param transform Transformation to be made to the currently iterated element.
- **/
+ */
 fun <I, O> Flow<Collection<I>>.flatMapEach(transform: suspend (I) -> Flow<O>): Flow<List<O>> {
-    return flatMapEach(selector = { it }, transform)
+  return flatMapEach(selector = { it }, transform)
 }
 
 /**
@@ -26,29 +26,25 @@ fun <I, O> Flow<Collection<I>>.flatMapEach(transform: suspend (I) -> Flow<O>): F
  *
  * @param selector Returns the value by which elements should be compared when replacing them.
  * @param transform Transformation to be made to the currently iterated element.
- **/
+ */
 @OptIn(ExperimentalCoroutinesApi::class)
 fun <I, O, S> Flow<Collection<I>>.flatMapEach(
-    selector: (O) -> S,
-    transform: suspend (I) -> Flow<O>
+  selector: (O) -> S,
+  transform: suspend (I) -> Flow<O>
 ): Flow<List<O>> {
-    return mapEach(transform).flatMapLatest { flows ->
-        flows.merge().runningFold(emptyReplacementList(selector)) { accumulator, element ->
-            accumulator.add(element)
-            accumulator
-        }
+  return mapEach(transform).flatMapLatest { flows ->
+    flows.merge().runningFold(emptyReplacementList(selector)) { accumulator, element ->
+      accumulator.add(element)
+      accumulator
     }
+  }
 }
 
 /**
  * Maps each element of the emitted [Collection]s to the result of [transform].
  *
  * @param transform Transformation to be made to the currently iterated element.
- **/
+ */
 fun <I, O> Flow<Collection<I>>.mapEach(transform: suspend (I) -> O): Flow<List<O>> {
-    return map { elements ->
-        elements.map { element ->
-            transform(element)
-        }
-    }
+  return map { elements -> elements.map { element -> transform(element) } }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/FocusRequester.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/FocusRequester.extensions.kt
@@ -4,8 +4,8 @@ import androidx.compose.ui.focus.FocusRequester
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 
-/** Requests focus with an initial delay. **/
+/** Requests focus with an initial delay. */
 suspend fun FocusRequester.requestFocusWithDelay() {
-    delay(256.milliseconds)
-    requestFocus()
+  delay(256.milliseconds)
+  requestFocus()
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Fragment.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Fragment.extensions.kt
@@ -7,21 +7,21 @@ import androidx.fragment.app.Fragment
  * [Application] to which this [Fragment] is attached.
  *
  * @throws IllegalStateException If it's not attached.
- **/
+ */
 val Fragment.application
-    get() = activity?.application ?: throw IllegalStateException(
-        "Fragment $this not attached to an Application."
-    )
+  get() =
+    activity?.application
+      ?: throw IllegalStateException("Fragment $this not attached to an Application.")
 
 /**
  * Gets the argument put with the given [key] lazily.
  *
  * @param key Key to which the argument is associated.
  * @throws ClassCastException If the argument is present but isn't a [T].
- **/
+ */
 fun <T> Fragment.argument(key: String): Lazy<T> {
-    return lazy {
-        @Suppress("DEPRECATION", "UNCHECKED_CAST")
-        requireArguments().get(key) as T
-    }
+  return lazy {
+    @Suppress("DEPRECATION", "UNCHECKED_CAST")
+    requireArguments().get(key) as T
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Intent.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/Intent.extensions.kt
@@ -9,10 +9,10 @@ import android.os.Bundle
  * Puts [extras] into this [Intent] if it isn't `null`.
  *
  * @param extras Extras [Bundle] to be put.
- **/
+ */
 @PublishedApi
 internal fun Intent.putExtras(extras: Bundle?): Intent {
-    return extras?.let(::putExtras) ?: this
+  return extras?.let(::putExtras) ?: this
 }
 
 /**
@@ -21,24 +21,24 @@ internal fun Intent.putExtras(extras: Bundle?): Intent {
  * @param context [Context] to create the [Intent] with.
  * @param args Arguments to be passed to the [Intent]'s [extras][Intent.getExtras].
  * @see Context.startActivity
- **/
+ */
 inline fun <reified T : Activity> Intent(
-    context: Context,
-    vararg args: Pair<String, Any?>
+  context: Context,
+  vararg args: Pair<String, Any?>
 ): Intent {
-    val extras = bundleOf(*args)
-    return Intent(context, T::class.java).apply { putExtras(extras) }
+  val extras = bundleOf(*args)
+  return Intent(context, T::class.java).apply { putExtras(extras) }
 }
 
 /**
  * [Intent] that allows the user to share the [text] externally.
  *
  * @param text Content to be shared.
- **/
+ */
 fun Intent(text: String): Intent {
-    return Intent(Intent.ACTION_SEND).apply {
-        flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        type = "text/plain"
-        putExtra(Intent.EXTRA_TEXT, text)
-    }
+  return Intent(Intent.ACTION_SEND).apply {
+    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+    type = "text/plain"
+    putExtra(Intent.EXTRA_TEXT, text)
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/composable/ComposableActivity.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/composable/ComposableActivity.kt
@@ -12,18 +12,13 @@ import com.jeanbarrossilva.orca.platform.ui.core.lifecycle.CompleteLifecycleActi
  * [Activity] that shows [Composable] content.
  *
  * @see Content
- **/
+ */
 abstract class ComposableActivity : CompleteLifecycleActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContent {
-            OrcaTheme {
-                Content()
-            }
-        }
-    }
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { OrcaTheme { Content() } }
+  }
 
-    /** Content to be shown inside the [ComposeView]. **/
-    @Composable
-    protected abstract fun Content()
+  /** Content to be shown inside the [ComposeView]. */
+  @Composable protected abstract fun Content()
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/composable/ComposableFragment.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/composable/ComposableFragment.kt
@@ -13,25 +13,18 @@ import com.jeanbarrossilva.orca.platform.theme.OrcaTheme
  * [Fragment] that shows [Composable][Composable] content.
  *
  * @see Content
- **/
+ */
 abstract class ComposableFragment : Fragment() {
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        return context?.let {
-            ComposeView(it).apply {
-                setContent {
-                    OrcaTheme {
-                        this@ComposableFragment.Content()
-                    }
-                }
-            }
-        }
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
+    return context?.let {
+      ComposeView(it).apply { setContent { OrcaTheme { this@ComposableFragment.Content() } } }
     }
+  }
 
-    /** Content to be shown inside the [ComposeView].  **/
-    @Composable
-    protected abstract fun Content()
+  /** Content to be shown inside the [ComposeView]. */
+  @Composable protected abstract fun Content()
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/context/Context.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/context/Context.extensions.kt
@@ -7,8 +7,8 @@ import com.jeanbarrossilva.orca.platform.ui.core.Intent
  * Opens the share sheet so that the [text] can be shared.
  *
  * @param text Text to be shared.
- **/
+ */
 fun Context.share(text: String) {
-    val intent = Intent(text)
-    startActivity(intent)
+  val intent = Intent(text)
+  startActivity(intent)
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/context/ContextProvider.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/context/ContextProvider.kt
@@ -2,8 +2,8 @@ package com.jeanbarrossilva.orca.platform.ui.core.context
 
 import android.content.Context
 
-/** Provides a [Context] through [provide]. **/
+/** Provides a [Context] through [provide]. */
 fun interface ContextProvider {
-    /** Provides a [Context]. **/
-    fun provide(): Context
+  /** Provides a [Context]. */
+  fun provide(): Context
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/lifecycle/CompleteLifecycleActivity.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/lifecycle/CompleteLifecycleActivity.kt
@@ -13,87 +13,87 @@ import com.jeanbarrossilva.orca.platform.ui.core.lifecycle.state.next
  * [stopped][CompleteLifecycleState.STOPPED] ones.
  *
  * @see CompleteLifecycleState
- **/
+ */
 open class CompleteLifecycleActivity : ComponentActivity() {
-    /** [CompleteLifecycleState] in which this [CompleteLifecycleActivity] currently is. **/
-    var completeLifecycleState: CompleteLifecycleState? = null
-        private set
+  /** [CompleteLifecycleState] in which this [CompleteLifecycleActivity] currently is. */
+  var completeLifecycleState: CompleteLifecycleState? = null
+    private set
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        completeLifecycleState = CompleteLifecycleState.CREATED
-        super.onCreate(savedInstanceState)
-    }
+  override fun onCreate(savedInstanceState: Bundle?) {
+    completeLifecycleState = CompleteLifecycleState.CREATED
+    super.onCreate(savedInstanceState)
+  }
 
-    override fun onStart() {
-        completeLifecycleState = CompleteLifecycleState.STARTED
-        super.onStart()
-    }
+  override fun onStart() {
+    completeLifecycleState = CompleteLifecycleState.STARTED
+    super.onStart()
+  }
 
-    override fun onResume() {
-        completeLifecycleState = CompleteLifecycleState.RESUMED
-        super.onResume()
-    }
+  override fun onResume() {
+    completeLifecycleState = CompleteLifecycleState.RESUMED
+    super.onResume()
+  }
 
-    override fun finish() {
-        sideEffectlesslyMoveTo(CompleteLifecycleState.STOPPED)
-        super.finish()
-        completeLifecycleState = CompleteLifecycleState.DESTROYED
-    }
+  override fun finish() {
+    sideEffectlesslyMoveTo(CompleteLifecycleState.STOPPED)
+    super.finish()
+    completeLifecycleState = CompleteLifecycleState.DESTROYED
+  }
 
-    override fun onPause() {
-        completeLifecycleState = CompleteLifecycleState.PAUSED
-        super.onPause()
-    }
+  override fun onPause() {
+    completeLifecycleState = CompleteLifecycleState.PAUSED
+    super.onPause()
+  }
 
-    override fun onStop() {
-        completeLifecycleState = CompleteLifecycleState.STOPPED
-        super.onStop()
-    }
+  override fun onStop() {
+    completeLifecycleState = CompleteLifecycleState.STOPPED
+    super.onStop()
+  }
 
-    override fun onDestroy() {
-        completeLifecycleState = CompleteLifecycleState.DESTROYED
-        super.onDestroy()
-    }
+  override fun onDestroy() {
+    completeLifecycleState = CompleteLifecycleState.DESTROYED
+    super.onDestroy()
+  }
 
-    /** Calls [onStart]. **/
-    internal fun callOnStart() {
-        onStart()
-    }
+  /** Calls [onStart]. */
+  internal fun callOnStart() {
+    onStart()
+  }
 
-    /** Calls [onPause]. **/
-    internal fun callOnPause() {
-        onPause()
-    }
+  /** Calls [onPause]. */
+  internal fun callOnPause() {
+    onPause()
+  }
 
-    /** Calls [onStop]. **/
-    internal fun callOnStop() {
-        onStop()
-    }
+  /** Calls [onStop]. */
+  internal fun callOnStop() {
+    onStop()
+  }
 
-    /**
-     * Iteratively moves [completeLifecycleState] to the given [state].
-     *
-     * **NOTE**: Currently only works if we're moving _toward_ the [state]; if [state] is a
-     * [CompleteLifecycleState] before [completeLifecycleState], nothing will be done.
-     *
-     * @param state [CompleteLifecycleState] to which [completeLifecycleState] will be moved.
-     **/
-    private fun sideEffectlesslyMoveTo(
-        @Suppress("SameParameterValue") state: CompleteLifecycleState
-    ) {
-        var current = completeLifecycleState
-        if (current < state) {
-            while (current != state) {
-                /*
-                 * The only scenario in which this call would return null is when both the
-                 * completeLifecycleState and the state we are moving to are
-                 * CompleteLifecycleState.DESTROYED.
-                 *
-                 * Since we've already ensured that the current one and the one we want to move to
-                 * are not the same, it is safe to null-assert.
-                 */
-                current = current.next()!!
-            }
-        }
+  /**
+   * Iteratively moves [completeLifecycleState] to the given [state].
+   *
+   * **NOTE**: Currently only works if we're moving _toward_ the [state]; if [state] is a
+   * [CompleteLifecycleState] before [completeLifecycleState], nothing will be done.
+   *
+   * @param state [CompleteLifecycleState] to which [completeLifecycleState] will be moved.
+   */
+  private fun sideEffectlesslyMoveTo(
+    @Suppress("SameParameterValue") state: CompleteLifecycleState
+  ) {
+    var current = completeLifecycleState
+    if (current < state) {
+      while (current != state) {
+        /*
+         * The only scenario in which this call would return null is when both the
+         * completeLifecycleState and the state we are moving to are
+         * CompleteLifecycleState.DESTROYED.
+         *
+         * Since we've already ensured that the current one and the one we want to move to
+         * are not the same, it is safe to null-assert.
+         */
+        current = current.next()!!
+      }
     }
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/lifecycle/state/CompleteLifecycleState.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/lifecycle/state/CompleteLifecycleState.extensions.kt
@@ -5,24 +5,24 @@ package com.jeanbarrossilva.orca.platform.ui.core.lifecycle.state
  * considered to be less than [other].
  *
  * @param other [CompleteLifecycleState] to compare this one with.
- **/
+ */
 infix operator fun CompleteLifecycleState?.compareTo(other: CompleteLifecycleState): Int {
-    return this?.compareTo(other) ?: -1
+  return this?.compareTo(other) ?: -1
 }
 
 /**
  * Whether this [CompleteLifecycleState] equals to or is greater than the given [state].
  *
  * @param state [CompleteLifecycleState] to compare this one with.
- **/
+ */
 fun CompleteLifecycleState?.isAtLeast(state: CompleteLifecycleState): Boolean {
-    return this != null && compareTo(state) >= 0
+  return this != null && compareTo(state) >= 0
 }
 
 /**
  * Provides the [CompleteLifecycleState] that succeeds this one; if it's `null`, provides the
  * [created][CompleteLifecycleState.CREATED] [CompleteLifecycleState].
- **/
+ */
 internal fun CompleteLifecycleState?.next(): CompleteLifecycleState? {
-    return if (this == null) CompleteLifecycleState.CREATED else next()
+  return if (this == null) CompleteLifecycleState.CREATED else next()
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/lifecycle/state/CompleteLifecycleState.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/lifecycle/state/CompleteLifecycleState.kt
@@ -3,32 +3,32 @@ package com.jeanbarrossilva.orca.platform.ui.core.lifecycle.state
 import android.app.Activity
 import androidx.lifecycle.Lifecycle
 
-/** Complete analogue of [Lifecycle.State]. **/
+/** Complete analogue of [Lifecycle.State]. */
 enum class CompleteLifecycleState {
-    /** Equivalent to [Lifecycle.State.CREATED]. **/
-    CREATED,
+  /** Equivalent to [Lifecycle.State.CREATED]. */
+  CREATED,
 
-    /** Equivalent to [Lifecycle.State.STARTED]. **/
-    STARTED,
+  /** Equivalent to [Lifecycle.State.STARTED]. */
+  STARTED,
 
-    /** Equivalent to [Lifecycle.State.RESUMED]. **/
-    RESUMED,
+  /** Equivalent to [Lifecycle.State.RESUMED]. */
+  RESUMED,
 
-    /**
-     * State in which an [Activity] is put whenever it's moved to the background while a new
-     * one is started.
-     **/
-    PAUSED,
+  /**
+   * State in which an [Activity] is put whenever it's moved to the background while a new one is
+   * started.
+   */
+  PAUSED,
 
-    /** State in which an [Activity] is not visible to the user. **/
-    STOPPED,
+  /** State in which an [Activity] is not visible to the user. */
+  STOPPED,
 
-    /** Equivalent to [Lifecycle.State.DESTROYED]. **/
-    DESTROYED;
+  /** Equivalent to [Lifecycle.State.DESTROYED]. */
+  DESTROYED;
 
-    /** Provides the [CompleteLifecycleState] that succeeds this one. **/
-    internal fun next(): CompleteLifecycleState? {
-        val index = values().indexOf(this) + 1
-        return values().getOrNull(index)
-    }
+  /** Provides the [CompleteLifecycleState] that succeeds this one. */
+  internal fun next(): CompleteLifecycleState? {
+    val index = values().indexOf(this) + 1
+    return values().getOrNull(index)
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/NavigationActivity.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/NavigationActivity.kt
@@ -5,21 +5,21 @@ import android.view.ViewGroup
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentContainerView
 
-/** [FragmentActivity] through which [Navigator]-based navigation can be performed. **/
+/** [FragmentActivity] through which [Navigator]-based navigation can be performed. */
 open class NavigationActivity : FragmentActivity() {
-    /**
-     * [Navigator] through which navigation can be performed.
-     *
-     * **NOTE**: Because the [FragmentContainerView] that this [NavigationActivity] holds needs to
-     * have an ID for the [Navigator] to work properly, one is automatically generated and assigned
-     * to it if it doesn't already have one.
-     *
-     * @throws IllegalStateException If a [FragmentContainerView] is not found within the [View]
-     * tree.
-     **/
-    val navigator
-        get() = requireViewById<ViewGroup>(android.R.id.content)
-            .get<FragmentContainerView>(isInclusive = false)
-            .also(View::identify)
-            .let { Navigator(supportFragmentManager, it.id) }
+  /**
+   * [Navigator] through which navigation can be performed.
+   *
+   * **NOTE**: Because the [FragmentContainerView] that this [NavigationActivity] holds needs to
+   * have an ID for the [Navigator] to work properly, one is automatically generated and assigned to
+   * it if it doesn't already have one.
+   *
+   * @throws IllegalStateException If a [FragmentContainerView] is not found within the [View] tree.
+   */
+  val navigator
+    get() =
+      requireViewById<ViewGroup>(android.R.id.content)
+        .get<FragmentContainerView>(isInclusive = false)
+        .also(View::identify)
+        .let { Navigator(supportFragmentManager, it.id) }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/Navigator.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/Navigator.kt
@@ -15,96 +15,96 @@ import com.jeanbarrossilva.orca.platform.ui.core.navigation.transition.Transitio
  *
  * @param fragmentManager [FragmentManager] that adds [Fragment]s to the [FragmentContainerView].
  * @param containerID ID of the [FragmentContainerView] to which [Fragment]s will be added.
- **/
-class Navigator internal constructor(
-    private val fragmentManager: FragmentManager,
-    @IdRes private val containerID: Int
+ */
+class Navigator
+internal constructor(
+  private val fragmentManager: FragmentManager,
+  @IdRes private val containerID: Int
 ) {
+  /**
+   * Defines the [Destination.Provider] that will provide the [Fragment] destination through [to].
+   */
+  class Navigation<T : Fragment> internal constructor() {
     /**
-     * Defines the [Destination.Provider] that will provide the [Fragment] destination through [to].
-     **/
-    class Navigation<T : Fragment> internal constructor() {
-        /**
-         * Target navigation site.
-         *
-         * @param T [Fragment] to be navigated to.
-         * @param route Path by which the [target] can be retrieved.
-         * @param target Returns the [Fragment] of this [Destination].
-         **/
-        data class Destination<T : Fragment>(val route: String, val target: () -> T) {
-            /**
-             * Provides the [Destination] to navigate to through [provide]. Can be instantiated via
-             * [to].
-             *
-             * @param T [Fragment] to navigate to.
-             **/
-            abstract class Provider<T : Fragment> internal constructor() {
-                /** Provides the [Destination] to navigate to. **/
-                internal abstract fun provide(): Destination<T>
-            }
-        }
-
-        /**
-         * Creates a [Destination.Provider].
-         *
-         * @param route Path by which the result of [target] can be retrieved.
-         * @param target Returns the [Fragment] to navigate to.
-         **/
-        fun to(route: String, target: () -> T): Destination.Provider<T> {
-            return object : Destination.Provider<T>() {
-                override fun provide(): Destination<T> {
-                    return Destination(route, target)
-                }
-            }
-        }
-    }
-
-    /**
-     * Navigates to the [Fragment] destination provided by the result of [navigation].
+     * Target navigation site.
      *
-     * @param T [Fragment] to navigate to.
-     * @param transition [Transition] with which the navigation will be animated.
-     * @param duplication Indicates whether the navigation should be performed even if the current
-     * [Navigation.Destination]'s and that of the provided by the result of [navigation] are the
-     * same.
-     * @param navigation Defines where to navigate to.
-     * @see allowingDuplication
-     * @see disallowingDuplication
-     * @see Navigation.to
-     **/
-    fun <T : Fragment> navigate(
-        transition: Transition,
-        duplication: Duplication = allowingDuplication(),
-        navigation: Navigation<T>.() -> Navigation.Destination.Provider<T>
-    ) {
-        val previousRoute = fragmentManager.fragments.lastOrNull()?.tag
-        val destination = Navigation<T>().navigation().provide()
-        val canNavigate = duplication.canNavigate(previousRoute, currentRoute = destination.route)
-        if (canNavigate) {
-            unconditionallyNavigate(transition, destination)
-        }
-    }
-
-    /** Pops the back stack. **/
-    fun pop() {
-        fragmentManager.popBackStack()
+     * @param T [Fragment] to be navigated to.
+     * @param route Path by which the [target] can be retrieved.
+     * @param target Returns the [Fragment] of this [Destination].
+     */
+    data class Destination<T : Fragment>(val route: String, val target: () -> T) {
+      /**
+       * Provides the [Destination] to navigate to through [provide]. Can be instantiated via [to].
+       *
+       * @param T [Fragment] to navigate to.
+       */
+      abstract class Provider<T : Fragment> internal constructor() {
+        /** Provides the [Destination] to navigate to. */
+        internal abstract fun provide(): Destination<T>
+      }
     }
 
     /**
-     * Navigates to the [destination] without checking if we're allowed to do so.
+     * Creates a [Destination.Provider].
      *
-     * @param transition [Transition] with which the navigation will be animated.
-     * @param destination [Navigation.Destination] to navigate to.
-     **/
-    private fun unconditionallyNavigate(
-        transition: Transition,
-        destination: Navigation.Destination<*>
-    ) {
-        fragmentManager.commit(allowStateLoss = true) {
-            addToBackStack(null)
-            setTransition(transition.value)
-            add(containerID, destination.target(), destination.route)
+     * @param route Path by which the result of [target] can be retrieved.
+     * @param target Returns the [Fragment] to navigate to.
+     */
+    fun to(route: String, target: () -> T): Destination.Provider<T> {
+      return object : Destination.Provider<T>() {
+        override fun provide(): Destination<T> {
+          return Destination(route, target)
         }
-        fragmentManager.executePendingTransactions()
+      }
     }
+  }
+
+  /**
+   * Navigates to the [Fragment] destination provided by the result of [navigation].
+   *
+   * @param T [Fragment] to navigate to.
+   * @param transition [Transition] with which the navigation will be animated.
+   * @param duplication Indicates whether the navigation should be performed even if the current
+   *   [Navigation.Destination]'s and that of the provided by the result of [navigation] are the
+   *   same.
+   * @param navigation Defines where to navigate to.
+   * @see allowingDuplication
+   * @see disallowingDuplication
+   * @see Navigation.to
+   */
+  fun <T : Fragment> navigate(
+    transition: Transition,
+    duplication: Duplication = allowingDuplication(),
+    navigation: Navigation<T>.() -> Navigation.Destination.Provider<T>
+  ) {
+    val previousRoute = fragmentManager.fragments.lastOrNull()?.tag
+    val destination = Navigation<T>().navigation().provide()
+    val canNavigate = duplication.canNavigate(previousRoute, currentRoute = destination.route)
+    if (canNavigate) {
+      unconditionallyNavigate(transition, destination)
+    }
+  }
+
+  /** Pops the back stack. */
+  fun pop() {
+    fragmentManager.popBackStack()
+  }
+
+  /**
+   * Navigates to the [destination] without checking if we're allowed to do so.
+   *
+   * @param transition [Transition] with which the navigation will be animated.
+   * @param destination [Navigation.Destination] to navigate to.
+   */
+  private fun unconditionallyNavigate(
+    transition: Transition,
+    destination: Navigation.Destination<*>
+  ) {
+    fragmentManager.commit(allowStateLoss = true) {
+      addToBackStack(null)
+      setTransition(transition.value)
+      add(containerID, destination.target(), destination.route)
+    }
+    fragmentManager.executePendingTransactions()
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/View.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/View.extensions.kt
@@ -9,49 +9,45 @@ import kotlin.reflect.KClass
  * Verifies if this [View]'s (if [isInclusive]) or one of its children's type is equal to [T] and
  * then returns it if it is.
  *
- * This method is run recursively on each child if it's a [ViewGroup] and continues to
- * do so if a child's child is a [ViewGroup], until either the [View] we're searching for is found
- * or none is found at all, in which case an [IllegalStateException] is thrown.
+ * This method is run recursively on each child if it's a [ViewGroup] and continues to do so if a
+ * child's child is a [ViewGroup], until either the [View] we're searching for is found or none is
+ * found at all, in which case an [IllegalStateException] is thrown.
  *
  * @param T [View] to be found.
  * @param isInclusive Whether this [View] should be taken into account in the search and returned if
- * its type matches [T].
+ *   its type matches [T].
  * @throws IllegalStateException If no matching [View] is found.
- **/
+ */
 internal inline fun <reified T : View> View.get(isInclusive: Boolean = true): T {
-    return get(T::class, isInclusive)
+  return get(T::class, isInclusive)
 }
 
-/** Assigns a generated ID to this [View] if it doesn't already have one. **/
+/** Assigns a generated ID to this [View] if it doesn't already have one. */
 internal fun View.identify() {
-    if (id == View.NO_ID) {
-        id = View.generateViewId()
-    }
+  if (id == View.NO_ID) {
+    id = View.generateViewId()
+  }
 }
 
 /**
  * Verifies if this [View]'s (if [isInclusive]) or one of its children's [KClass] equal to the given
  * [viewClass].
  *
- * This method is run recursively on each child if it's a [ViewGroup] and continues to
- * do so if a child's child is a [ViewGroup], until either the [View] we're searching for is found
- * or none is found at all, in which case an [IllegalStateException] is thrown.
+ * This method is run recursively on each child if it's a [ViewGroup] and continues to do so if a
+ * child's child is a [ViewGroup], until either the [View] we're searching for is found or none is
+ * found at all, in which case an [IllegalStateException] is thrown.
  *
  * @param T [View] to be found.
  * @param viewClass [KClass] of the [View] to be found.
  * @param isInclusive Whether this [View] should be taken into account in the search and returned if
- * its [KClass] matches the [viewClass].
+ *   its [KClass] matches the [viewClass].
  * @throws IllegalStateException If no matching [View] is found.
- **/
+ */
 private fun <T : View> View.get(viewClass: KClass<T>, isInclusive: Boolean): T {
-    @Suppress("UNCHECKED_CAST")
-    return when {
-        isInclusive && this::class == viewClass ->
-            this as T
-        this is ViewGroup ->
-            children.firstNotNullOfOrNull { it.get(viewClass, isInclusive = true) }
-        else ->
-            null
-    }
-        ?: throw IllegalStateException("No ${viewClass.simpleName} found from $this.")
+  @Suppress("UNCHECKED_CAST")
+  return when {
+    isInclusive && this::class == viewClass -> this as T
+    this is ViewGroup -> children.firstNotNullOfOrNull { it.get(viewClass, isInclusive = true) }
+    else -> null
+  } ?: throw IllegalStateException("No ${viewClass.simpleName} found from $this.")
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/duplication/Duplication.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/duplication/Duplication.extensions.kt
@@ -1,11 +1,11 @@
 package com.jeanbarrossilva.orca.platform.ui.core.navigation.duplication
 
-/** Indicates that duplicate navigation is allowed. **/
+/** Indicates that duplicate navigation is allowed. */
 fun allowingDuplication(): Duplication {
-    return Duplication.Allowed
+  return Duplication.Allowed
 }
 
-/** Indicates that duplicate navigation is disallowed. **/
+/** Indicates that duplicate navigation is disallowed. */
 fun disallowingDuplication(): Duplication {
-    return Duplication.Disallowed
+  return Duplication.Disallowed
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/duplication/Duplication.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/duplication/Duplication.kt
@@ -2,27 +2,27 @@ package com.jeanbarrossilva.orca.platform.ui.core.navigation.duplication
 
 import com.jeanbarrossilva.orca.platform.ui.core.navigation.Navigator
 
-/** Indicates the approval or lack thereof of duplicate navigation. **/
+/** Indicates the approval or lack thereof of duplicate navigation. */
 sealed class Duplication {
-    /** Indicates that duplicate navigation is disallowed. **/
-    internal object Disallowed : Duplication() {
-        override fun canNavigate(previousRoute: String?, currentRoute: String): Boolean {
-            return previousRoute == null || currentRoute != previousRoute
-        }
+  /** Indicates that duplicate navigation is disallowed. */
+  internal object Disallowed : Duplication() {
+    override fun canNavigate(previousRoute: String?, currentRoute: String): Boolean {
+      return previousRoute == null || currentRoute != previousRoute
     }
+  }
 
-    /** Indicates that duplicate navigation is allowed. **/
-    internal object Allowed : Duplication() {
-        override fun canNavigate(previousRoute: String?, currentRoute: String): Boolean {
-            return true
-        }
+  /** Indicates that duplicate navigation is allowed. */
+  internal object Allowed : Duplication() {
+    override fun canNavigate(previousRoute: String?, currentRoute: String): Boolean {
+      return true
     }
+  }
 
-    /**
-     * Determines whether navigation can be performed.
-     *
-     * @param previousRoute Route of the previous [Navigator.Navigation.Destination].
-     * @param currentRoute Route to which navigation has been requested.
-     **/
-    internal abstract fun canNavigate(previousRoute: String?, currentRoute: String): Boolean
+  /**
+   * Determines whether navigation can be performed.
+   *
+   * @param previousRoute Route of the previous [Navigator.Navigation.Destination].
+   * @param currentRoute Route to which navigation has been requested.
+   */
+  internal abstract fun canNavigate(previousRoute: String?, currentRoute: String): Boolean
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/transition/Transition.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/transition/Transition.extensions.kt
@@ -2,17 +2,17 @@ package com.jeanbarrossilva.orca.platform.ui.core.navigation.transition
 
 import androidx.fragment.app.FragmentTransaction
 
-/** Creates a close [Transition]. **/
+/** Creates a close [Transition]. */
 fun closing(): Transition {
-    return Transition(FragmentTransaction.TRANSIT_FRAGMENT_CLOSE)
+  return Transition(FragmentTransaction.TRANSIT_FRAGMENT_CLOSE)
 }
 
-/** Creates an open [Transition]. **/
+/** Creates an open [Transition]. */
 fun opening(): Transition {
-    return Transition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
+  return Transition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
 }
 
-/** Creates a sudden [Transition]. **/
+/** Creates a sudden [Transition]. */
 fun suddenly(): Transition {
-    return Transition(FragmentTransaction.TRANSIT_NONE)
+  return Transition(FragmentTransaction.TRANSIT_NONE)
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/transition/Transition.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/navigation/transition/Transition.kt
@@ -6,17 +6,17 @@ import androidx.fragment.app.FragmentTransaction
  * Indicates how navigation from one destination to another will transition.
  *
  * @param value [FragmentTransaction]-related value that's equivalent to this [Transition].
- **/
+ */
 @JvmInline
 value class Transition internal constructor(internal val value: Int) {
-    init {
-        require(
-            value == FragmentTransaction.TRANSIT_NONE ||
-                value == FragmentTransaction.TRANSIT_FRAGMENT_FADE ||
-                value == FragmentTransaction.TRANSIT_FRAGMENT_OPEN ||
-                value == FragmentTransaction.TRANSIT_FRAGMENT_CLOSE
-        ) {
-            "Unknown value: $value."
-        }
+  init {
+    require(
+      value == FragmentTransaction.TRANSIT_NONE ||
+        value == FragmentTransaction.TRANSIT_FRAGMENT_FADE ||
+        value == FragmentTransaction.TRANSIT_FRAGMENT_OPEN ||
+        value == FragmentTransaction.TRANSIT_FRAGMENT_CLOSE
+    ) {
+      "Unknown value: $value."
     }
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/replacement/ReplacementList.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/replacement/ReplacementList.extensions.kt
@@ -1,30 +1,26 @@
 package com.jeanbarrossilva.orca.platform.ui.core.replacement
 
-/** Creates an empty [ReplacementList]. **/
+/** Creates an empty [ReplacementList]. */
 internal fun <T> emptyReplacementList(): ReplacementList<T, T> {
-    return ReplacementList(mutableListOf()) {
-        it
-    }
+  return ReplacementList(mutableListOf()) { it }
 }
 
 /**
  * Creates an empty [ReplacementList].
  *
  * @param selector Returns the value by which elements should be compared when replacing them.
- **/
+ */
 internal fun <I, O> emptyReplacementList(selector: (I) -> O): ReplacementList<I, O> {
-    return ReplacementList(mutableListOf(), selector)
+  return ReplacementList(mutableListOf(), selector)
 }
 
 /**
  * Creates a [ReplacementList] with the given [elements].
  *
  * @param elements Elements to be added to the [ReplacementList].
- **/
+ */
 internal fun <T> replacementListOf(vararg elements: T): ReplacementList<T, T> {
-    return ReplacementList(mutableListOf(*elements)) {
-        it
-    }
+  return ReplacementList(mutableListOf(*elements)) { it }
 }
 
 /**
@@ -32,8 +28,10 @@ internal fun <T> replacementListOf(vararg elements: T): ReplacementList<T, T> {
  *
  * @param elements Elements to be added to the [ReplacementList].
  * @param selector Returns the value by which elements should be compared when replacing them.
- **/
-internal fun <I, O> replacementListOf(vararg elements: I, selector: (I) -> O):
-    ReplacementList<I, O> {
-    return ReplacementList(mutableListOf(*elements), selector)
+ */
+internal fun <I, O> replacementListOf(
+  vararg elements: I,
+  selector: (I) -> O
+): ReplacementList<I, O> {
+  return ReplacementList(mutableListOf(*elements), selector)
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/replacement/ReplacementList.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/replacement/ReplacementList.kt
@@ -7,49 +7,47 @@ import com.jeanbarrossilva.orca.core.sample.feed.profile.type.editable.replaceOn
  * being added, maintaining its index.
  *
  * @param elements [MutableList] to which this [ReplacementList]'s functionality will be delegated,
- * except for that of [add].
+ *   except for that of [add].
  * @param selector Returns the value by which elements should be compared when replacing them.
- **/
+ */
 internal class ReplacementList<I, O>(
-    private val elements: MutableList<I>,
-    private val selector: (I) -> O
+  private val elements: MutableList<I>,
+  private val selector: (I) -> O
 ) : MutableList<I> by elements {
-    override fun equals(other: Any?): Boolean {
-        return other is MutableList<*> && size == other.size && areElementsPositionallyEqual(other)
-    }
+  override fun equals(other: Any?): Boolean {
+    return other is MutableList<*> && size == other.size && areElementsPositionallyEqual(other)
+  }
 
-    override fun hashCode(): Int {
-        return elements.hashCode()
-    }
+  override fun hashCode(): Int {
+    return elements.hashCode()
+  }
 
-    override fun toString(): String {
-        return elements.toString()
-    }
+  override fun toString(): String {
+    return elements.toString()
+  }
 
-    override fun add(element: I): Boolean {
-        val hasBeenReplaced =
-            elements.replaceOnceBy({ element }) { selector(element) == selector(it) }
-        if (!hasBeenReplaced) {
-            elements.add(element)
-        }
-        return true
+  override fun add(element: I): Boolean {
+    val hasBeenReplaced = elements.replaceOnceBy({ element }) { selector(element) == selector(it) }
+    if (!hasBeenReplaced) {
+      elements.add(element)
     }
+    return true
+  }
 
-    /**
-     * Checks whether this [ReplacementList] and [other] have elements that don't vary neither in
-     * identity nor in index.
-     *
-     * @param other [MutableList] whose elements will be compared to those of this
-     * [ReplacementList].
-     **/
-    private fun areElementsPositionallyEqual(other: MutableList<*>): Boolean {
-        var areElementsPositionallyEqual: Boolean? = null
-        other.forEachIndexed { index, element ->
-            areElementsPositionallyEqual = get(index) == element
-            if (areElementsPositionallyEqual == false) {
-                return@forEachIndexed
-            }
-        }
-        return areElementsPositionallyEqual == true
+  /**
+   * Checks whether this [ReplacementList] and [other] have elements that don't vary neither in
+   * identity nor in index.
+   *
+   * @param other [MutableList] whose elements will be compared to those of this [ReplacementList].
+   */
+  private fun areElementsPositionallyEqual(other: MutableList<*>): Boolean {
+    var areElementsPositionallyEqual: Boolean? = null
+    other.forEachIndexed { index, element ->
+      areElementsPositionallyEqual = get(index) == element
+      if (areElementsPositionallyEqual == false) {
+        return@forEachIndexed
+      }
     }
+    return areElementsPositionallyEqual == true
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/style/Spanned.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/style/Spanned.extensions.kt
@@ -5,13 +5,11 @@ import androidx.core.text.getSpans
 import com.jeanbarrossilva.orca.std.styledstring.StyledString
 import com.jeanbarrossilva.orca.std.styledstring.buildStyledString
 
-/** Converts this [Spanned] into a [StyledString]. **/
+/** Converts this [Spanned] into a [StyledString]. */
 fun Spanned.toStyledString(): StyledString {
-    return buildStyledString {
-        forEachIndexed { index, char ->
-            getSpans<Any>(start = index, end = index).onEach { append(char, it) }.ifEmpty {
-                +char
-            }
-        }
+  return buildStyledString {
+    forEachIndexed { index, char ->
+      getSpans<Any>(start = index, end = index).onEach { append(char, it) }.ifEmpty { +char }
     }
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/style/Style.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/style/Style.extensions.kt
@@ -17,13 +17,16 @@ import com.jeanbarrossilva.orca.std.styledstring.type.Mention
  *
  * @param colors [Colors] by which the resulting [SpanStyle] can be colored.
  * @throws IllegalArgumentException If the [Style] is unknown.
- **/
+ */
 @Throws(IllegalArgumentException::class)
 internal fun Style.toSpanStyle(colors: Colors): SpanStyle {
-    return when (this) {
-        is Bold -> SpanStyle(fontWeight = FontWeight.Bold)
-        is Email, is Hashtag, is Link, is Mention -> SpanStyle(colors.link)
-        is Italic -> SpanStyle(fontStyle = FontStyle.Italic)
-        else -> throw IllegalArgumentException("Cannot convert an unknown $this style.")
-    }
+  return when (this) {
+    is Bold -> SpanStyle(fontWeight = FontWeight.Bold)
+    is Email,
+    is Hashtag,
+    is Link,
+    is Mention -> SpanStyle(colors.link)
+    is Italic -> SpanStyle(fontStyle = FontStyle.Italic)
+    else -> throw IllegalArgumentException("Cannot convert an unknown $this style.")
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/style/StyledString.Builder.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/style/StyledString.Builder.extensions.kt
@@ -9,12 +9,12 @@ import com.jeanbarrossilva.orca.std.styledstring.StyledString
  *
  * @param text [Char] to be appended.
  * @param span Span to be applied to the [text].
- **/
+ */
 internal fun StyledString.Builder.append(text: Char, span: Any) {
-    when (span) {
-        is StyleSpan -> append(text, span)
-        else -> +text
-    }
+  when (span) {
+    is StyleSpan -> append(text, span)
+    else -> +text
+  }
 }
 
 /**
@@ -22,18 +22,11 @@ internal fun StyledString.Builder.append(text: Char, span: Any) {
  *
  * @param text [Char] to be appended.
  * @param span [StyleSpan] to be applied to the [text].
- **/
+ */
 private fun StyledString.Builder.append(text: Char, span: StyleSpan) {
-    when (span.style) {
-        Typeface.BOLD ->
-            bold { +text }
-        Typeface.BOLD_ITALIC ->
-            bold {
-                italic {
-                    +text
-                }
-            }
-        Typeface.ITALIC ->
-            italic { +text }
-    }
+  when (span.style) {
+    Typeface.BOLD -> bold { +text }
+    Typeface.BOLD_ITALIC -> bold { italic { +text } }
+    Typeface.ITALIC -> italic { +text }
+  }
 }

--- a/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/style/StyledString.extensions.kt
+++ b/platform/ui/src/main/java/com/jeanbarrossilva/orca/platform/ui/core/style/StyledString.extensions.kt
@@ -14,33 +14,33 @@ import com.jeanbarrossilva.orca.std.styledstring.StyledString
  * Creates a [StyledString] from the [html].
  *
  * @param html HTML-formatted [String] from which a [StyledString] will be created.
- **/
+ */
 fun StyledString.Companion.fromHtml(html: String): StyledString {
-    val paragraphLessHtml = html.replace("<p>", "").replace("</p>", "")
-    return Html.fromHtml(paragraphLessHtml, Html.FROM_HTML_MODE_COMPACT).toStyledString()
+  val paragraphLessHtml = html.replace("<p>", "").replace("</p>", "")
+  return Html.fromHtml(paragraphLessHtml, Html.FROM_HTML_MODE_COMPACT).toStyledString()
 }
 
-/** Converts this [StyledString] into an [AnnotatedString]. **/
+/** Converts this [StyledString] into an [AnnotatedString]. */
 @Composable
 fun StyledString.toAnnotatedString(): AnnotatedString {
-    return toAnnotatedString(OrcaTheme.colors)
+  return toAnnotatedString(OrcaTheme.colors)
 }
 
 /**
  * Converts this [StyledString] into an [AnnotatedString].
  *
  * @param colors [Colors] by which the [AnnotatedString] can be colored.
- **/
+ */
 fun StyledString.toAnnotatedString(colors: Colors): AnnotatedString {
-    val conversions = HashMap<Style, SpanStyle>()
-    return buildAnnotatedString {
-        append(this@toAnnotatedString)
-        styles.forEach {
-            addStyle(
-                conversions.getOrPut(it) { it.toSpanStyle(colors) },
-                it.indices.first,
-                it.indices.last.inc()
-            )
-        }
+  val conversions = HashMap<Style, SpanStyle>()
+  return buildAnnotatedString {
+    append(this@toAnnotatedString)
+    styles.forEach {
+      addStyle(
+        conversions.getOrPut(it) { it.toSpanStyle(colors) },
+        it.indices.first,
+        it.indices.last.inc()
+      )
     }
+  }
 }

--- a/platform/ui/src/test/java/com/jeanbarrossilva/orca/platform/ui/core/replacement/ReplacementListTests.kt
+++ b/platform/ui/src/test/java/com/jeanbarrossilva/orca/platform/ui/core/replacement/ReplacementListTests.kt
@@ -4,16 +4,16 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class ReplacementListTests {
-    @Test
-    fun adds() {
-        assertEquals(replacementListOf(0), emptyReplacementList<Int>().apply { add(0) })
-    }
+  @Test
+  fun adds() {
+    assertEquals(replacementListOf(0), emptyReplacementList<Int>().apply { add(0) })
+  }
 
-    @Test
-    fun replaces() {
-        assertEquals(
-            replacementListOf("Hello,", "world!", selector = String::first),
-            replacementListOf("Hey,", "world!", selector = String::first).apply { add("Hello,") }
-        )
-    }
+  @Test
+  fun replaces() {
+    assertEquals(
+      replacementListOf("Hello,", "world!", selector = String::first),
+      replacementListOf("Hey,", "world!", selector = String::first).apply { add("Hello,") }
+    )
+  }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,37 +1,38 @@
 rootProject.name = "Orca"
 
 pluginManagement.repositories {
-    google()
-    gradlePluginPortal()
-    mavenCentral()
+  google()
+  gradlePluginPortal()
+  mavenCentral()
 }
 
 includeBuild("build-src")
+
 include(
-    ":app",
-    ":core",
-    ":core:http",
-    ":core:sample",
-    ":core:sample-test",
-    ":core:shared-preferences",
-    ":core-test",
-    ":feature:composer",
-    ":feature:feed",
-    ":feature:profile-details",
-    ":feature:search",
-    ":feature:settings",
-    ":feature:settings:term-muting",
-    ":feature:toot-details",
-    ":platform:cache",
-    ":platform:launchable",
-    ":platform:theme",
-    ":platform:ui",
-    ":platform:ui-test",
-    ":std:image-loader",
-    ":std:image-loader:compose",
-    ":std:image-loader-test",
-    ":std:injector",
-    ":std:injector-processor",
-    ":std:injector-test",
-    ":std:styled-string"
+  ":app",
+  ":core",
+  ":core:http",
+  ":core:sample",
+  ":core:sample-test",
+  ":core:shared-preferences",
+  ":core-test",
+  ":feature:composer",
+  ":feature:feed",
+  ":feature:profile-details",
+  ":feature:search",
+  ":feature:settings",
+  ":feature:settings:term-muting",
+  ":feature:toot-details",
+  ":platform:cache",
+  ":platform:launchable",
+  ":platform:theme",
+  ":platform:ui",
+  ":platform:ui-test",
+  ":std:image-loader",
+  ":std:image-loader:compose",
+  ":std:image-loader-test",
+  ":std:injector",
+  ":std:injector-processor",
+  ":std:injector-test",
+  ":std:styled-string"
 )

--- a/std/image-loader-test/src/main/java/com/jeanbarrossilva/orca/std/imageloader/test/TestImageLoader.kt
+++ b/std/image-loader-test/src/main/java/com/jeanbarrossilva/orca/std/imageloader/test/TestImageLoader.kt
@@ -5,11 +5,9 @@ import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
 import com.jeanbarrossilva.orca.std.imageloader.buildImage
 import java.net.URL
 
-/** [ImageLoader] that loads an empty [Image]. **/
+/** [ImageLoader] that loads an empty [Image]. */
 object TestImageLoader : ImageLoader {
-    override suspend fun load(width: Int, height: Int, url: URL): Image {
-        return buildImage(width = 1, height = 1) {
-            pixel(0)
-        }
-    }
+  override suspend fun load(width: Int, height: Int, url: URL): Image {
+    return buildImage(width = 1, height = 1) { pixel(0) }
+  }
 }

--- a/std/image-loader/compose/build.gradle.kts
+++ b/std/image-loader/compose/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     buildFeatures.compose = true
-    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+    composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.get()
     namespace = namespaceFor("std.imageloader.compose")
 }
 

--- a/std/image-loader/compose/src/main/java/com/jeanbarrossilva/orca/std/imageloader/compose/Bitmap.extensions.kt
+++ b/std/image-loader/compose/src/main/java/com/jeanbarrossilva/orca/std/imageloader/compose/Bitmap.extensions.kt
@@ -4,16 +4,17 @@ import android.graphics.Bitmap
 import com.jeanbarrossilva.orca.std.imageloader.Image
 import com.jeanbarrossilva.orca.std.imageloader.buildImage
 
-/** Converts this [Bitmap] into an [Image]. **/
+/** Converts this [Bitmap] into an [Image]. */
 internal fun Bitmap.toImage(): Image {
-    return buildImage(width, height) {
-        val nonHardwareBitmap = if (config == Bitmap.Config.HARDWARE) {
-            copy(Bitmap.Config.ARGB_8888, false)
-        } else {
-            this@toImage
-        }
-        IntArray(size = width * height)
-            .also { nonHardwareBitmap.getPixels(it, 0, width, 0, 0, width, height) }
-            .forEach(::pixel)
-    }
+  return buildImage(width, height) {
+    val nonHardwareBitmap =
+      if (config == Bitmap.Config.HARDWARE) {
+        copy(Bitmap.Config.ARGB_8888, false)
+      } else {
+        this@toImage
+      }
+    IntArray(size = width * height)
+      .also { nonHardwareBitmap.getPixels(it, 0, width, 0, 0, width, height) }
+      .forEach(::pixel)
+  }
 }

--- a/std/image-loader/compose/src/main/java/com/jeanbarrossilva/orca/std/imageloader/compose/CoilImageLoader.kt
+++ b/std/image-loader/compose/src/main/java/com/jeanbarrossilva/orca/std/imageloader/compose/CoilImageLoader.kt
@@ -12,30 +12,29 @@ import java.net.URL
  * [ImageLoader] powered by the Coil library.
  *
  * @param context [Context] through which [ImageRequest]s will be performed.
- **/
+ */
 internal class CoilImageLoader private constructor(private val context: Context) : ImageLoader {
-    override suspend fun load(width: Int, height: Int, url: URL): Image? {
-        val request = ImageRequest.Builder(context).data("$url").size(width, height).build()
-        return context.imageLoader.execute(request).drawable?.toBitmap()?.toImage()
-    }
+  override suspend fun load(width: Int, height: Int, url: URL): Image? {
+    val request = ImageRequest.Builder(context).data("$url").size(width, height).build()
+    return context.imageLoader.execute(request).drawable?.toBitmap()?.toImage()
+  }
 
-    companion object {
-        /** Single [CoilImageLoader] instance. **/
-        @Suppress("StaticFieldLeak")
-        private lateinit var instance: CoilImageLoader
+  companion object {
+    /** Single [CoilImageLoader] instance. */
+    @Suppress("StaticFieldLeak") private lateinit var instance: CoilImageLoader
 
-        /**
-         * Creates or retrieves an existing instance of a [CoilImageLoader].
-         *
-         * @param context [Context] through which [ImageRequest]s will be performed.
-         **/
-        fun getInstance(context: Context): CoilImageLoader {
-            return if (::instance.isInitialized) {
-                instance
-            } else {
-                instance = CoilImageLoader(context)
-                instance
-            }
-        }
+    /**
+     * Creates or retrieves an existing instance of a [CoilImageLoader].
+     *
+     * @param context [Context] through which [ImageRequest]s will be performed.
+     */
+    fun getInstance(context: Context): CoilImageLoader {
+      return if (::instance.isInitialized) {
+        instance
+      } else {
+        instance = CoilImageLoader(context)
+        instance
+      }
     }
+  }
 }

--- a/std/image-loader/compose/src/main/java/com/jeanbarrossilva/orca/std/imageloader/compose/Image.extensions.kt
+++ b/std/image-loader/compose/src/main/java/com/jeanbarrossilva/orca/std/imageloader/compose/Image.extensions.kt
@@ -4,11 +4,7 @@ import android.graphics.Bitmap
 import androidx.core.graphics.createBitmap
 import com.jeanbarrossilva.orca.std.imageloader.Image
 
-/** Converts this [Image] into a [Bitmap]. **/
+/** Converts this [Image] into a [Bitmap]. */
 internal fun Image.toBitmap(): Bitmap {
-    return createBitmap(width, height).apply {
-        pixels.forEach {
-            setPixel(it.x, it.y, it.color)
-        }
-    }
+  return createBitmap(width, height).apply { pixels.forEach { setPixel(it.x, it.y, it.color) } }
 }

--- a/std/image-loader/compose/src/main/java/com/jeanbarrossilva/orca/std/imageloader/compose/Image.kt
+++ b/std/image-loader/compose/src/main/java/com/jeanbarrossilva/orca/std/imageloader/compose/Image.kt
@@ -49,88 +49,80 @@ import java.net.URL
  * @param loader [ImageLoader] by which the image will be loaded.
  * @param shape [Shape] by which this [Image][_Image] will be clipped.
  * @param contentScale Defines how the image will be scaled within this [Composable]'s bounds.
- **/
+ */
 @Composable
 fun Image(
-    url: URL,
-    contentDescription: String,
-    modifier: Modifier = Modifier,
-    loader: ImageLoader = rememberImageLoader(),
-    shape: Shape = RectangleShape,
-    contentScale: ContentScale = ContentScale.Fit
+  url: URL,
+  contentDescription: String,
+  modifier: Modifier = Modifier,
+  loader: ImageLoader = rememberImageLoader(),
+  shape: Shape = RectangleShape,
+  contentScale: ContentScale = ContentScale.Fit
 ) {
-    val isInspecting = LocalInspectionMode.current
-    var size by remember { mutableStateOf<IntSize?>(null) }
-    val canLoadImage = remember(isInspecting, size) { !isInspecting || size != null }
-    var bitmapLoadable by remember(canLoadImage) {
-        mutableStateOf<Loadable<ImageBitmap>>(
-            if (canLoadImage) {
-                Loadable.Loading()
-            } else {
-                Loadable.Failed(UnsupportedOperationException("Image cannot be loaded."))
-            }
-        )
-    }
-
-    LaunchedEffect(url, size, canLoadImage, loader) {
+  val isInspecting = LocalInspectionMode.current
+  var size by remember { mutableStateOf<IntSize?>(null) }
+  val canLoadImage = remember(isInspecting, size) { !isInspecting || size != null }
+  var bitmapLoadable by
+    remember(canLoadImage) {
+      mutableStateOf<Loadable<ImageBitmap>>(
         if (canLoadImage) {
-            size?.let {
-                bitmapLoadable =
-                    loader.load(it.width, it.height, url)?.toBitmap()?.asImageBitmap().loadable()!!
-            }
+          Loadable.Loading()
+        } else {
+          Loadable.Failed(UnsupportedOperationException("Image cannot be loaded."))
         }
+      )
     }
 
-    Placeholder(
-        modifier.onPlaced { size = it.size },
-        isLoading = bitmapLoadable is Loadable.Loading,
-        shape
+  LaunchedEffect(url, size, canLoadImage, loader) {
+    if (canLoadImage) {
+      size?.let {
+        bitmapLoadable =
+          loader.load(it.width, it.height, url)?.toBitmap()?.asImageBitmap().loadable()!!
+      }
+    }
+  }
+
+  Placeholder(
+    modifier.onPlaced { size = it.size },
+    isLoading = bitmapLoadable is Loadable.Loading,
+    shape
+  ) {
+    CompositionLocalProvider(
+      LocalContentColor provides contentColorFor(PlaceholderDefaults.color)
     ) {
-        CompositionLocalProvider(
-            LocalContentColor provides contentColorFor(PlaceholderDefaults.color)
-        ) {
-            BoxWithConstraints(Modifier.matchParentSize(), Alignment.Center) {
-                bitmapLoadable.let {
-                    if (it is Loadable.Loaded) {
-                        Image(
-                            it.content,
-                            contentDescription,
-                            Modifier
-                                .clip(shape)
-                                .matchParentSize(),
-                            contentScale = contentScale
-                        )
-                    } else if (it is Loadable.Failed) {
-                        Box(
-                            Modifier
-                                .clip(shape)
-                                .background(PlaceholderDefaults.color)
-                                .matchParentSize()
-                        )
+      BoxWithConstraints(Modifier.matchParentSize(), Alignment.Center) {
+        bitmapLoadable.let {
+          if (it is Loadable.Loaded) {
+            Image(
+              it.content,
+              contentDescription,
+              Modifier.clip(shape).matchParentSize(),
+              contentScale = contentScale
+            )
+          } else if (it is Loadable.Failed) {
+            Box(Modifier.clip(shape).background(PlaceholderDefaults.color).matchParentSize())
 
-                        Icon(
-                            OrcaTheme.iconography.unavailable.filled,
-                            contentDescription = "Unavailable image",
-                            Modifier
-                                .height(maxHeight / 2)
-                                .width(maxWidth / 2)
-                        )
-                    }
-                }
-            }
+            Icon(
+              OrcaTheme.iconography.unavailable.filled,
+              contentDescription = "Unavailable image",
+              Modifier.height(maxHeight / 2).width(maxWidth / 2)
+            )
+          }
         }
+      }
     }
+  }
 }
 
-/** Preview of an [Image][_Image]. **/
+/** Preview of an [Image][_Image]. */
 @Composable
 @MultiThemePreview
 private fun ImagePreview() {
-    OrcaTheme {
-        _Image(
-            URL("https://images.unsplash.com/photo-1692890846581-da1a95435f34"),
-            contentDescription = "Preview image",
-            Modifier.size(128.dp)
-        )
-    }
+  OrcaTheme {
+    _Image(
+      URL("https://images.unsplash.com/photo-1692890846581-da1a95435f34"),
+      contentDescription = "Preview image",
+      Modifier.size(128.dp)
+    )
+  }
 }

--- a/std/image-loader/compose/src/main/java/com/jeanbarrossilva/orca/std/imageloader/compose/ImageLoader.extensions.kt
+++ b/std/image-loader/compose/src/main/java/com/jeanbarrossilva/orca/std/imageloader/compose/ImageLoader.extensions.kt
@@ -5,9 +5,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
 
-/** Remembers an [ImageLoader]. **/
+/** Remembers an [ImageLoader]. */
 @Composable
 fun rememberImageLoader(): ImageLoader {
-    val context = LocalContext.current
-    return remember(context) { CoilImageLoader.getInstance(context) }
+  val context = LocalContext.current
+  return remember(context) { CoilImageLoader.getInstance(context) }
 }

--- a/std/image-loader/src/main/java/com/jeanbarrossilva/orca/std/imageloader/Image.extensions.kt
+++ b/std/image-loader/src/main/java/com/jeanbarrossilva/orca/std/imageloader/Image.extensions.kt
@@ -6,7 +6,7 @@ package com.jeanbarrossilva.orca.std.imageloader
  * @param width How wide the [Image] is.
  * @param height How tall the [Image] is.
  * @param build Configures the [Image] to be built.
- **/
+ */
 fun buildImage(width: Int, height: Int, build: Image.Builder.() -> Unit): Image {
-    return Image.Builder(width, height).apply(build).build()
+  return Image.Builder(width, height).apply(build).build()
 }

--- a/std/image-loader/src/main/java/com/jeanbarrossilva/orca/std/imageloader/Image.kt
+++ b/std/image-loader/src/main/java/com/jeanbarrossilva/orca/std/imageloader/Image.kt
@@ -8,82 +8,82 @@ import java.util.Objects
  * @param width How wide this [Image] is.
  * @param height How tall this [Image] is.
  * @param pixels [Pixel]s by which this [Image] is composed.
- **/
+ */
 class Image private constructor(val width: Int, val height: Int, val pixels: List<Pixel>) {
-    init {
-        if (pixels.size < width * height) {
-            throw IllegalArgumentException("Insufficient amount of pixels for $width x $height.")
-        }
+  init {
+    if (pixels.size < width * height) {
+      throw IllegalArgumentException("Insufficient amount of pixels for $width x $height.")
     }
+  }
 
-    /**
-     * Smallest addressable element in an [Image].
-     *
-     * @param x Location on the x-axis.
-     * @param y Location on the y-axis.
-     * @param color [Int] form of the color by which this [Pixel] is colored.
-     **/
-    class Pixel internal constructor(val x: Int, val y: Int, val color: Int) {
-        override fun equals(other: Any?): Boolean {
-            return other is Pixel && x == other.x && y == other.y && color == other.color
-        }
-
-        override fun hashCode(): Int {
-            return Objects.hash(x, y, color)
-        }
-
-        override fun toString(): String {
-            return "Pixel(x=$x, y=$y, color=$color)"
-        }
-    }
-
-    /**
-     * Configures an [Image] to be built.
-     *
-     * @param width How wide the [Image] is.
-     * @param height How tall the [Image] is.
-     **/
-    class Builder internal constructor(private val width: Int, private val height: Int) {
-        /** [Pixel]s by which the [Image] will be composed. **/
-        private val pixels = mutableListOf<Pixel>()
-
-        /**
-         * Adds a [Pixel] to the next remaining space in the x-axis, jumping to the next column if
-         * the row has been filled.
-         *
-         * @param color [Int] form of the color by which the [Pixel] will be colored.
-         * @throws IllegalStateException If the [Image] cannot have more [Pixel]s added to it.
-         **/
-        fun pixel(color: Int) {
-            val lastPixel = pixels.lastOrNull()
-            val x = lastPixel?.x?.inc()?.mirror(0, width.dec()) ?: 0
-            val y = if (lastPixel != null && x == 0) lastPixel.y.inc() else lastPixel?.y ?: 0
-            if (y >= height) {
-                throw IllegalStateException("Coordinate out of $width x $height bounds: ($x, $y).")
-            }
-            val pixel = Pixel(x, y, color)
-            pixels.add(pixel)
-        }
-
-        /** Builds the [Image] with the provided configurations. **/
-        internal fun build(): Image {
-            val pixelsAsList = pixels.toList()
-            return Image(width, height, pixelsAsList)
-        }
-    }
-
+  /**
+   * Smallest addressable element in an [Image].
+   *
+   * @param x Location on the x-axis.
+   * @param y Location on the y-axis.
+   * @param color [Int] form of the color by which this [Pixel] is colored.
+   */
+  class Pixel internal constructor(val x: Int, val y: Int, val color: Int) {
     override fun equals(other: Any?): Boolean {
-        return other is Image &&
-            width == other.width &&
-            height == other.height &&
-            pixels.containsAll(other.pixels)
+      return other is Pixel && x == other.x && y == other.y && color == other.color
     }
 
     override fun hashCode(): Int {
-        return Objects.hash(width, height, pixels)
+      return Objects.hash(x, y, color)
     }
 
     override fun toString(): String {
-        return "Image(width=$width, height=$height, pixels=$pixels)"
+      return "Pixel(x=$x, y=$y, color=$color)"
     }
+  }
+
+  /**
+   * Configures an [Image] to be built.
+   *
+   * @param width How wide the [Image] is.
+   * @param height How tall the [Image] is.
+   */
+  class Builder internal constructor(private val width: Int, private val height: Int) {
+    /** [Pixel]s by which the [Image] will be composed. */
+    private val pixels = mutableListOf<Pixel>()
+
+    /**
+     * Adds a [Pixel] to the next remaining space in the x-axis, jumping to the next column if the
+     * row has been filled.
+     *
+     * @param color [Int] form of the color by which the [Pixel] will be colored.
+     * @throws IllegalStateException If the [Image] cannot have more [Pixel]s added to it.
+     */
+    fun pixel(color: Int) {
+      val lastPixel = pixels.lastOrNull()
+      val x = lastPixel?.x?.inc()?.mirror(0, width.dec()) ?: 0
+      val y = if (lastPixel != null && x == 0) lastPixel.y.inc() else lastPixel?.y ?: 0
+      if (y >= height) {
+        throw IllegalStateException("Coordinate out of $width x $height bounds: ($x, $y).")
+      }
+      val pixel = Pixel(x, y, color)
+      pixels.add(pixel)
+    }
+
+    /** Builds the [Image] with the provided configurations. */
+    internal fun build(): Image {
+      val pixelsAsList = pixels.toList()
+      return Image(width, height, pixelsAsList)
+    }
+  }
+
+  override fun equals(other: Any?): Boolean {
+    return other is Image &&
+      width == other.width &&
+      height == other.height &&
+      pixels.containsAll(other.pixels)
+  }
+
+  override fun hashCode(): Int {
+    return Objects.hash(width, height, pixels)
+  }
+
+  override fun toString(): String {
+    return "Image(width=$width, height=$height, pixels=$pixels)"
+  }
 }

--- a/std/image-loader/src/main/java/com/jeanbarrossilva/orca/std/imageloader/ImageLoader.kt
+++ b/std/image-loader/src/main/java/com/jeanbarrossilva/orca/std/imageloader/ImageLoader.kt
@@ -2,14 +2,14 @@ package com.jeanbarrossilva.orca.std.imageloader
 
 import java.net.URL
 
-/** Loads [Image]s asynchronously through [load]. **/
+/** Loads [Image]s asynchronously through [load]. */
 interface ImageLoader {
-    /**
-     * Loads the [Image] to which the [url] leads.
-     *
-     * @param width How wide the [Image] is.
-     * @param height How tall the [Image] is.
-     * @param url [URL] of the [Image] to be loaded.
-     **/
-    suspend fun load(width: Int, height: Int, url: URL): Image?
+  /**
+   * Loads the [Image] to which the [url] leads.
+   *
+   * @param width How wide the [Image] is.
+   * @param height How tall the [Image] is.
+   * @param url [URL] of the [Image] to be loaded.
+   */
+  suspend fun load(width: Int, height: Int, url: URL): Image?
 }

--- a/std/image-loader/src/main/java/com/jeanbarrossilva/orca/std/imageloader/Number.extensions.kt
+++ b/std/image-loader/src/main/java/com/jeanbarrossilva/orca/std/imageloader/Number.extensions.kt
@@ -6,7 +6,7 @@ package com.jeanbarrossilva.orca.std.imageloader
  *
  * @param min Minimum [Int] to be returned if this one exceeds [max].
  * @param max Maximum [Int] to be returned if this one is less than [min].
- **/
+ */
 internal fun Int.mirror(min: Int, max: Int): Int {
-    return if (this < min) max else if (this > max) min else this
+  return if (this < min) max else if (this > max) min else this
 }

--- a/std/image-loader/src/test/java/com/jeanbarrossilva/orca/std/imageloader/ImageTests.kt
+++ b/std/image-loader/src/test/java/com/jeanbarrossilva/orca/std/imageloader/ImageTests.kt
@@ -6,41 +6,30 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertFailsWith
 
 internal class ImageTests {
-    @Test
-    fun `GIVEN an image WHEN adding an insufficient amount of pixels to it THEN it throws`() {
-        assertFailsWith<IllegalArgumentException> {
-            buildImage(width = 2, height = 2) {
-                pixel(Color.BLACK.rgb)
-            }
-        }
+  @Test
+  fun `GIVEN an image WHEN adding an insufficient amount of pixels to it THEN it throws`() {
+    assertFailsWith<IllegalArgumentException> {
+      buildImage(width = 2, height = 2) { pixel(Color.BLACK.rgb) }
     }
+  }
 
-    @Test
-    fun `GIVEN an image WHEN adding more pixels than it can hold THEN it throws`() {
-        assertFailsWith<IllegalStateException> {
-            buildImage(width = 1, height = 1) {
-                repeat(2) {
-                    pixel(Color.BLACK.rgb)
-                }
-            }
-        }
+  @Test
+  fun `GIVEN an image WHEN adding more pixels than it can hold THEN it throws`() {
+    assertFailsWith<IllegalStateException> {
+      buildImage(width = 1, height = 1) { repeat(2) { pixel(Color.BLACK.rgb) } }
     }
+  }
 
-    @Test
-    fun `GIVEN an image WHEN adding pixels to it THEN they're placed in the right coordinates`() {
-        assertContentEquals(
-            listOf(
-                Image.Pixel(x = 0, y = 0, Color.BLACK.rgb),
-                Image.Pixel(x = 1, y = 0, Color.BLACK.rgb),
-                Image.Pixel(x = 0, y = 1, Color.BLACK.rgb),
-                Image.Pixel(x = 1, y = 1, Color.BLACK.rgb)
-            ),
-            buildImage(width = 2, height = 2) {
-                repeat(4) {
-                    pixel(Color.BLACK.rgb)
-                }
-            }
-                .pixels
-        )
-    }
+  @Test
+  fun `GIVEN an image WHEN adding pixels to it THEN they're placed in the right coordinates`() {
+    assertContentEquals(
+      listOf(
+        Image.Pixel(x = 0, y = 0, Color.BLACK.rgb),
+        Image.Pixel(x = 1, y = 0, Color.BLACK.rgb),
+        Image.Pixel(x = 0, y = 1, Color.BLACK.rgb),
+        Image.Pixel(x = 1, y = 1, Color.BLACK.rgb)
+      ),
+      buildImage(width = 2, height = 2) { repeat(4) { pixel(Color.BLACK.rgb) } }.pixels
+    )
+  }
 }

--- a/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/FileSpec.Builder.extensions.kt
+++ b/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/FileSpec.Builder.extensions.kt
@@ -7,11 +7,7 @@ import com.squareup.kotlinpoet.FileSpec
  * Adds the imports of the given [file] to the [FileSpec] being built.
  *
  * @param file [KSFile] whose imported structures will be added.
- **/
+ */
 internal fun FileSpec.Builder.addImports(file: KSFile): FileSpec.Builder {
-    return apply {
-        file.imports.forEach {
-            addImport(it.asString())
-        }
-    }
+  return apply { file.imports.forEach { addImport(it.asString()) } }
 }

--- a/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/KSDeclaration.extensions.kt
+++ b/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/KSDeclaration.extensions.kt
@@ -11,11 +11,11 @@ import com.squareup.kotlinpoet.typeNameOf
  * Whether this [KSDeclaration] is within [T]'s [KSClassDeclaration].
  *
  * @param T Structure whose ownership of this [KSDeclaration] will be verified.
- **/
+ */
 internal inline fun <reified T : Any> KSDeclaration.isWithin(): Boolean {
-    val parentDeclaration = parentDeclaration as? KSClassDeclaration ?: return false
-    val typeName = typeNameOf<T>()
-    return parentDeclaration.superTypes.map(KSTypeReference::toTypeName).any(typeName::equals)
+  val parentDeclaration = parentDeclaration as? KSClassDeclaration ?: return false
+  val typeName = typeNameOf<T>()
+  return parentDeclaration.superTypes.map(KSTypeReference::toTypeName).any(typeName::equals)
 }
 
 /**
@@ -23,7 +23,7 @@ internal inline fun <reified T : Any> KSDeclaration.isWithin(): Boolean {
  * doesn't have one.
  *
  * @throws IllegalStateException If this [KSDeclaration] isn't part of a [KSFile].
- **/
+ */
 internal fun KSDeclaration.requireContainingFile(): KSFile {
-    return containingFile ?: throw IllegalStateException("$this doesn't have a containing KSFile.")
+  return containingFile ?: throw IllegalStateException("$this doesn't have a containing KSFile.")
 }

--- a/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/KSFile.extensions.kt
+++ b/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/KSFile.extensions.kt
@@ -13,25 +13,24 @@ import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtImportDirective
 
-/** [Name]s imported within this [KSFile]. **/
+/** [Name]s imported within this [KSFile]. */
 internal val KSFile.imports: List<Name>
-    get() {
-        val disposable = Disposer.newDisposable()
-        return try {
-            val config = CompilerConfiguration()
-            val configFiles = EnvironmentConfigFiles.JVM_CONFIG_FILES
-            val env = KotlinCoreEnvironment.createForProduction(disposable, config, configFiles)
-            val path = Path.of(filePath)
-            val text = Files.readString(path)
-            val virtualFile = LightVirtualFile(fileName, KotlinFileType.INSTANCE, text)
-            PsiManager
-                .getInstance(env.project)
-                .findFile(virtualFile)
-                ?.children
-                ?.filterIsInstance<KtImportDirective>()
-                ?.mapNotNull(KtImportDirective::importedName)
-                .orEmpty()
-        } finally {
-            disposable.dispose()
-        }
+  get() {
+    val disposable = Disposer.newDisposable()
+    return try {
+      val config = CompilerConfiguration()
+      val configFiles = EnvironmentConfigFiles.JVM_CONFIG_FILES
+      val env = KotlinCoreEnvironment.createForProduction(disposable, config, configFiles)
+      val path = Path.of(filePath)
+      val text = Files.readString(path)
+      val virtualFile = LightVirtualFile(fileName, KotlinFileType.INSTANCE, text)
+      PsiManager.getInstance(env.project)
+        .findFile(virtualFile)
+        ?.children
+        ?.filterIsInstance<KtImportDirective>()
+        ?.mapNotNull(KtImportDirective::importedName)
+        .orEmpty()
+    } finally {
+      disposable.dispose()
     }
+  }

--- a/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/KSPropertyDeclaration.extensions.kt
+++ b/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/KSPropertyDeclaration.extensions.kt
@@ -6,9 +6,11 @@ import com.jeanbarrossilva.orca.std.injector.module.Module
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.typeNameOf
 
-/** Whether this [KSPropertyDeclaration]'s return type is considered to be an injection. **/
+/** Whether this [KSPropertyDeclaration]'s return type is considered to be an injection. */
 internal val KSPropertyDeclaration.isInjection
-    get() = with(type.resolve().arguments.map(KSTypeArgument::toTypeName)) {
-        firstOrNull() == typeNameOf<Module>() &&
-            !last().isNullable && last().toString() != "kotlin.Nothing"
+  get() =
+    with(type.resolve().arguments.map(KSTypeArgument::toTypeName)) {
+      firstOrNull() == typeNameOf<Module>() &&
+        !last().isNullable &&
+        last().toString() != "kotlin.Nothing"
     }

--- a/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/Resolver.extensions.kt
+++ b/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/Resolver.extensions.kt
@@ -4,8 +4,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 
-/** Gets the [Inject]-annotated injections. **/
+/** Gets the [Inject]-annotated injections. */
 internal fun Resolver.getInjections(): Sequence<KSPropertyDeclaration> {
-    return getSymbolsWithAnnotation(Inject::class.java.name)
-        .filterIsInstance<KSPropertyDeclaration>()
+  return getSymbolsWithAnnotation(Inject::class.java.name).filterIsInstance<KSPropertyDeclaration>()
 }

--- a/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/Visibility.extensions.kt
+++ b/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/Visibility.extensions.kt
@@ -7,25 +7,25 @@ import com.google.devtools.ksp.symbol.Visibility
  *
  * @param a [Visibility] to be compared to [b].
  * @param b [Visibility] to be compared to [a].
- **/
+ */
 internal fun minOf(a: Visibility, b: Visibility): Visibility {
-    val aWeight = a.weight()
-    val bWeight = b.weight()
-    val minWeight = listOf(aWeight, bWeight).min()
-    return if (minWeight == aWeight) a else b
+  val aWeight = a.weight()
+  val bWeight = b.weight()
+  val minWeight = listOf(aWeight, bWeight).min()
+  return if (minWeight == aWeight) a else b
 }
 
 /**
  * Since the [Visibility] enum entries aren't sorted according to their "weight", returns a positive
  * [Int] that classifies this [Visibility].
- **/
+ */
 private fun Visibility.weight(): Int {
-    return when (this) {
-        Visibility.LOCAL -> 0
-        Visibility.PRIVATE -> 1
-        Visibility.PROTECTED -> 2
-        Visibility.JAVA_PACKAGE -> 3
-        Visibility.INTERNAL -> 4
-        Visibility.PUBLIC -> 5
-    }
+  return when (this) {
+    Visibility.LOCAL -> 0
+    Visibility.PRIVATE -> 1
+    Visibility.PROTECTED -> 2
+    Visibility.JAVA_PACKAGE -> 3
+    Visibility.INTERNAL -> 4
+    Visibility.PUBLIC -> 5
+  }
 }

--- a/std/injector-test/src/main/java/com/jeanbarrossilva/orca/std/injector/test/InjectorTestRule.kt
+++ b/std/injector-test/src/main/java/com/jeanbarrossilva/orca/std/injector/test/InjectorTestRule.kt
@@ -7,25 +7,25 @@ import org.junit.rules.ExternalResource
  * Rule for running the [injection] before and clearing the [Injector] after the test is done.
  *
  * @param injection Operation to be performed on the [Injector].
- **/
-class InjectorTestRule(private val injection: Injector.() -> Unit = { }) : ExternalResource() {
-    override fun before() {
-        Injector.injection()
-    }
+ */
+class InjectorTestRule(private val injection: Injector.() -> Unit = {}) : ExternalResource() {
+  override fun before() {
+    Injector.injection()
+  }
 
-    override fun after() {
-        Injector.clear()
-    }
+  override fun after() {
+    Injector.clear()
+  }
 
-    /**
-     * Surrounds the execution of the [use] lambda with a call to [before] that precedes it and
-     * another to [after] that succeeds it.
-     *
-     * @param use Operation to be performed.
-     **/
-    internal fun use(use: () -> Unit = { }) {
-        before()
-        use()
-        after()
-    }
+  /**
+   * Surrounds the execution of the [use] lambda with a call to [before] that precedes it and
+   * another to [after] that succeeds it.
+   *
+   * @param use Operation to be performed.
+   */
+  internal fun use(use: () -> Unit = {}) {
+    before()
+    use()
+    after()
+  }
 }

--- a/std/injector-test/src/test/java/com/jeanbarrossilva/orca/std/injector/test/InjectorTestRuleTests.kt
+++ b/std/injector-test/src/test/java/com/jeanbarrossilva/orca/std/injector/test/InjectorTestRuleTests.kt
@@ -4,13 +4,9 @@ import com.jeanbarrossilva.orca.std.injector.Injector
 import kotlin.test.Test
 
 internal class InjectorTestRuleTests {
-    @Test(expected = NoSuchElementException::class)
-    fun clears() {
-        InjectorTestRule().use {
-            Injector.inject {
-                0
-            }
-        }
-        Injector.get<Int>()
-    }
+  @Test(expected = NoSuchElementException::class)
+  fun clears() {
+    InjectorTestRule().use { Injector.inject { 0 } }
+    Injector.get<Int>()
+  }
 }

--- a/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Any.extensions.kt
+++ b/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Any.extensions.kt
@@ -5,10 +5,9 @@ package com.jeanbarrossilva.orca.std.injector
  *
  * @param T Value to which this will be casted.
  * @throws ClassCastException If this cannot be casted to [T].
- **/
+ */
 @PublishedApi
 @Throws(ClassCastException::class)
 internal fun <T> Any.castTo(): T {
-    @Suppress("UNCHECKED_CAST")
-    return this as T
+  @Suppress("UNCHECKED_CAST") return this as T
 }

--- a/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Collection.extensions.kt
+++ b/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Collection.extensions.kt
@@ -9,22 +9,21 @@ import kotlin.reflect.typeOf
 /**
  * Returns a [List] containing only [KProperty1]s that characterize an injection into a [Module].
  * Those:
- *
  * - Are annotated with [Inject], denoting that the dependencies returned by their values should be
- * automatically injected into the [Module] in which they were declared;
+ *   automatically injected into the [Module] in which they were declared;
  * - Have a return type of `Module.() -> Any`, which allows for operations to be performed within
- * the [Module] and returns a dependency of any non-`null` type.
+ *   the [Module] and returns a dependency of any non-`null` type.
  *
  * @param T [Module] into which the resulting dependencies of the [KProperty1]s' values will be
- * injected.
- **/
+ *   injected.
+ */
 @PublishedApi
 internal fun <T : Module> Collection<KProperty1<T, *>>.filterIsInjection():
-    List<KProperty1<T, Module.() -> Any>> {
-    return filter {
-        it.hasAnnotation<Inject>() &&
-            it.returnType.arguments.size == 2 &&
-            it.returnType.arguments.first().type == typeOf<Module>()
+  List<KProperty1<T, Module.() -> Any>> {
+  return filter {
+      it.hasAnnotation<Inject>() &&
+        it.returnType.arguments.size == 2 &&
+        it.returnType.arguments.first().type == typeOf<Module>()
     }
-        .castTo()
+    .castTo()
 }

--- a/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Injector.kt
+++ b/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Injector.kt
@@ -5,98 +5,95 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.isAccessible
 
-/** [Module] that enables global [Module] and dependency injection. **/
+/** [Module] that enables global [Module] and dependency injection. */
 object Injector : Module() {
-    /** [Module]s that have been registered associated to their assigned types. **/
-    @PublishedApi
-    internal val modularization = hashMapOf<KClass<out Module>, Module>()
+  /** [Module]s that have been registered associated to their assigned types. */
+  @PublishedApi internal val modularization = hashMapOf<KClass<out Module>, Module>()
 
-    /** [IllegalArgumentException] thrown if the [Injector] registers itself. **/
-    class SelfRegistrationException
-    @PublishedApi
-    internal constructor() : IllegalArgumentException("Injector cannot register itself.")
+  /** [IllegalArgumentException] thrown if the [Injector] registers itself. */
+  class SelfRegistrationException @PublishedApi internal constructor() :
+    IllegalArgumentException("Injector cannot register itself.")
 
-    /** [IllegalArgumentException] thrown if the [Injector] gets itself. **/
-    class SelfRetrievalException
-    @PublishedApi
-    internal constructor() : IllegalArgumentException("Injector cannot get itself.")
+  /** [IllegalArgumentException] thrown if the [Injector] gets itself. */
+  class SelfRetrievalException @PublishedApi internal constructor() :
+    IllegalArgumentException("Injector cannot get itself.")
 
-    /**
-     * [NoSuchElementException] thrown if a [Module] that hasn't been registered is requested to be
-     * obtained.
-     *
-     * @param moduleClass [KClass] of the requested [Module].
-     **/
-    class ModuleNotRegisteredException
-    @PublishedApi
-    internal constructor(moduleClass: KClass<out Module>) :
-        NoSuchElementException("No module of type ${moduleClass.qualifiedName} has been injected.")
+  /**
+   * [NoSuchElementException] thrown if a [Module] that hasn't been registered is requested to be
+   * obtained.
+   *
+   * @param moduleClass [KClass] of the requested [Module].
+   */
+  class ModuleNotRegisteredException
+  @PublishedApi
+  internal constructor(moduleClass: KClass<out Module>) :
+    NoSuchElementException("No module of type ${moduleClass.qualifiedName} has been injected.")
 
-    /**
-     * Registers the given [module].
-     *
-     * @param T [Module] to be associated to the given one.
-     * @param module [Module] to be registered.
-     * @throws SelfRegistrationException If the [module] is this [Injector].
-     **/
-    inline fun <reified T : Module> register(module: T) {
-        if (module != this) {
-            registerWithoutSelfRegistrationInsurance(module)
-        } else {
-            throw SelfRegistrationException()
-        }
+  /**
+   * Registers the given [module].
+   *
+   * @param T [Module] to be associated to the given one.
+   * @param module [Module] to be registered.
+   * @throws SelfRegistrationException If the [module] is this [Injector].
+   */
+  inline fun <reified T : Module> register(module: T) {
+    if (module != this) {
+      registerWithoutSelfRegistrationInsurance(module)
+    } else {
+      throw SelfRegistrationException()
     }
+  }
 
-    /**
-     * Gets the injected [Module] of type [T].
-     *
-     * @param T [Module] to be obtained.
-     * @throws SelfRetrievalException If the [Module] is this [Injector].
-     * @throws ModuleNotRegisteredException If no [Module] of type [T] has been injected.
-     **/
-    @Throws(ModuleNotRegisteredException::class)
-    inline fun <reified T : Module> from(): T {
-        return if (T::class != Injector::class) {
-            modularization[T::class] as T? ?: throw ModuleNotRegisteredException(T::class)
-        } else {
-            throw SelfRetrievalException()
-        }
+  /**
+   * Gets the injected [Module] of type [T].
+   *
+   * @param T [Module] to be obtained.
+   * @throws SelfRetrievalException If the [Module] is this [Injector].
+   * @throws ModuleNotRegisteredException If no [Module] of type [T] has been injected.
+   */
+  @Throws(ModuleNotRegisteredException::class)
+  inline fun <reified T : Module> from(): T {
+    return if (T::class != Injector::class) {
+      modularization[T::class] as T? ?: throw ModuleNotRegisteredException(T::class)
+    } else {
+      throw SelfRetrievalException()
     }
+  }
 
-    override fun onClear() {
-        modularization.values.forEach(Module::clear)
-        modularization.clear()
-    }
+  override fun onClear() {
+    modularization.values.forEach(Module::clear)
+    modularization.clear()
+  }
 
-    /**
-     * Registers the given [module] without ensuring that this [Module] isn't injecting itself.
-     *
-     * @param T [Module] to be associated to the given one.
-     * @param module [Module] to be registered.
-     **/
-    @PublishedApi
-    internal inline fun <reified T : Module> registerWithoutSelfRegistrationInsurance(module: T) {
-        modularization[T::class] = module
-        injectDeclaredDependenciesOf(module)
-    }
+  /**
+   * Registers the given [module] without ensuring that this [Module] isn't injecting itself.
+   *
+   * @param T [Module] to be associated to the given one.
+   * @param module [Module] to be registered.
+   */
+  @PublishedApi
+  internal inline fun <reified T : Module> registerWithoutSelfRegistrationInsurance(module: T) {
+    modularization[T::class] = module
+    injectDeclaredDependenciesOf(module)
+  }
 
-    /**
-     * Injects the dependencies declared within the given [module].
-     *
-     * @param T [Module] into which its dependencies will be injected.
-     * @param module [Module] whose dependencies will be injected into it.
-     **/
-    @PublishedApi
-    internal inline fun <reified T : Module> injectDeclaredDependenciesOf(module: T) {
-        T::class
-            .memberProperties
-            .filterIsInjection()
-            .associateBy { it.returnType.arguments.last().type?.classifier }
-            .mapKeys { (dependencyClassifier, _) -> dependencyClassifier as KClass<*> }
-            .onEach { (_, property) -> property.isAccessible = true }
-            .mapValues { (_, property) -> property.get(module) }
-            .forEach { (dependencyClass, injection) ->
-                module.inject(dependencyClass, injection.castTo())
-            }
-    }
+  /**
+   * Injects the dependencies declared within the given [module].
+   *
+   * @param T [Module] into which its dependencies will be injected.
+   * @param module [Module] whose dependencies will be injected into it.
+   */
+  @PublishedApi
+  internal inline fun <reified T : Module> injectDeclaredDependenciesOf(module: T) {
+    T::class
+      .memberProperties
+      .filterIsInjection()
+      .associateBy { it.returnType.arguments.last().type?.classifier }
+      .mapKeys { (dependencyClassifier, _) -> dependencyClassifier as KClass<*> }
+      .onEach { (_, property) -> property.isAccessible = true }
+      .mapValues { (_, property) -> property.get(module) }
+      .forEach { (dependencyClass, injection) ->
+        module.inject(dependencyClass, injection.castTo())
+      }
+  }
 }

--- a/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/Inject.kt
+++ b/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/Inject.kt
@@ -11,10 +11,9 @@ import com.jeanbarrossilva.orca.std.injector.Injector
  * it in the [Injector] injects `dependency` into `MyModule` and makes its provided `Int` accessible
  * via a `MyModule.dependency()` extension function.
  *
- * Note that the annotated property should return a `Module.() -> Any`, which is how an injection
- * is recognized; otherwise, an error will be thrown at build time.
+ * Note that the annotated property should return a `Module.() -> Any`, which is how an injection is
+ * recognized; otherwise, an error will be thrown at build time.
  *
  * @see Injector.register
- **/
-@Target(AnnotationTarget.PROPERTY)
-annotation class Inject
+ */
+@Target(AnnotationTarget.PROPERTY) annotation class Inject

--- a/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/Module.kt
+++ b/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/Module.kt
@@ -2,79 +2,75 @@ package com.jeanbarrossilva.orca.std.injector.module
 
 import kotlin.reflect.KClass
 
-/** Container in which dependencies within a given context can be injected. **/
+/** Container in which dependencies within a given context can be injected. */
 abstract class Module {
-    /** Dependencies that have been injected associated to their assigned types. **/
-    @PublishedApi
-    internal val injections = hashMapOf<KClass<*>, Lazy<Any>>()
+  /** Dependencies that have been injected associated to their assigned types. */
+  @PublishedApi internal val injections = hashMapOf<KClass<*>, Lazy<Any>>()
 
-    /**
-     * [NoSuchElementException] thrown if a dependency that hasn't been injected is requested to
-     * be obtained.
-     *
-     * @param dependencyClass [KClass] of the requested dependency.
-     **/
-    inner class DependencyNotInjectedException
-    @PublishedApi
-    internal constructor(dependencyClass: KClass<*>) :
-        NoSuchElementException(
-            "No dependency of type ${dependencyClass.qualifiedName} has been injected into " +
-                "${this::class.simpleName}."
-        )
+  /**
+   * [NoSuchElementException] thrown if a dependency that hasn't been injected is requested to be
+   * obtained.
+   *
+   * @param dependencyClass [KClass] of the requested dependency.
+   */
+  inner class DependencyNotInjectedException
+  @PublishedApi
+  internal constructor(dependencyClass: KClass<*>) :
+    NoSuchElementException(
+      "No dependency of type ${dependencyClass.qualifiedName} has been injected into " +
+        "${this::class.simpleName}."
+    )
 
-    /**
-     * Injects the dependency returned by the [injection].
-     *
-     * @param T Dependency to be injected.
-     * @param injection Returns the dependency to be injected.
-     **/
-    inline fun <reified T : Any> inject(noinline injection: Module.() -> T) {
-        inject(T::class, injection)
+  /**
+   * Injects the dependency returned by the [injection].
+   *
+   * @param T Dependency to be injected.
+   * @param injection Returns the dependency to be injected.
+   */
+  inline fun <reified T : Any> inject(noinline injection: Module.() -> T) {
+    inject(T::class, injection)
+  }
+
+  /**
+   * Lazily obtains the injected dependency whose type is [T].
+   *
+   * @param T Dependency to be lazily obtained.
+   */
+  inline fun <reified T : Any> lazy(): Lazy<T> {
+    return lazy(::get)
+  }
+
+  /**
+   * Obtains the injected dependency whose type is [T].
+   *
+   * @param T Dependency to be obtained.
+   * @throws DependencyNotInjectedException If no dependency of type [T] has been injected.
+   */
+  @Throws(NoSuchElementException::class)
+  inline fun <reified T : Any> get(): T {
+    return injections[T::class]?.value as T? ?: throw DependencyNotInjectedException(T::class)
+  }
+
+  /** Removes all injected dependencies. */
+  fun clear() {
+    injections.clear()
+    onClear()
+  }
+
+  /**
+   * Injects the dependency returned by the [injection].
+   *
+   * @param T Dependency to be injected.
+   * @param dependencyClass [KClass] to which the dependency will be associated.
+   * @param injection Returns the dependency to be injected.
+   */
+  @PublishedApi
+  internal fun <T : Any> inject(dependencyClass: KClass<T>, injection: Module.() -> T) {
+    if (dependencyClass !in injections) {
+      injections[dependencyClass] = lazy { injection() }
     }
+  }
 
-    /**
-     * Lazily obtains the injected dependency whose type is [T].
-     *
-     * @param T Dependency to be lazily obtained.
-     **/
-    inline fun <reified T : Any> lazy(): Lazy<T> {
-        return lazy(::get)
-    }
-
-    /**
-     * Obtains the injected dependency whose type is [T].
-     *
-     * @param T Dependency to be obtained.
-     * @throws DependencyNotInjectedException If no dependency of type [T] has been injected.
-     **/
-    @Throws(NoSuchElementException::class)
-    inline fun <reified T : Any> get(): T {
-        return injections[T::class]?.value as T? ?: throw DependencyNotInjectedException(T::class)
-    }
-
-    /** Removes all injected dependencies. **/
-    fun clear() {
-        injections.clear()
-        onClear()
-    }
-
-    /**
-     * Injects the dependency returned by the [injection].
-     *
-     * @param T Dependency to be injected.
-     * @param dependencyClass [KClass] to which the dependency will be associated.
-     * @param injection Returns the dependency to be injected.
-     **/
-    @PublishedApi
-    internal fun <T : Any> inject(dependencyClass: KClass<T>, injection: Module.() -> T) {
-        if (dependencyClass !in injections) {
-            injections[dependencyClass] = lazy {
-                injection()
-            }
-        }
-    }
-
-    /** Callback run whenever this [Module] is cleared. **/
-    internal open fun onClear() {
-    }
+  /** Callback run whenever this [Module] is cleared. */
+  internal open fun onClear() {}
 }

--- a/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/InjectorTests.kt
+++ b/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/InjectorTests.kt
@@ -9,61 +9,58 @@ import kotlin.test.Test
 import org.junit.Rule
 
 internal class InjectorTests {
-    @get:Rule
-    val injectorRule = InjectorTestRule()
+  @get:Rule val injectorRule = InjectorTestRule()
 
-    private abstract class SuperModuleWithNonAnnotatedDependency(
-        @Suppress("unused") private val dependency: Module.() -> Int
-    ) : Module()
+  private abstract class SuperModuleWithNonAnnotatedDependency(
+    @Suppress("unused") private val dependency: Module.() -> Int
+  ) : Module()
 
-    private class SubModuleWithAnnotatedDependency : SuperModuleWithAnnotatedDependency({ 0 })
+  private class SubModuleWithAnnotatedDependency : SuperModuleWithAnnotatedDependency({ 0 })
 
-    internal abstract class SuperModuleWithAnnotatedDependency(
-        @Inject val dependency: Module.() -> Int
-    ) : Module()
+  internal abstract class SuperModuleWithAnnotatedDependency(
+    @Inject val dependency: Module.() -> Int
+  ) : Module()
 
-    private class SubModuleWithNonAnnotatedDependency :
-        SuperModuleWithNonAnnotatedDependency({ 0 })
+  private class SubModuleWithNonAnnotatedDependency : SuperModuleWithNonAnnotatedDependency({ 0 })
 
-    @Test(expected = Injector.SelfRegistrationException::class)
-    fun throwsWhenRegisteringItself() {
-        Injector.register(Injector)
-    }
+  @Test(expected = Injector.SelfRegistrationException::class)
+  fun throwsWhenRegisteringItself() {
+    Injector.register(Injector)
+  }
 
-    @Test
-    fun registersModule() {
-        val module = object : Module() { }
-        Injector.register<Module>(module)
-        assertThat(Injector.from<Module>()).isEqualTo(module)
-    }
+  @Test
+  fun registersModule() {
+    val module = object : Module() {}
+    Injector.register<Module>(module)
+    assertThat(Injector.from<Module>()).isEqualTo(module)
+  }
 
-    @Test(expected = Injector.SelfRetrievalException::class)
-    fun throwsWhenGettingItself() {
-        Injector.from<Injector>()
-    }
+  @Test(expected = Injector.SelfRetrievalException::class)
+  fun throwsWhenGettingItself() {
+    Injector.from<Injector>()
+  }
 
-    @Test(expected = Injector.ModuleNotRegisteredException::class)
-    fun throwsWhenGettingUnregisteredModule() {
-        Injector.from<Module>()
-    }
+  @Test(expected = Injector.ModuleNotRegisteredException::class)
+  fun throwsWhenGettingUnregisteredModule() {
+    Injector.from<Module>()
+  }
 
-    @Test(expected = Module.DependencyNotInjectedException::class)
-    fun doesNotInjectNonAnnotatedModuleDependenciesWhenRegisteringIt() {
-        Injector
-            .register<SuperModuleWithNonAnnotatedDependency>(SubModuleWithNonAnnotatedDependency())
-        Injector.from<SuperModuleWithNonAnnotatedDependency>().get<Int>()
-    }
+  @Test(expected = Module.DependencyNotInjectedException::class)
+  fun doesNotInjectNonAnnotatedModuleDependenciesWhenRegisteringIt() {
+    Injector.register<SuperModuleWithNonAnnotatedDependency>(SubModuleWithNonAnnotatedDependency())
+    Injector.from<SuperModuleWithNonAnnotatedDependency>().get<Int>()
+  }
 
-    @Test
-    fun injectsAnnotatedModuleDependenciesWhenRegisteringIt() {
-        Injector.register<SuperModuleWithAnnotatedDependency>(SubModuleWithAnnotatedDependency())
-        assertThat(Injector.from<SuperModuleWithAnnotatedDependency>().get<Int>()).isEqualTo(0)
-    }
+  @Test
+  fun injectsAnnotatedModuleDependenciesWhenRegisteringIt() {
+    Injector.register<SuperModuleWithAnnotatedDependency>(SubModuleWithAnnotatedDependency())
+    assertThat(Injector.from<SuperModuleWithAnnotatedDependency>().get<Int>()).isEqualTo(0)
+  }
 
-    @Test
-    fun getsDependencyFromModuleInjectedAfterItWasRegistered() {
-        Injector.register<Module>(object : Module() { })
-        Injector.from<Module>().inject { 0 }
-        assertThat(Injector.from<Module>().get<Int>()).isEqualTo(0)
-    }
+  @Test
+  fun getsDependencyFromModuleInjectedAfterItWasRegistered() {
+    Injector.register<Module>(object : Module() {})
+    Injector.from<Module>().inject { 0 }
+    assertThat(Injector.from<Module>().get<Int>()).isEqualTo(0)
+  }
 }

--- a/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/ModuleTests.kt
+++ b/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/ModuleTests.kt
@@ -8,31 +8,30 @@ import kotlin.test.Test
 import org.junit.Rule
 
 internal class ModuleTests {
-    @get:Rule
-    val injectorRule = InjectorTestRule()
+  @get:Rule val injectorRule = InjectorTestRule()
 
-    @Test
-    fun injectsDependency() {
-        Injector.inject { 0 }
-        assertThat(Injector.get<Int>()).isEqualTo(0)
-    }
+  @Test
+  fun injectsDependency() {
+    Injector.inject { 0 }
+    assertThat(Injector.get<Int>()).isEqualTo(0)
+  }
 
-    @Test(expected = Module.DependencyNotInjectedException::class)
-    fun throwsWhenGettingDependencyThatHasNotBeenInjected() {
-        Injector.get<Int>()
-    }
+  @Test(expected = Module.DependencyNotInjectedException::class)
+  fun throwsWhenGettingDependencyThatHasNotBeenInjected() {
+    Injector.get<Int>()
+  }
 
-    @Test
-    fun getsDependencyThatGetsPreviouslyInjectedOne() {
-        Injector.inject { 0 }
-        Injector.inject { get<Int>() }
-        assertThat(Injector.get<Int>()).isEqualTo(0)
-    }
+  @Test
+  fun getsDependencyThatGetsPreviouslyInjectedOne() {
+    Injector.inject { 0 }
+    Injector.inject { get<Int>() }
+    assertThat(Injector.get<Int>()).isEqualTo(0)
+  }
 
-    @Test(Module.DependencyNotInjectedException::class)
-    fun clears() {
-        Injector.inject { 0 }
-        Injector.clear()
-        Injector.get<Int>()
-    }
+  @Test(Module.DependencyNotInjectedException::class)
+  fun clears() {
+    Injector.inject { 0 }
+    Injector.clear()
+    Injector.get<Int>()
+  }
 }

--- a/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/String.extensions.kt
+++ b/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/String.extensions.kt
@@ -15,7 +15,7 @@ import java.net.URL
  * @param emailDelimiter [Email.Delimiter] by which this [String]'s e-mails are delimited.
  * @param hashtagDelimiter [Hashtag.Delimiter] by which this [String]'s hashtags are delimited.
  * @param italicDelimiter [Italic.Delimiter] by which this [String]'s italicized portions are
- * delimited.
+ *   delimited.
  * @param linkDelimiter [Link.Delimiter] by which this [String]'s links are delimited.
  * @param mentionDelimiter [Mention.Delimiter] by which this [String]'s mentions are delimited.
  * @param mentioning Given its start index, maps each mention to a username to a [URL].
@@ -25,36 +25,36 @@ import java.net.URL
  * @see Italic
  * @see Link
  * @see Mention
- **/
+ */
 fun String.toStyledString(
-    boldDelimiter: Bold.Delimiter? = Bold.Delimiter.Default,
-    emailDelimiter: Email.Delimiter = Email.Delimiter.Default,
-    hashtagDelimiter: Hashtag.Delimiter? = Hashtag.Delimiter.Default,
-    italicDelimiter: Italic.Delimiter? = Italic.Delimiter.Default,
-    linkDelimiter: Link.Delimiter? = Link.Delimiter.Default,
-    mentionDelimiter: Mention.Delimiter? = Mention.Delimiter.Default,
-    mentioning: (startIndex: Int) -> URL? = { null }
+  boldDelimiter: Bold.Delimiter? = Bold.Delimiter.Default,
+  emailDelimiter: Email.Delimiter = Email.Delimiter.Default,
+  hashtagDelimiter: Hashtag.Delimiter? = Hashtag.Delimiter.Default,
+  italicDelimiter: Italic.Delimiter? = Italic.Delimiter.Default,
+  linkDelimiter: Link.Delimiter? = Link.Delimiter.Default,
+  mentionDelimiter: Mention.Delimiter? = Mention.Delimiter.Default,
+  mentioning: (startIndex: Int) -> URL? = { null }
 ): StyledString {
-    val text = StyledString.normalize(
-        this,
-        boldDelimiter,
-        emailDelimiter,
-        hashtagDelimiter,
-        italicDelimiter,
-        linkDelimiter,
-        mentionDelimiter
+  val text =
+    StyledString.normalize(
+      this,
+      boldDelimiter,
+      emailDelimiter,
+      hashtagDelimiter,
+      italicDelimiter,
+      linkDelimiter,
+      mentionDelimiter
     )
-    val emboldened = text.stylize(Bold.Delimiter.Default, ::Bold)
-    val emails = text.stylize(Email.Delimiter.Default, ::Email)
-    val hashtags = text.stylize(Hashtag.Delimiter.Default, ::Hashtag)
-    val italicized = text.stylize(Italic.Delimiter.Default, ::Italic)
-    val links = text.stylize(Link.Delimiter.Default, ::Link)
-    val mentions = text.stylize(Mention.Delimiter.Default) {
-        mentioning(it.first)?.let { url ->
-            Mention(indices = it, url)
-        }
+  val emboldened = text.stylize(Bold.Delimiter.Default, ::Bold)
+  val emails = text.stylize(Email.Delimiter.Default, ::Email)
+  val hashtags = text.stylize(Hashtag.Delimiter.Default, ::Hashtag)
+  val italicized = text.stylize(Italic.Delimiter.Default, ::Italic)
+  val links = text.stylize(Link.Delimiter.Default, ::Link)
+  val mentions =
+    text.stylize(Mention.Delimiter.Default) {
+      mentioning(it.first)?.let { url -> Mention(indices = it, url) }
     }
-    return StyledString(text, emails + emboldened + hashtags + italicized + links + mentions)
+  return StyledString(text, emails + emboldened + hashtags + italicized + links + mentions)
 }
 
 /**
@@ -62,10 +62,10 @@ fun String.toStyledString(
  *
  * @param delimiter [Style.Delimiter] by which the [Style]s to be obtained are delimited.
  * @param style Returns the respective [Style] applied to the given [indices] of this [String].
- **/
+ */
 internal fun <T : Style> String.stylize(
-    delimiter: Style.Delimiter?,
-    style: (indices: IntRange) -> T?
+  delimiter: Style.Delimiter?,
+  style: (indices: IntRange) -> T?
 ): List<T> {
-    return delimiter?.delimit(this)?.mapNotNull { style(it.range) }.orEmpty()
+  return delimiter?.delimit(this)?.mapNotNull { style(it.range) }.orEmpty()
 }

--- a/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/Style.kt
+++ b/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/Style.kt
@@ -2,99 +2,96 @@ package com.jeanbarrossilva.orca.std.styledstring
 
 import java.io.Serializable
 
-/** Indicates where and how a target has been stylized. **/
+/** Indicates where and how a target has been stylized. */
 abstract class Style : Serializable {
-    /** Indices at which both the style symbols and the target are in the whole [String]. **/
-    abstract val indices: IntRange
+  /** Indices at which both the style symbols and the target are in the whole [String]. */
+  abstract val indices: IntRange
+
+  /**
+   * Describes how a portion of a whole [String] is stylized is applied and identifies the target
+   * it's been applied onto.
+   */
+  abstract class Delimiter {
+    /** Previously applied delimitations to [String]s. */
+    private val delimitations = HashMap<String, List<MatchResult>>()
+
+    /** Root [Delimiter] in the tree. */
+    internal val root: Delimiter by lazy { parent?.root ?: this }
+
+    /** [Delimiter] that's this one's parent. */
+    internal abstract val parent: Delimiter?
+
+    /** [Regex] that matches a styled target. */
+    internal val regex by lazy(::getRegex)
 
     /**
-     * Describes how a portion of a whole [String] is stylized is applied and identifies the target
-     * it's been applied onto.
-     **/
-    abstract class Delimiter {
-        /** Previously applied delimitations to [String]s. **/
-        private val delimitations = HashMap<String, List<MatchResult>>()
-
-        /** Root [Delimiter] in the tree. **/
-        internal val root: Delimiter by lazy { parent?.root ?: this }
-
-        /** [Delimiter] that's this one's parent. **/
-        internal abstract val parent: Delimiter?
-
-        /** [Regex] that matches a styled target. **/
-        internal val regex by lazy(::getRegex)
-
-        /**
-         * Delimits the whole [string].
-         *
-         * @param string [String] with targets to be delimited.
-         **/
-        internal fun delimit(string: String): List<MatchResult> {
-            return delimitations.getOrPut(string) {
-                regex.findAll(string).toList()
-            }
-        }
-
-        /**
-         * Gets the target from the [String] region that matches the [regex].
-         *
-         * @param match Part of the [String] in which the target has been found.
-         **/
-        internal fun getTarget(match: String): String {
-            return onGetTarget(match)
-        }
-
-        /**
-         * Adds the [Style]'s symbols to the [target].
-         *
-         * @param target [String] to be targeted.
-         **/
-        internal fun target(target: String): String {
-            return onTarget(target)
-        }
-
-        /** Gets the [Regex] that matches a styled target. **/
-        protected abstract fun getRegex(): Regex
-
-        /**
-         * Gets the target from the [String] region that matches the [regex].
-         *
-         * @param match Part of the [String] in which the target has been found.
-         **/
-        protected abstract fun onGetTarget(match: String): String
-
-        /**
-         * Adds the [Style]'s symbols to the [target].
-         *
-         * @param target [String] to be targeted.
-         **/
-        protected abstract fun onTarget(target: String): String
-
-        companion object {
-            /**
-             * Creates a [Delimiter] that delimits a target by surrounding it with the given
-             * [symbol].
-             *
-             * @param symbol [Char] by which targets will be surrounded.
-             **/
-            internal fun surroundedBy(symbol: Char): Delimiter {
-                return object : Delimiter() {
-                    override val parent = null
-
-                    override fun getRegex(): Regex {
-                        val escapedSymbol = Regex.escape("$symbol")
-                        return Regex("$escapedSymbol.+?$escapedSymbol")
-                    }
-
-                    override fun onGetTarget(match: String): String {
-                        return match.substringAfter(symbol).substringBefore(symbol)
-                    }
-
-                    override fun onTarget(target: String): String {
-                        return symbol + target + symbol
-                    }
-                }
-            }
-        }
+     * Delimits the whole [string].
+     *
+     * @param string [String] with targets to be delimited.
+     */
+    internal fun delimit(string: String): List<MatchResult> {
+      return delimitations.getOrPut(string) { regex.findAll(string).toList() }
     }
+
+    /**
+     * Gets the target from the [String] region that matches the [regex].
+     *
+     * @param match Part of the [String] in which the target has been found.
+     */
+    internal fun getTarget(match: String): String {
+      return onGetTarget(match)
+    }
+
+    /**
+     * Adds the [Style]'s symbols to the [target].
+     *
+     * @param target [String] to be targeted.
+     */
+    internal fun target(target: String): String {
+      return onTarget(target)
+    }
+
+    /** Gets the [Regex] that matches a styled target. */
+    protected abstract fun getRegex(): Regex
+
+    /**
+     * Gets the target from the [String] region that matches the [regex].
+     *
+     * @param match Part of the [String] in which the target has been found.
+     */
+    protected abstract fun onGetTarget(match: String): String
+
+    /**
+     * Adds the [Style]'s symbols to the [target].
+     *
+     * @param target [String] to be targeted.
+     */
+    protected abstract fun onTarget(target: String): String
+
+    companion object {
+      /**
+       * Creates a [Delimiter] that delimits a target by surrounding it with the given [symbol].
+       *
+       * @param symbol [Char] by which targets will be surrounded.
+       */
+      internal fun surroundedBy(symbol: Char): Delimiter {
+        return object : Delimiter() {
+          override val parent = null
+
+          override fun getRegex(): Regex {
+            val escapedSymbol = Regex.escape("$symbol")
+            return Regex("$escapedSymbol.+?$escapedSymbol")
+          }
+
+          override fun onGetTarget(match: String): String {
+            return match.substringAfter(symbol).substringBefore(symbol)
+          }
+
+          override fun onTarget(target: String): String {
+            return symbol + target + symbol
+          }
+        }
+      }
+    }
+  }
 }

--- a/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/StyledString.extensions.kt
+++ b/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/StyledString.extensions.kt
@@ -4,7 +4,7 @@ package com.jeanbarrossilva.orca.std.styledstring
  * Builds a [StyledString].
  *
  * @param build Configures the [StyledString] to be built.
- **/
+ */
 inline fun buildStyledString(build: StyledString.Builder.() -> Unit): StyledString {
-    return StyledString.Builder().apply(build).build()
+  return StyledString.Builder().apply(build).build()
 }

--- a/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/StyledString.kt
+++ b/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/StyledString.kt
@@ -22,212 +22,200 @@ import java.util.Objects
  *
  * @param text Underlying [String] that's been built.
  * @param styles [Style]s applied to the [text].
- **/
+ */
 class StyledString internal constructor(private val text: String, val styles: List<Style>) :
-    CharSequence by text, Serializable {
-    /**
-     * [StyledString] without [Style]s.
-     *
-     * @param text [String] without any [Style]s attached to it.
-     **/
-    constructor(text: String) : this(text, styles = emptyList())
+  CharSequence by text, Serializable {
+  /**
+   * [StyledString] without [Style]s.
+   *
+   * @param text [String] without any [Style]s attached to it.
+   */
+  constructor(text: String) : this(text, styles = emptyList())
+
+  /**
+   * Allows text and [Style]s to be appended and for a [StyledString] to be built.
+   *
+   * @see append
+   * @see bold
+   * @see hashtag
+   * @see italic
+   * @see mention
+   * @see build
+   */
+  class Builder @PublishedApi internal constructor() {
+    /** [String] to be the [text][StyledString.text] of the [StyledString] being built. */
+    private var text = ""
+
+    /** [Style]s applied to the [text]. */
+    private val styles = mutableListOf<Style>()
+
+    /** [Appender]s that are currently active. */
+    private val activeAppenders = mutableListOf<Appender>()
 
     /**
-     * Allows text and [Style]s to be appended and for a [StyledString] to be built.
+     * Appends text with the result of [style] applied to it through [append].
      *
-     * @see append
-     * @see bold
-     * @see hashtag
-     * @see italic
-     * @see mention
-     * @see build
-     **/
-    class Builder @PublishedApi internal constructor() {
-        /**
-         * [String] to be the [text][StyledString.text] of the [StyledString] being built.
-         **/
-        private var text = ""
+     * @param delimiter [Style.Delimiter] by which the result of [style] applied to the text will be
+     *   delimited.
+     * @param style Creates a [Style] based on the given indices at which it'll be applied.
+     */
+    inner class Appender
+    internal constructor(
+      private val delimiter: Style.Delimiter,
+      private val style: (indices: IntRange) -> Style
+    ) {
+      /**
+       * Appends this [Char], stylizing it with the result of [style] and the [Style]s of
+       * [Appender]s that are currently active.
+       */
+      operator fun Char.unaryPlus() {
+        +toString()
+      }
 
-        /** [Style]s applied to the [text]. **/
-        private val styles = mutableListOf<Style>()
+      /**
+       * Appends this [String], stylizing it with the result of [style] and the [Style]s of
+       * [Appender]s that are currently active.
+       */
+      operator fun String.unaryPlus() {
+        val stylized = delimiter.target(this)
+        require(stylized matches delimiter.regex) { "\"$stylized\" is invalid." }
+        val indices = calculateIndicesFor(stylized)
+        val styles = activeAppenders.map { it.style(indices) }
+        with(this@Builder) { +stylized }
+        this@Builder.styles.addAll(styles)
+      }
 
-        /** [Appender]s that are currently active. **/
-        private val activeAppenders = mutableListOf<Appender>()
-
-        /**
-         * Appends text with the result of [style] applied to it through [append].
-         *
-         * @param delimiter [Style.Delimiter] by which the result of [style] applied to the text
-         * will be delimited.
-         * @param style Creates a [Style] based on the given indices at which it'll be applied.
-         **/
-        inner class Appender internal constructor(
-            private val delimiter: Style.Delimiter,
-            private val style: (indices: IntRange) -> Style
-        ) {
-            /**
-             * Appends this [Char], stylizing it with the result of [style] and the [Style]s of
-             * [Appender]s that are currently active.
-             **/
-            operator fun Char.unaryPlus() {
-                +toString()
-            }
-
-            /**
-             * Appends this [String], stylizing it with the result of [style] and the [Style]s of
-             * [Appender]s that are currently active.
-             **/
-            operator fun String.unaryPlus() {
-                val stylized = delimiter.target(this)
-                require(stylized matches delimiter.regex) { "\"$stylized\" is invalid." }
-                val indices = calculateIndicesFor(stylized)
-                val styles = activeAppenders.map { it.style(indices) }
-                with(this@Builder) { +stylized }
-                this@Builder.styles.addAll(styles)
-            }
-
-            /** Calculates the indices at which the [text] will be when appended. **/
-            private fun calculateIndicesFor(text: String): IntRange {
-                return this@Builder.text.length..(this@Builder.text.length + text.lastIndex)
-            }
-        }
-
-        /**
-         * Appends this [Char] to the [text][StyledString.text] of the [StyledString] being built.
-         **/
-        operator fun Char.unaryPlus() {
-            text += this
-        }
-
-        /**
-         * Appends this [String] to the [text][StyledString.text] of the [StyledString] being built.
-         **/
-        operator fun String.unaryPlus() {
-            text += this
-        }
-
-        /**
-         * Emboldens the text to be appended.
-         *
-         * @param appendix Additionally stylizes the bold text to be appended or solely appends it.
-         * @see Bold
-         **/
-        fun bold(appendix: Appender.() -> Unit) {
-            append(Bold.Delimiter.Default, appendix, ::Bold)
-        }
-
-        /**
-         * Turns the text to be appended into a hashtag.
-         *
-         * @param appendix Additionally stylizes the hashtag to be appended or solely appends it.
-         * @see Hashtag
-         **/
-        fun hashtag(appendix: Appender.() -> Unit) {
-            append(Hashtag.Delimiter.Default, appendix, ::Hashtag)
-        }
-
-        /**
-         * Italicizes the text to be appended.
-         *
-         * @param appendix Additionally stylizes the italic text to be appended or solely appends
-         * it.
-         * @see Italic
-         **/
-        fun italic(appendix: Appender.() -> Unit) {
-            append(Italic.Delimiter.Default, appendix, ::Italic)
-        }
-
-        /**
-         * Turns the text to be appended into a mention.
-         *
-         * @param appendix Additionally stylizes the mention to be appended or solely appends it.
-         * @see Mention
-         **/
-        fun mention(url: URL, appendix: Appender.() -> Unit) {
-            append(Mention.Delimiter.Default, appendix) {
-                Mention(it, url)
-            }
-        }
-
-        /** Builds a [StyledString] with the provided styles. **/
-        @PublishedApi
-        internal fun build(): StyledString {
-            val emails = text.stylize(Email.Delimiter.Default, ::Email)
-            val links = text.stylize(Link.Delimiter.Default, ::Link)
-            val stylesAsList = styles.apply { addAll(emails + links) }.toList()
-            return StyledString(text, stylesAsList)
-        }
-
-        /**
-         * Creates an [Appender] and runs [appendix] on it, making it active for as long as it's
-         * being used.
-         *
-         * @param delimiter [Style.Delimiter] by which the result of [style] applied to the text
-         * will be delimited.
-         * @param appendix Additionally stylizes the text to be appended or solely appends it.
-         * @param style Creates the [Style] to be applied to the appended text at the specified
-         * indices.
-         **/
-        private fun append(
-            delimiter: Style.Delimiter,
-            appendix: Appender.() -> Unit,
-            style: (IntRange) -> Style
-        ) {
-            val appender = Appender(delimiter, style)
-            activeAppenders.add(appender)
-            appender.appendix()
-            activeAppenders.remove(appender)
-        }
+      /** Calculates the indices at which the [text] will be when appended. */
+      private fun calculateIndicesFor(text: String): IntRange {
+        return this@Builder.text.length..(this@Builder.text.length + text.lastIndex)
+      }
     }
 
-    override fun equals(other: Any?): Boolean {
-        return other is String &&
-            toString() == other ||
-            other is StyledString &&
-            text == other.text &&
-            styles.containsAll(other.styles)
+    /** Appends this [Char] to the [text][StyledString.text] of the [StyledString] being built. */
+    operator fun Char.unaryPlus() {
+      text += this
     }
 
-    override fun hashCode(): Int {
-        return Objects.hash(text, styles)
+    /** Appends this [String] to the [text][StyledString.text] of the [StyledString] being built. */
+    operator fun String.unaryPlus() {
+      text += this
     }
 
-    override fun toString(): String {
-        return text
+    /**
+     * Emboldens the text to be appended.
+     *
+     * @param appendix Additionally stylizes the bold text to be appended or solely appends it.
+     * @see Bold
+     */
+    fun bold(appendix: Appender.() -> Unit) {
+      append(Bold.Delimiter.Default, appendix, ::Bold)
     }
 
-    companion object {
-        /**
-         * Normalizes the [string] whose [Style]s are delimited by the specified [delimiters].
-         *
-         * @param string [String] to be normalized.
-         * @param delimiters [Style.Delimiter] by which the [String]'s [Style]s are delimited.
-         **/
-        internal fun normalize(string: String, vararg delimiters: Style.Delimiter?): String {
-            var normalized = string
-            val delimiterIterator = delimiters.filterNotNull().iterator()
-            while (delimiterIterator.hasNext()) {
-                normalized = normalize(normalized, delimiterIterator.next())
-            }
-            return normalized
-        }
-
-        /**
-         * Normalizes the [string] whose respective [Style] is delimited by the specified
-         * [delimiter].
-         *
-         * @param string [String] to be normalized.
-         * @param delimiter [Style.Delimiter] by which the [String]'s [Style] is delimited.
-         **/
-        internal fun normalize(string: String, delimiter: Style.Delimiter): String {
-            var normalized = string
-            delimiter.delimit(normalized).forEach {
-                normalized = normalized.replaceRange(
-                    it.range.first..it.range.last,
-                    delimiter.root.target(delimiter.getTarget(it.value))
-                )
-            }
-            return normalized
-        }
+    /**
+     * Turns the text to be appended into a hashtag.
+     *
+     * @param appendix Additionally stylizes the hashtag to be appended or solely appends it.
+     * @see Hashtag
+     */
+    fun hashtag(appendix: Appender.() -> Unit) {
+      append(Hashtag.Delimiter.Default, appendix, ::Hashtag)
     }
+
+    /**
+     * Italicizes the text to be appended.
+     *
+     * @param appendix Additionally stylizes the italic text to be appended or solely appends it.
+     * @see Italic
+     */
+    fun italic(appendix: Appender.() -> Unit) {
+      append(Italic.Delimiter.Default, appendix, ::Italic)
+    }
+
+    /**
+     * Turns the text to be appended into a mention.
+     *
+     * @param appendix Additionally stylizes the mention to be appended or solely appends it.
+     * @see Mention
+     */
+    fun mention(url: URL, appendix: Appender.() -> Unit) {
+      append(Mention.Delimiter.Default, appendix) { Mention(it, url) }
+    }
+
+    /** Builds a [StyledString] with the provided styles. */
+    @PublishedApi
+    internal fun build(): StyledString {
+      val emails = text.stylize(Email.Delimiter.Default, ::Email)
+      val links = text.stylize(Link.Delimiter.Default, ::Link)
+      val stylesAsList = styles.apply { addAll(emails + links) }.toList()
+      return StyledString(text, stylesAsList)
+    }
+
+    /**
+     * Creates an [Appender] and runs [appendix] on it, making it active for as long as it's being
+     * used.
+     *
+     * @param delimiter [Style.Delimiter] by which the result of [style] applied to the text will be
+     *   delimited.
+     * @param appendix Additionally stylizes the text to be appended or solely appends it.
+     * @param style Creates the [Style] to be applied to the appended text at the specified indices.
+     */
+    private fun append(
+      delimiter: Style.Delimiter,
+      appendix: Appender.() -> Unit,
+      style: (IntRange) -> Style
+    ) {
+      val appender = Appender(delimiter, style)
+      activeAppenders.add(appender)
+      appender.appendix()
+      activeAppenders.remove(appender)
+    }
+  }
+
+  override fun equals(other: Any?): Boolean {
+    return other is String && toString() == other ||
+      other is StyledString && text == other.text && styles.containsAll(other.styles)
+  }
+
+  override fun hashCode(): Int {
+    return Objects.hash(text, styles)
+  }
+
+  override fun toString(): String {
+    return text
+  }
+
+  companion object {
+    /**
+     * Normalizes the [string] whose [Style]s are delimited by the specified [delimiters].
+     *
+     * @param string [String] to be normalized.
+     * @param delimiters [Style.Delimiter] by which the [String]'s [Style]s are delimited.
+     */
+    internal fun normalize(string: String, vararg delimiters: Style.Delimiter?): String {
+      var normalized = string
+      val delimiterIterator = delimiters.filterNotNull().iterator()
+      while (delimiterIterator.hasNext()) {
+        normalized = normalize(normalized, delimiterIterator.next())
+      }
+      return normalized
+    }
+
+    /**
+     * Normalizes the [string] whose respective [Style] is delimited by the specified [delimiter].
+     *
+     * @param string [String] to be normalized.
+     * @param delimiter [Style.Delimiter] by which the [String]'s [Style] is delimited.
+     */
+    internal fun normalize(string: String, delimiter: Style.Delimiter): String {
+      var normalized = string
+      delimiter.delimit(normalized).forEach {
+        normalized =
+          normalized.replaceRange(
+            it.range.first..it.range.last,
+            delimiter.root.target(delimiter.getTarget(it.value))
+          )
+      }
+      return normalized
+    }
+  }
 }

--- a/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/type/Bold.kt
+++ b/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/type/Bold.kt
@@ -2,41 +2,41 @@ package com.jeanbarrossilva.orca.std.styledstring.type
 
 import com.jeanbarrossilva.orca.std.styledstring.Style
 
-/** [Style] that applies a heavier weight to the target's font. **/
+/** [Style] that applies a heavier weight to the target's font. */
 data class Bold(override val indices: IntRange) : Style() {
-    /** [Style.Delimiter] for emboldened portions of a [String]. **/
-    sealed class Delimiter : Style.Delimiter() {
-        /**
-         * [Delimiter] that's the [parent] of all [Delimiter.Variant]s and considers [Bold] parts of
-         * a [String] surrounded by a [Bold.SYMBOL].
-         **/
-        internal object Default : Delimiter() {
-            /** [Delimiter] to which overridden functionality will be delegated. **/
-            private val delegate = surroundedBy(SYMBOL)
+  /** [Style.Delimiter] for emboldened portions of a [String]. */
+  sealed class Delimiter : Style.Delimiter() {
+    /**
+     * [Delimiter] that's the [parent] of all [Delimiter.Variant]s and considers [Bold] parts of a
+     * [String] surrounded by a [Bold.SYMBOL].
+     */
+    internal object Default : Delimiter() {
+      /** [Delimiter] to which overridden functionality will be delegated. */
+      private val delegate = surroundedBy(SYMBOL)
 
-            override val parent = delegate.parent
+      override val parent = delegate.parent
 
-            override fun getRegex(): Regex {
-                return delegate.regex
-            }
+      override fun getRegex(): Regex {
+        return delegate.regex
+      }
 
-            override fun onGetTarget(match: String): String {
-                return delegate.getTarget(match)
-            }
+      override fun onGetTarget(match: String): String {
+        return delegate.getTarget(match)
+      }
 
-            override fun onTarget(target: String): String {
-                return delegate.target(target)
-            }
-        }
-
-        /** [Delimiter] that's a child of [Default]. **/
-        abstract class Variant : Delimiter() {
-            final override val parent = Default
-        }
+      override fun onTarget(target: String): String {
+        return delegate.target(target)
+      }
     }
 
-    companion object {
-        /** [Char] that indicates the start and the end of a bold target. **/
-        internal const val SYMBOL = '*'
+    /** [Delimiter] that's a child of [Default]. */
+    abstract class Variant : Delimiter() {
+      final override val parent = Default
     }
+  }
+
+  companion object {
+    /** [Char] that indicates the start and the end of a bold target. */
+    internal const val SYMBOL = '*'
+  }
 }

--- a/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/type/Email.kt
+++ b/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/type/Email.kt
@@ -2,42 +2,43 @@ package com.jeanbarrossilva.orca.std.styledstring.type
 
 import com.jeanbarrossilva.orca.std.styledstring.Style
 
-/** [Style] for referencing an e-mail, such as "john@appleseed.com". **/
+/** [Style] for referencing an e-mail, such as "john@appleseed.com". */
 data class Email(override val indices: IntRange) : Style() {
-    /** [Style.Delimiter] for [Email]s. **/
-    sealed class Delimiter : Style.Delimiter() {
-        /** [Delimiter] that's the [parent] of all [Variant]s. **/
-        internal object Default : Delimiter() {
-            override val parent = null
+  /** [Style.Delimiter] for [Email]s. */
+  sealed class Delimiter : Style.Delimiter() {
+    /** [Delimiter] that's the [parent] of all [Variant]s. */
+    internal object Default : Delimiter() {
+      override val parent = null
 
-            override fun getRegex(): Regex {
-                return Email.regex
-            }
+      override fun getRegex(): Regex {
+        return Email.regex
+      }
 
-            override fun onGetTarget(match: String): String {
-                return match
-            }
+      override fun onGetTarget(match: String): String {
+        return match
+      }
 
-            override fun onTarget(target: String): String {
-                return target
-            }
-        }
-
-        /** [Delimiter] that's a child of [Default]. **/
-        abstract class Variant : Delimiter() {
-            final override val parent = Default
-        }
+      override fun onTarget(target: String): String {
+        return target
+      }
     }
 
-    companion object {
-        /** [Regex] that matches an [Email]. **/
-        internal val regex = Regex(
-            "(?:[a-z0-9!#\$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#\$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\" +
-                "x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c" +
-                "\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]" +
-                "*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-" +
-                "4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f" +
-                "\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)])"
-        )
+    /** [Delimiter] that's a child of [Default]. */
+    abstract class Variant : Delimiter() {
+      final override val parent = Default
     }
+  }
+
+  companion object {
+    /** [Regex] that matches an [Email]. */
+    internal val regex =
+      Regex(
+        "(?:[a-z0-9!#\$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#\$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\" +
+          "x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c" +
+          "\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]" +
+          "*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-" +
+          "4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f" +
+          "\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)])"
+      )
+  }
 }

--- a/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/type/Hashtag.kt
+++ b/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/type/Hashtag.kt
@@ -2,45 +2,45 @@ package com.jeanbarrossilva.orca.std.styledstring.type
 
 import com.jeanbarrossilva.orca.std.styledstring.Style
 
-/** [Style] for a specific subject. **/
+/** [Style] for a specific subject. */
 data class Hashtag(override val indices: IntRange) : Style() {
-    /** [Style.Delimiter] for [Mention]s. **/
-    sealed class Delimiter : Style.Delimiter() {
-        /**
-         * [Delimiter] that's the [parent] of all [Variant]s and considers [Hashtag]s parts of a
-         * [String] starting with a [SYMBOL] and determines its end by the absence of alphanumeric
-         * or some other special characters.
-         **/
-        internal object Default : Delimiter() {
-            override val parent = null
+  /** [Style.Delimiter] for [Mention]s. */
+  sealed class Delimiter : Style.Delimiter() {
+    /**
+     * [Delimiter] that's the [parent] of all [Variant]s and considers [Hashtag]s parts of a
+     * [String] starting with a [SYMBOL] and determines its end by the absence of alphanumeric or
+     * some other special characters.
+     */
+    internal object Default : Delimiter() {
+      override val parent = null
 
-            override fun getRegex(): Regex {
-                return Hashtag.regex
-            }
+      override fun getRegex(): Regex {
+        return Hashtag.regex
+      }
 
-            override fun onGetTarget(match: String): String {
-                return match.removePrefix("$SYMBOL")
-            }
+      override fun onGetTarget(match: String): String {
+        return match.removePrefix("$SYMBOL")
+      }
 
-            override fun onTarget(target: String): String {
-                return SYMBOL + target
-            }
-        }
-
-        /** [Delimiter] that's a child of [Default]. **/
-        abstract class Variant : Delimiter() {
-            final override val parent = Default
-        }
+      override fun onTarget(target: String): String {
+        return SYMBOL + target
+      }
     }
 
-    companion object {
-        /** [Char] that indicates the start of a [Hashtag] by default. **/
-        const val SYMBOL = '#'
-
-        /** [Regex] that matches a [Hashtag]'s target. **/
-        val targetRegex = Regex("\\w+")
-
-        /** [Regex] that matches a [Hashtag]. **/
-        internal val regex = Regex("#$targetRegex")
+    /** [Delimiter] that's a child of [Default]. */
+    abstract class Variant : Delimiter() {
+      final override val parent = Default
     }
+  }
+
+  companion object {
+    /** [Char] that indicates the start of a [Hashtag] by default. */
+    const val SYMBOL = '#'
+
+    /** [Regex] that matches a [Hashtag]'s target. */
+    val targetRegex = Regex("\\w+")
+
+    /** [Regex] that matches a [Hashtag]. */
+    internal val regex = Regex("#$targetRegex")
+  }
 }

--- a/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/type/Italic.kt
+++ b/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/type/Italic.kt
@@ -2,41 +2,41 @@ package com.jeanbarrossilva.orca.std.styledstring.type
 
 import com.jeanbarrossilva.orca.std.styledstring.Style
 
-/** [Style] that slightly slants the target [String] to the right. **/
+/** [Style] that slightly slants the target [String] to the right. */
 data class Italic(override val indices: IntRange) : Style() {
-    /** [Style.Delimiter] for italicized portions of a [String]. **/
-    sealed class Delimiter : Style.Delimiter() {
-        /**
-         * [Delimiter] that's the [parent] of all [Delimiter.Variant]s and considers [Italic] parts
-         * of a [String] surrounded by a [SYMBOL].
-         **/
-        internal object Default : Delimiter() {
-            /** [Delimiter] to which overridden functionality will be delegated. **/
-            private val delegate = surroundedBy(SYMBOL)
+  /** [Style.Delimiter] for italicized portions of a [String]. */
+  sealed class Delimiter : Style.Delimiter() {
+    /**
+     * [Delimiter] that's the [parent] of all [Delimiter.Variant]s and considers [Italic] parts of a
+     * [String] surrounded by a [SYMBOL].
+     */
+    internal object Default : Delimiter() {
+      /** [Delimiter] to which overridden functionality will be delegated. */
+      private val delegate = surroundedBy(SYMBOL)
 
-            override val parent = delegate.parent
+      override val parent = delegate.parent
 
-            override fun getRegex(): Regex {
-                return delegate.regex
-            }
+      override fun getRegex(): Regex {
+        return delegate.regex
+      }
 
-            override fun onGetTarget(match: String): String {
-                return delegate.getTarget(match)
-            }
+      override fun onGetTarget(match: String): String {
+        return delegate.getTarget(match)
+      }
 
-            override fun onTarget(target: String): String {
-                return delegate.target(target)
-            }
-        }
-
-        /** [Delimiter] that's a child of [Default]. **/
-        abstract class Variant : Delimiter() {
-            final override val parent = Default
-        }
+      override fun onTarget(target: String): String {
+        return delegate.target(target)
+      }
     }
 
-    companion object {
-        /** [Char] that indicates the start and the end of an [Italic] target. **/
-        internal const val SYMBOL = '_'
+    /** [Delimiter] that's a child of [Default]. */
+    abstract class Variant : Delimiter() {
+      final override val parent = Default
     }
+  }
+
+  companion object {
+    /** [Char] that indicates the start and the end of an [Italic] target. */
+    internal const val SYMBOL = '_'
+  }
 }

--- a/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/type/Link.kt
+++ b/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/type/Link.kt
@@ -3,52 +3,51 @@ package com.jeanbarrossilva.orca.std.styledstring.type
 import com.jeanbarrossilva.orca.std.styledstring.Style
 import java.net.URL
 
-/** [Style] for [URL]s. **/
+/** [Style] for [URL]s. */
 data class Link(override val indices: IntRange) : Style() {
-    /** [Style.Delimiter] for [Link]s. **/
-    sealed class Delimiter : Style.Delimiter() {
-        /**
-         * [Delimiter] that's the [parent] of all [Variant]s and considers [Link]s parts of a
-         * [String] conforming to a [URL] format.
-         **/
-        internal object Default : Delimiter() {
-            override val parent = null
+  /** [Style.Delimiter] for [Link]s. */
+  sealed class Delimiter : Style.Delimiter() {
+    /**
+     * [Delimiter] that's the [parent] of all [Variant]s and considers [Link]s parts of a [String]
+     * conforming to a [URL] format.
+     */
+    internal object Default : Delimiter() {
+      override val parent = null
 
-            override fun getRegex(): Regex {
-                return protocoledRegex
-            }
+      override fun getRegex(): Regex {
+        return protocoledRegex
+      }
 
-            override fun onGetTarget(match: String): String {
-                return match
-            }
+      override fun onGetTarget(match: String): String {
+        return match
+      }
 
-            override fun onTarget(target: String): String {
-                return target
-            }
-        }
-
-        /** [Delimiter] that's a child of [Default]. **/
-        abstract class Variant : Delimiter() {
-            final override val parent = Default
-        }
+      override fun onTarget(target: String): String {
+        return target
+      }
     }
 
-    companion object {
-        /** [Regex] that matches the [protocol][URL.getProtocol] of a [URL]. **/
-        val protocolRegex = Regex("https?://")
-
-        /** [Regex] that matches the [path][URL.path] of a [URL]. **/
-        val pathRegex = Regex("[-a-zA-Z0-9()@:%_+.~#?&/=]+")
-
-        /** [Regex] that matches the subdomain of a URL. **/
-        val subdomainRegex = Regex("www\\.")
-
-        /** [Regex] that matches [String]s with an unprotocoled [URL] format. **/
-        val unprotocoledRegex = Regex(
-            "($subdomainRegex)?[-a-zA-Z0-9@:%._+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}$pathRegex"
-        )
-
-        /** [Regex] that matches [String]s with a [URL] format. **/
-        val protocoledRegex = Regex("$protocolRegex" + "$unprotocoledRegex")
+    /** [Delimiter] that's a child of [Default]. */
+    abstract class Variant : Delimiter() {
+      final override val parent = Default
     }
+  }
+
+  companion object {
+    /** [Regex] that matches the [protocol][URL.getProtocol] of a [URL]. */
+    val protocolRegex = Regex("https?://")
+
+    /** [Regex] that matches the [path][URL.path] of a [URL]. */
+    val pathRegex = Regex("[-a-zA-Z0-9()@:%_+.~#?&/=]+")
+
+    /** [Regex] that matches the subdomain of a URL. */
+    val subdomainRegex = Regex("www\\.")
+
+    /** [Regex] that matches [String]s with an unprotocoled [URL] format. */
+    val unprotocoledRegex =
+      Regex("($subdomainRegex)?[-a-zA-Z0-9@:%._+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}$pathRegex")
+
+    /** [Regex] that matches [String]s with a [URL] format. */
+    val protocoledRegex = Regex("$protocolRegex" + "$unprotocoledRegex")
+  }
 }

--- a/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/type/Mention.kt
+++ b/std/styled-string/src/main/java/com/jeanbarrossilva/orca/std/styledstring/type/Mention.kt
@@ -8,42 +8,42 @@ import java.net.URL
  *
  * @param indices Indices at which both the style symbols and the target are in the whole [String].
  * @param url [URL] that leads to the owner of the mentioned username.
- **/
+ */
 data class Mention(override val indices: IntRange, val url: URL) : Style() {
-    /** [Style.Delimiter] for [Mention]s. **/
-    sealed class Delimiter : Style.Delimiter() {
-        /**
-         * [Delimiter] that's the [parent] of all [Variant]s and considers [Mention]s parts of a
-         * [String] starting with a [Mention.SYMBOL] and determines its end by the absence of
-         * alphanumeric or some other special characters.
-         **/
-        internal object Default : Delimiter() {
-            override val parent = null
+  /** [Style.Delimiter] for [Mention]s. */
+  sealed class Delimiter : Style.Delimiter() {
+    /**
+     * [Delimiter] that's the [parent] of all [Variant]s and considers [Mention]s parts of a
+     * [String] starting with a [Mention.SYMBOL] and determines its end by the absence of
+     * alphanumeric or some other special characters.
+     */
+    internal object Default : Delimiter() {
+      override val parent = null
 
-            override fun getRegex(): Regex {
-                return Regex(SYMBOL + "$targetRegex")
-            }
+      override fun getRegex(): Regex {
+        return Regex(SYMBOL + "$targetRegex")
+      }
 
-            override fun onGetTarget(match: String): String {
-                return match.removePrefix("$SYMBOL")
-            }
+      override fun onGetTarget(match: String): String {
+        return match.removePrefix("$SYMBOL")
+      }
 
-            override fun onTarget(target: String): String {
-                return SYMBOL + target
-            }
-        }
-
-        /** [Delimiter] that's a child of [Default]. **/
-        abstract class Variant : Delimiter() {
-            final override val parent = Default
-        }
+      override fun onTarget(target: String): String {
+        return SYMBOL + target
+      }
     }
 
-    companion object {
-        /** [Char] that indicates the start of a [Mention] by default. **/
-        internal const val SYMBOL = '@'
-
-        /** [Regex] that matches a [Mention]'s target. **/
-        val targetRegex = Regex("[a-zA-Z0-9._%+-]+")
+    /** [Delimiter] that's a child of [Default]. */
+    abstract class Variant : Delimiter() {
+      final override val parent = Default
     }
+  }
+
+  companion object {
+    /** [Char] that indicates the start of a [Mention] by default. */
+    internal const val SYMBOL = '@'
+
+    /** [Regex] that matches a [Mention]'s target. */
+    val targetRegex = Regex("[a-zA-Z0-9._%+-]+")
+  }
 }

--- a/std/styled-string/src/test/java/com/jeanbarrossilva/orca/std/styledstring/StringExtensionsTests.kt
+++ b/std/styled-string/src/test/java/com/jeanbarrossilva/orca/std/styledstring/StringExtensionsTests.kt
@@ -9,58 +9,60 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 internal class StringExtensionsTests {
-    @Test
-    fun `GIVEN a string with a mention WHEN converting it into a styled string THEN the mention is preserved`() { // ktlint-disable max-line-length
-        assertEquals(
-            buildStyledString {
-                +"Hello, "
-                mention(Mention.url) { +Mention.username }
-                +('!')
-            },
-            "Hello, @${Mention.username}!".toStyledString { Mention.url }
-        )
-    }
+  @Test
+  fun `GIVEN a string with a mention WHEN converting it into a styled string THEN the mention is preserved`() {
+    assertEquals(
+      buildStyledString {
+        +"Hello, "
+        mention(Mention.url) { +Mention.username }
+        +('!')
+      },
+      "Hello, @${Mention.username}!".toStyledString { Mention.url }
+    )
+  }
 
-    @Test
-    fun `GIVEN a string with a mention containing two delimiters WHEN converting it into a styled string THEN the leading delimiter is ignored`() { // ktlint-disable max-line-length
-        assertEquals(
-            buildStyledString {
-                +"Hello, ${Mention.SYMBOL}"
-                mention(Mention.url) { +Mention.username }
-                +'!'
-            },
-            ("Hello, " + Mention.SYMBOL + Mention.SYMBOL + Mention.username + '!')
-                .toStyledString { Mention.url }
-        )
-    }
+  @Test
+  fun `GIVEN a string with a mention containing two delimiters WHEN converting it into a styled string THEN the leading delimiter is ignored`() {
+    assertEquals(
+      buildStyledString {
+        +"Hello, ${Mention.SYMBOL}"
+        mention(Mention.url) { +Mention.username }
+        +'!'
+      },
+      ("Hello, " + Mention.SYMBOL + Mention.SYMBOL + Mention.username + '!').toStyledString {
+        Mention.url
+      }
+    )
+  }
 
-    @Test
-    fun `GIVEN a string with multiple mentions WHEN converting it into a styled string THEN the mentions are preserved`() { // ktlint-disable max-line-length
-        assertEquals(
-            buildStyledString {
-                +"Hello, "
-                mention(Mention.url) { +Mention.username }
-                +" and "
-                mention(URL("https://mastodon.social/@christianselig")) { +"christianselig" }
-                +'!'
-            },
-            "Hello, @${Mention.username} and @christianselig!".toStyledString {
-                when (it) {
-                    7 -> Mention.url
-                    28 -> URL("https://mastodon.social/@christianselig")
-                    else -> throw IllegalStateException("🫠")
-                }
-            }
-        )
-    }
+  @Test
+  fun `GIVEN a string with multiple mentions WHEN converting it into a styled string THEN the mentions are preserved`() {
+    assertEquals(
+      buildStyledString {
+        +"Hello, "
+        mention(Mention.url) { +Mention.username }
+        +" and "
+        mention(URL("https://mastodon.social/@christianselig")) { +"christianselig" }
+        +'!'
+      },
+      "Hello, @${Mention.username} and @christianselig!"
+        .toStyledString {
+          when (it) {
+            7 -> Mention.url
+            28 -> URL("https://mastodon.social/@christianselig")
+            else -> throw IllegalStateException("🫠")
+          }
+        }
+    )
+  }
 
-    @Test
-    fun `GIVEN a string with a different mention delimiter WHEN converting it into a styled string THEN the mentions start with their default symbol`() { // ktlint-disable max-line-length
-        assertEquals(
-            "Hello, " + Mention.SYMBOL + Mention.username + '!',
-            "Hello, :${Mention.username}!"
-                .toStyledString(mentionDelimiter = ColonMentionDelimiter)
-                .toString()
-        )
-    }
+  @Test
+  fun `GIVEN a string with a different mention delimiter WHEN converting it into a styled string THEN the mentions start with their default symbol`() {
+    assertEquals(
+      "Hello, " + Mention.SYMBOL + Mention.username + '!',
+      "Hello, :${Mention.username}!"
+        .toStyledString(mentionDelimiter = ColonMentionDelimiter)
+        .toString()
+    )
+  }
 }

--- a/std/styled-string/src/test/java/com/jeanbarrossilva/orca/std/styledstring/StyledStringTests.kt
+++ b/std/styled-string/src/test/java/com/jeanbarrossilva/orca/std/styledstring/StyledStringTests.kt
@@ -14,138 +14,126 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 internal class StyledStringTests {
-    @Test
-    fun `GIVEN a string with bold portions delimited differently WHEN normalizing it THEN they're delimited by the bold symbol`() { // ktlint-disable max-line-length
-        assertEquals(
-            buildStyledString {
-                bold { +"Hi" }
-                +", "
-                bold { +"hello" }
-                +'!'
-            }
-                .toString(),
-            StyledString.normalize(":Hi:, :hello:!", ColonBoldDelimiter)
-        )
-    }
-
-    @Test
-    fun `GIVEN an invalid e-mail WHEN appending it THEN it isn't stylized as an e-mail`() {
-        assertContentEquals(buildStyledString { +"john@@appleseed.com" }.styles, emptyList())
-    }
-
-    @Test
-    fun `GIVEN a string with an e-mail WHEN converting it into a styled string THEN it's styled accordingly`() { // ktlint-disable max-line-length
-        assertEquals(
-            buildStyledString { +"Send a message to john@appleseed.com!" },
-            "Send a message to john@appleseed.com!".toStyledString()
-        )
-    }
-
-    @Test
-    fun `GIVEN an invalid subject WHEN appending a hashtag THEN it throws`() {
-        assertFailsWith<IllegalArgumentException> {
-            buildStyledString {
-                hashtag {
-                    +"subjects - cannot - have - whitespaces"
-                }
-            }
+  @Test
+  fun `GIVEN a string with bold portions delimited differently WHEN normalizing it THEN they're delimited by the bold symbol`() {
+    assertEquals(
+      buildStyledString {
+          bold { +"Hi" }
+          +", "
+          bold { +"hello" }
+          +'!'
         }
-    }
+        .toString(),
+      StyledString.normalize(":Hi:, :hello:!", ColonBoldDelimiter)
+    )
+  }
 
-    @Test
-    fun `GIVEN a string with italicized portions WHEN converting it into a styled string THEN the italic style is preserved`() { // ktlint-disable max-line-length
-        assertEquals(
-            buildStyledString {
-                +"Hello, "
-                italic { +"world" }
-                +'!'
-            },
-            ("Hello, " + Italic.SYMBOL + "world" + Italic.SYMBOL + '!').toStyledString()
-        )
-    }
+  @Test
+  fun `GIVEN an invalid e-mail WHEN appending it THEN it isn't stylized as an e-mail`() {
+    assertContentEquals(buildStyledString { +"john@@appleseed.com" }.styles, emptyList())
+  }
 
-    @Test
-    fun `GIVEN a string with a link WHEN converting it into a styled string THEN it's styled accordingly`() { // ktlint-disable max-line-length
-        assertEquals(
-            buildStyledString { +"Check out https://pudim.com.br!" },
-            "Check out https://pudim.com.br!".toStyledString()
-        )
-    }
+  @Test
+  fun `GIVEN a string with an e-mail WHEN converting it into a styled string THEN it's styled accordingly`() {
+    assertEquals(
+      buildStyledString { +"Send a message to john@appleseed.com!" },
+      "Send a message to john@appleseed.com!".toStyledString()
+    )
+  }
 
-    @Test
-    fun `GIVEN a string with multiple links WHEN converting it into a styled string THEN it's styled accordingly`() { // ktlint-disable max-line-length
-        assertEquals(
-            buildStyledString {
-                +"Check both https://rambo.codes and https://hackingwithswift.com out!"
-            },
-            "Check both https://rambo.codes and https://hackingwithswift.com out!".toStyledString()
-        )
+  @Test
+  fun `GIVEN an invalid subject WHEN appending a hashtag THEN it throws`() {
+    assertFailsWith<IllegalArgumentException> {
+      buildStyledString { hashtag { +"subjects - cannot - have - whitespaces" } }
     }
+  }
 
-    @Test
-    fun `GIVEN a string with mentions delimited differently WHEN normalizing it THEN they're delimited by the mention symbol`() { // ktlint-disable max-line-length
-        assertEquals(
-            buildStyledString {
-                mention(Mention.url) { +Mention.username }
-                +", "
-                mention(URL("https://mastodon.social/@_inside")) { +"_inside" }
-                +", hello!"
-            }
-                .toString(),
-            StyledString
-                .normalize(":${Mention.username}, :_inside, hello!", ColonMentionDelimiter)
-        )
-    }
+  @Test
+  fun `GIVEN a string with italicized portions WHEN converting it into a styled string THEN the italic style is preserved`() {
+    assertEquals(
+      buildStyledString {
+        +"Hello, "
+        italic { +"world" }
+        +'!'
+      },
+      ("Hello, " + Italic.SYMBOL + "world" + Italic.SYMBOL + '!').toStyledString()
+    )
+  }
 
-    @Test
-    fun `GIVEN a mention WHEN appending it THEN it's been placed correctly`() {
-        assertEquals(
-            Mention(indices = 7..(7 + Mention.username.length), Mention.url),
-            buildStyledString {
-                +"Hello, "
-                mention(Mention.url) { +Mention.username }
-                +"!"
-            }
-                .styles
-                .single()
-        )
-    }
+  @Test
+  fun `GIVEN a string with a link WHEN converting it into a styled string THEN it's styled accordingly`() {
+    assertEquals(
+      buildStyledString { +"Check out https://pudim.com.br!" },
+      "Check out https://pudim.com.br!".toStyledString()
+    )
+  }
 
-    @Test
-    fun `GIVEN a styled string WHEN getting its string representation THEN it has the mentions`() { // ktlint-disable max-line-length
-        assertEquals(
-            "Olá, @jeanbarrossilva!",
-            buildStyledString {
-                +"Olá, "
-                mention(Mention.url) { +Mention.username }
-                +"!"
-            }
-                .toString()
-        )
-    }
+  @Test
+  fun `GIVEN a string with multiple links WHEN converting it into a styled string THEN it's styled accordingly`() {
+    assertEquals(
+      buildStyledString { +"Check both https://rambo.codes and https://hackingwithswift.com out!" },
+      "Check both https://rambo.codes and https://hackingwithswift.com out!".toStyledString()
+    )
+  }
 
-    @Test
-    fun `GIVEN a mention put directly in the underlying string WHEN getting the mentions THEN it's not found`() { // ktlint-disable max-line-length
-        assertContentEquals(
-            emptyList(),
-            StyledString("안녕하세요, " + Mention.SYMBOL + Mention.username + '!')
-                .styles
-        )
-    }
+  @Test
+  fun `GIVEN a string with mentions delimited differently WHEN normalizing it THEN they're delimited by the mention symbol`() {
+    assertEquals(
+      buildStyledString {
+          mention(Mention.url) { +Mention.username }
+          +", "
+          mention(URL("https://mastodon.social/@_inside")) { +"_inside" }
+          +", hello!"
+        }
+        .toString(),
+      StyledString.normalize(":${Mention.username}, :_inside, hello!", ColonMentionDelimiter)
+    )
+  }
 
-    @Test
-    fun `GIVEN nested styles WHEN appending text with them THEN they've been applied`() {
-        assertContentEquals(
-            listOf(Bold(0..6), Italic(0..6)),
-            buildStyledString {
-                bold {
-                    italic {
-                        +"Hello"
-                    }
-                }
-                +'!'
-            }
-                .styles
-        )
-    }
+  @Test
+  fun `GIVEN a mention WHEN appending it THEN it's been placed correctly`() {
+    assertEquals(
+      Mention(indices = 7..(7 + Mention.username.length), Mention.url),
+      buildStyledString {
+          +"Hello, "
+          mention(Mention.url) { +Mention.username }
+          +"!"
+        }
+        .styles
+        .single()
+    )
+  }
+
+  @Test
+  fun `GIVEN a styled string WHEN getting its string representation THEN it has the mentions`() {
+    assertEquals(
+      "Olá, @jeanbarrossilva!",
+      buildStyledString {
+          +"Olá, "
+          mention(Mention.url) { +Mention.username }
+          +"!"
+        }
+        .toString()
+    )
+  }
+
+  @Test
+  fun `GIVEN a mention put directly in the underlying string WHEN getting the mentions THEN it's not found`() {
+    assertContentEquals(
+      emptyList(),
+      StyledString("안녕하세요, " + Mention.SYMBOL + Mention.username + '!').styles
+    )
+  }
+
+  @Test
+  fun `GIVEN nested styles WHEN appending text with them THEN they've been applied`() {
+    assertContentEquals(
+      listOf(Bold(0..6), Italic(0..6)),
+      buildStyledString {
+          bold { italic { +"Hello" } }
+          +'!'
+        }
+        .styles
+    )
+  }
 }

--- a/std/styled-string/src/test/java/com/jeanbarrossilva/orca/std/styledstring/type/test/ColonBoldDelimiter.kt
+++ b/std/styled-string/src/test/java/com/jeanbarrossilva/orca/std/styledstring/type/test/ColonBoldDelimiter.kt
@@ -3,17 +3,17 @@ package com.jeanbarrossilva.orca.std.styledstring.type.test
 import com.jeanbarrossilva.orca.std.styledstring.type.Bold
 
 internal object ColonBoldDelimiter : Bold.Delimiter.Variant() {
-    private val delegate = surroundedBy(':')
+  private val delegate = surroundedBy(':')
 
-    override fun getRegex(): Regex {
-        return delegate.regex
-    }
+  override fun getRegex(): Regex {
+    return delegate.regex
+  }
 
-    override fun onGetTarget(match: String): String {
-        return delegate.getTarget(match)
-    }
+  override fun onGetTarget(match: String): String {
+    return delegate.getTarget(match)
+  }
 
-    override fun onTarget(target: String): String {
-        return delegate.target(target)
-    }
+  override fun onTarget(target: String): String {
+    return delegate.target(target)
+  }
 }

--- a/std/styled-string/src/test/java/com/jeanbarrossilva/orca/std/styledstring/type/test/mention/ColonMentionDelimiter.kt
+++ b/std/styled-string/src/test/java/com/jeanbarrossilva/orca/std/styledstring/type/test/mention/ColonMentionDelimiter.kt
@@ -3,15 +3,15 @@ package com.jeanbarrossilva.orca.std.styledstring.type.test.mention
 import com.jeanbarrossilva.orca.std.styledstring.type.Mention
 
 internal object ColonMentionDelimiter : Mention.Delimiter.Variant() {
-    override fun getRegex(): Regex {
-        return Regex(":[a-zA-Z0-9._%+-]+")
-    }
+  override fun getRegex(): Regex {
+    return Regex(":[a-zA-Z0-9._%+-]+")
+  }
 
-    override fun onGetTarget(match: String): String {
-        return match.removePrefix(":")
-    }
+  override fun onGetTarget(match: String): String {
+    return match.removePrefix(":")
+  }
 
-    override fun onTarget(target: String): String {
-        return ":$target"
-    }
+  override fun onTarget(target: String): String {
+    return ":$target"
+  }
 }

--- a/std/styled-string/src/test/java/com/jeanbarrossilva/orca/std/styledstring/type/test/mention/Mention.extensions.kt
+++ b/std/styled-string/src/test/java/com/jeanbarrossilva/orca/std/styledstring/type/test/mention/Mention.extensions.kt
@@ -9,15 +9,15 @@ import java.net.URL
  *
  * @see StyledString.Builder.mention
  * @see Mention
- **/
+ */
 internal val Mention.Companion.url
-    get() = URL("https://mastodon.social/@jeanbarrossilva")
+  get() = URL("https://mastodon.social/@jeanbarrossilva")
 
 /**
  * Sample username to mention.
  *
  * @see StyledString.Builder.mention
  * @see Mention
- **/
+ */
 internal val Mention.Companion.username
-    get() = "jeanbarrossilva"
+  get() = "jeanbarrossilva"


### PR DESCRIPTION
[ktlint](https://pinterest.github.io/ktlint) started to become a headache starting from [0.49.1](https://github.com/pinterest/ktlint/releases/tag/0.49.1), failing when `--code-style=android_studio` is applied and ignoring the `.editorconfig` file.

This PR defines [ktfmt](https://facebook.github.io/ktfmt) as the formatter of Kotlin files, with the Google style (with 2-space indents 😱).