### PR TITLE
Fix error report on injections within modules that indirectly subclass `Module`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", vers
 kotlin-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.5.1" }
 kotlin-symbolProcessor = { group = "com.google.devtools.ksp", name = "symbol-processing-api", version.ref = "kotlin-symbolProcessor" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
+kctfork-ksp = { group = "dev.zacsweers.kctfork", name = "ksp", version = "0.3.2" }
 kotlinPoet = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotlinPoet" }
 kotlinPoet-ksp = { group = "com.squareup", name = "kotlinpoet-ksp", version.ref = "kotlinPoet" }
 ktor-client-contentNegotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }

--- a/std/injector-processor/build.gradle.kts
+++ b/std/injector-processor/build.gradle.kts
@@ -10,4 +10,8 @@ dependencies {
   implementation(libs.kotlin.symbolProcessor)
   implementation(libs.kotlinPoet)
   implementation(libs.kotlinPoet.ksp)
+
+  testImplementation(libs.assertk)
+  testImplementation(libs.kctfork.ksp)
+  testImplementation(libs.kotlin.test)
 }

--- a/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/KSClassDeclaration.extensions.kt
+++ b/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/KSClassDeclaration.extensions.kt
@@ -1,0 +1,13 @@
+package com.jeanbarrossilva.orca.std.injector.processor.inject
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSTypeReference
+
+/**
+ * All super types of each subclass that the class to which this [KSClassDeclaration] refers
+ * subclasses alongside its own.
+ */
+internal val KSClassDeclaration.flattenedSuperTypes: Sequence<KSTypeReference>
+  get() =
+    superTypes +
+      superTypes.flatMap { (it.resolve().declaration as KSClassDeclaration).flattenedSuperTypes }

--- a/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/KSDeclaration.extensions.kt
+++ b/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/KSDeclaration.extensions.kt
@@ -15,7 +15,9 @@ import com.squareup.kotlinpoet.typeNameOf
 internal inline fun <reified T : Any> KSDeclaration.isWithin(): Boolean {
   val parentDeclaration = parentDeclaration as? KSClassDeclaration ?: return false
   val typeName = typeNameOf<T>()
-  return parentDeclaration.superTypes.map(KSTypeReference::toTypeName).any(typeName::equals)
+  return parentDeclaration.flattenedSuperTypes
+    .map(KSTypeReference::toTypeName)
+    .any(typeName::equals)
 }
 
 /**

--- a/std/injector-processor/src/test/java/com/jeanbarrossilva/orca/std/injector/processor/inject/InjectProcessorTests.kt
+++ b/std/injector-processor/src/test/java/com/jeanbarrossilva/orca/std/injector/processor/inject/InjectProcessorTests.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 internal class InjectProcessorTests {
   @OptIn(ExperimentalCompilerApi::class)
   @Test
-  fun doesNotReportErrorOnInjectionWithinModuleThatIsSubclassingAnotherOne() {
+  fun doesNotReportErrorOnInjectionWithinModuleThatIndirectlySubclassesTheBaseClass() {
     val source =
       SourceFile.kotlin(
         "Modules.kt",

--- a/std/injector-processor/src/test/java/com/jeanbarrossilva/orca/std/injector/processor/inject/InjectProcessorTests.kt
+++ b/std/injector-processor/src/test/java/com/jeanbarrossilva/orca/std/injector/processor/inject/InjectProcessorTests.kt
@@ -1,0 +1,40 @@
+package com.jeanbarrossilva.orca.std.injector.processor.inject
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import kotlin.test.Test
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+internal class InjectProcessorTests {
+  @OptIn(ExperimentalCompilerApi::class)
+  @Test
+  fun doesNotReportErrorOnInjectionWithinModuleThatIsSubclassingAnotherOne() {
+    val source =
+      SourceFile.kotlin(
+        "Modules.kt",
+        """
+            import com.jeanbarrossilva.orca.std.injector.module.Inject
+            import com.jeanbarrossilva.orca.std.injector.module.Module
+
+            class SubModule(@Inject override val dependency: Module.() -> Int = { 0 }) :
+              SuperModule(dependency)
+
+            abstract class SuperModule(@Inject open val dependency: Module.() -> Int = { 0 }) :
+              Module()
+        """
+          .trimIndent()
+      )
+    val result =
+      KotlinCompilation()
+        .apply {
+          inheritClassPath = true
+          sources = listOf(source)
+          symbolProcessorProviders = listOf(InjectProcessor.Provider())
+        }
+        .compile()
+    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+  }
+}


### PR DESCRIPTION
The [`InjectProcessor`](https://github.com/jeanbarrossilva/Orca/blob/e745c7e2919364031cf8399b4c0ab9f157019869/std/injector-processor/src/main/java/com/jeanbarrossilva/orca/std/injector/processor/inject/InjectProcessor.kt) was incorrectly reporting an error on injections within [`Module`](https://github.com/jeanbarrossilva/Orca/blob/e745c7e2919364031cf8399b4c0ab9f157019869/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/Module.kt)s that indirectly subclass the base [`Module`](https://github.com/jeanbarrossilva/Orca/blob/e745c7e2919364031cf8399b4c0ab9f157019869/std/injector/src/main/java/com/jeanbarrossilva/orca/std/injector/module/Module.kt) class.