### PR TITLE
Add ability to unregister `Module`s to the `Injector`

### DIFF
--- a/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Injector.kt
+++ b/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Injector.kt
@@ -20,7 +20,7 @@ object Injector : Module() {
 
   /**
    * [NoSuchElementException] thrown if a [Module] that hasn't been registered is requested to be
-   * obtained.
+   * obtained or unregistered.
    *
    * @param moduleClass [KClass] of the requested [Module].
    */
@@ -49,7 +49,7 @@ object Injector : Module() {
    *
    * @param T [Module] to be obtained.
    * @throws SelfRetrievalException If the [Module] is this [Injector].
-   * @throws ModuleNotRegisteredException If no [Module] of type [T] has been injected.
+   * @throws ModuleNotRegisteredException If no [Module] of type [T] has been registered.
    */
   @Throws(ModuleNotRegisteredException::class)
   inline fun <reified T : Module> from(): T {
@@ -57,6 +57,21 @@ object Injector : Module() {
       modularization[T::class] as T? ?: throw ModuleNotRegisteredException(T::class)
     } else {
       throw SelfRetrievalException()
+    }
+  }
+
+  /**
+   * Unregisters the given [Module].
+   *
+   * @param T [Module] to be unregistered.
+   * @throws ModuleNotRegisteredException If no [Module] of type [T] has been injected.
+   */
+  @Throws(ModuleNotRegisteredException::class)
+  inline fun <reified T : Module> unregister() {
+    if (T::class in modularization) {
+      modularization.remove(T::class)
+    } else {
+      throw ModuleNotRegisteredException(T::class)
     }
   }
 

--- a/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/InjectorTests.kt
+++ b/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/InjectorTests.kt
@@ -18,7 +18,7 @@ internal class InjectorTests {
   private class SubModuleWithAnnotatedDependency : SuperModuleWithAnnotatedDependency({ 0 })
 
   internal abstract class SuperModuleWithAnnotatedDependency(
-    @Inject val dependency: Module.() -> Int
+    @Suppress("unused") @Inject val dependency: Module.() -> Int
   ) : Module()
 
   private class SubModuleWithNonAnnotatedDependency : SuperModuleWithNonAnnotatedDependency({ 0 })

--- a/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/InjectorTests.kt
+++ b/std/injector/src/test/java/com/jeanbarrossilva/orca/std/injector/InjectorTests.kt
@@ -63,4 +63,16 @@ internal class InjectorTests {
     Injector.from<Module>().inject { 0 }
     assertThat(Injector.from<Module>().get<Int>()).isEqualTo(0)
   }
+
+  @Test(expected = Injector.ModuleNotRegisteredException::class)
+  fun throwsWhenUnregisteringUnregisteredModule() {
+    Injector.unregister<Module>()
+  }
+
+  @Test(expected = Injector.ModuleNotRegisteredException::class)
+  fun unregistersModule() {
+    Injector.register<Module>(object : Module() {})
+    Injector.unregister<Module>()
+    Injector.from<Module>()
+  }
 }


### PR DESCRIPTION
Adds an [`unregister`](https://github.com/jeanbarrossilva/Orca/blob/ea70835efa1ab173402b3a98253767e715386c28/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Injector.kt#L70) method to the [`Injector`](https://github.com/jeanbarrossilva/Orca/blob/ea70835efa1ab173402b3a98253767e715386c28/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Injector.kt) that unregisters a [`Module`](https://github.com/jeanbarrossilva/Orca/blob/ea70835efa1ab173402b3a98253767e715386c28/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Injector.kt#L70) of a given type or throws an [`Injector.ModuleNotRegisteredException`](https://github.com/jeanbarrossilva/Orca/blob/ea70835efa1ab173402b3a98253767e715386c28/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/Injector.kt#L27) if it wasn't registered before.