### PR TITLE
Add `@Providable` annotation

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,5 +36,7 @@ include(
   ":std:injector",
   ":std:injector-processor",
   ":std:injector-test",
+  ":std:providable",
+  ":std:providable-processor",
   ":std:styled-string"
 )

--- a/std/providable-processor/build.gradle.kts
+++ b/std/providable-processor/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+  alias(libs.plugins.kotlin.jvm)
+
+  `java-library`
+}
+
+dependencies {
+  implementation(project(":std:providable"))
+  implementation(libs.kotlin.symbolProcessor)
+  implementation(libs.kotlinPoet)
+  implementation(libs.kotlinPoet.ksp)
+
+  testImplementation(libs.assertk)
+  testImplementation(libs.kotlin.test)
+}

--- a/std/providable-processor/build.gradle.kts
+++ b/std/providable-processor/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
   implementation(libs.kotlinPoet.ksp)
 
   testImplementation(libs.assertk)
+  testImplementation(libs.kctfork.ksp)
   testImplementation(libs.kotlin.test)
 }

--- a/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/IndefiniteArticle.java
+++ b/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/IndefiniteArticle.java
@@ -35,7 +35,7 @@ class IndefiniteArticle {
   /** Whether the given word should be preceded by {@link IndefiniteArticle#AN}. */
   private static boolean shouldWordBePrecededByAn(@NotNull String word, char initialLetter) {
     return shouldInitialLetterSoundBeChecked(word) && isLetterWithVowelSound(initialLetter)
-        || isExceptionalWord(word)
+        || startsWithVowelSoundingConsonant(word)
         || startsWithUnexceptionalVowel(removeDiacritics(word));
   }
 
@@ -76,16 +76,10 @@ class IndefiniteArticle {
         || letter == 'x';
   }
 
-  /**
-   * Returns whether the given word is an exceptional one; that is, even if its start sounds like a
-   * vowel, it should still be preceded by {@link IndefiniteArticle#AN}.
-   */
-  private static boolean isExceptionalWord(@NotNull String word) {
+  /** Returns whether the given word starts with a consonant that sounds like a vowel. */
+  private static boolean startsWithVowelSoundingConsonant(@NotNull String word) {
     word = word.toLowerCase();
-    return word.startsWith("euler")
-        || word.startsWith("heir")
-        || word.startsWith("hon")
-        || word.startsWith("hour");
+    return word.startsWith("heir") || word.startsWith("hon") || word.startsWith("hour");
   }
 
   /**

--- a/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/IndefiniteArticle.java
+++ b/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/IndefiniteArticle.java
@@ -1,0 +1,139 @@
+package com.jeanbarrossilva.orca.std.providable.processor;
+
+import java.text.Normalizer;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Obtains the appropriate indefinite article for a {@link String} through {@link
+ * IndefiniteArticle#of}.
+ */
+class IndefiniteArticle {
+  /** Indefinite article "a". */
+  @NotNull static final String A = "a";
+
+  /** Indefinite article "an". */
+  @NotNull static final String AN = "an";
+
+  private IndefiniteArticle() {}
+
+  /** Obtains the appropriate indefinite article for the given {@link String}. */
+  @NotNull
+  static String of(@NotNull String string) {
+    if (string.isBlank()) {
+      return A;
+    }
+    String word = string.trim().split(" ")[0];
+    char initialChar = word.charAt(0);
+    boolean isInitialCharLetter = Character.isAlphabetic(initialChar);
+    if ((isInitialCharLetter && shouldWordBePrecededByAn(word, initialChar))
+        || (!isInitialCharLetter && shouldNonLetterCharacterBePrecededByAn(initialChar))) {
+      return AN;
+    }
+    return A;
+  }
+
+  /** Whether the given word should be preceded by {@link IndefiniteArticle#AN}. */
+  private static boolean shouldWordBePrecededByAn(@NotNull String word, char initialLetter) {
+    return shouldInitialLetterSoundBeChecked(word) && isLetterWithVowelSound(initialLetter)
+        || isExceptionalWord(word)
+        || startsWithUnexceptionalVowel(removeDiacritics(word));
+  }
+
+  /**
+   * Returns whether the given word should have its initial letter's sound checked in order to
+   * determine if it has to be preceded by {@link IndefiniteArticle#AN}.
+   */
+  private static boolean shouldInitialLetterSoundBeChecked(@NotNull String word) {
+    return word.length() == 1 || isAcronym(word);
+  }
+
+  /** Returns whether the given word is an acronym, such as "SOLID" or "SAAS". */
+  private static boolean isAcronym(String word) {
+    char[] charArray = word.toCharArray();
+    for (char character : charArray) {
+      boolean isNotUpperCase = !Character.isUpperCase(character);
+      if (isNotUpperCase) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Returns whether the sound of the given letter is that of a vowel. */
+  private static boolean isLetterWithVowelSound(char letter) {
+    letter = Character.toLowerCase(letter);
+    return letter == 'a'
+        || letter == 'e'
+        || letter == 'f'
+        || letter == 'h'
+        || letter == 'i'
+        || letter == 'l'
+        || letter == 'm'
+        || letter == 'n'
+        || letter == 'o'
+        || letter == 'r'
+        || letter == 's'
+        || letter == 'x';
+  }
+
+  /**
+   * Returns whether the given word is an exceptional one; that is, even if its start sounds like a
+   * vowel, it should still be preceded by {@link IndefiniteArticle#AN}.
+   */
+  private static boolean isExceptionalWord(@NotNull String word) {
+    word = word.toLowerCase();
+    return word.startsWith("euler")
+        || word.startsWith("heir")
+        || word.startsWith("hon")
+        || word.startsWith("hour");
+  }
+
+  /**
+   * Returns whether the given word starts with a vowel that isn't succeeded by "ne" if it's an "o"
+   * or "ni" if it's a "u".
+   */
+  private static boolean startsWithUnexceptionalVowel(@NotNull String word) {
+    word = word.toLowerCase();
+    return word.startsWith("a")
+        || word.startsWith("e")
+        || word.startsWith("i")
+        || word.startsWith("o") && !word.startsWith("one")
+        || word.startsWith("u") && !word.startsWith("uni");
+  }
+
+  /** Returns the given word without any diacritics. */
+  @NotNull
+  private static String removeDiacritics(@NotNull String word) {
+    Normalizer.Form form = Normalizer.Form.NFKD;
+    boolean doesNotHaveDiacritics = Normalizer.isNormalized(word, form);
+    if (doesNotHaveDiacritics) {
+      return word;
+    }
+    return Normalizer.normalize(word, form).replaceAll("\\p{M}", "");
+  }
+
+  /**
+   * Returns whether the given non-letter character should be preceded by {@link
+   * IndefiniteArticle#AN}.
+   */
+  private static boolean shouldNonLetterCharacterBePrecededByAn(char nonLetterCharacter) {
+    String normalizedName = getNormalizedName(nonLetterCharacter);
+    char initialNormalizedNameLetter = normalizedName.charAt(0);
+    return shouldWordBePrecededByAn(normalizedName, initialNormalizedNameLetter);
+  }
+
+  /**
+   * Returns a normalized version of the given character's name, lower-casing it and removing
+   * prefixes like "digit" with which it is provided by the standard {@link Character#getName}
+   * method.
+   */
+  @NotNull
+  private static String getNormalizedName(char character) {
+    String normalizedName = Character.getName(character).toLowerCase();
+    boolean isCharacterDigit = Character.isDigit(character);
+    if (isCharacterDigit) {
+      normalizedName = normalizedName.replaceFirst("digit ", "");
+    }
+    return normalizedName;
+  }
+}

--- a/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/KSDeclaration.extensions.kt
+++ b/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/KSDeclaration.extensions.kt
@@ -1,0 +1,14 @@
+package com.jeanbarrossilva.orca.std.providable.processor
+
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+
+/**
+ * Requires the [KSFile] in which this [KSDeclaration] is or throws an [IllegalStateException] if it
+ * doesn't have one.
+ *
+ * @throws IllegalStateException If this [KSDeclaration] isn't part of a [KSFile].
+ */
+internal fun KSDeclaration.requireContainingFile(): KSFile {
+  return containingFile ?: throw IllegalStateException("$this doesn't have a containing KSFile.")
+}

--- a/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/ProvidableProcessor.kt
+++ b/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/ProvidableProcessor.kt
@@ -10,10 +10,8 @@ import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
-import com.google.devtools.ksp.symbol.KSName
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSTypeParameter
-import com.google.devtools.ksp.symbol.KSValueParameter
 import com.jeanbarrossilva.orca.std.providable.Providable
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
@@ -159,9 +157,8 @@ class ProvidableProcessor private constructor(private val environment: SymbolPro
     typeParameters: List<KSTypeParameter>,
     parameters: Sequence<KSPropertyDeclaration>
   ): FunSpec {
-    val parameterSpecs = parameters.map {
-      createProvideFunParameterSpec(it.docString, typeParameters, it)
-    }
+    val parameterSpecs =
+      parameters.map { createProvideFunParameterSpec(it.docString, typeParameters, it) }
     return FunSpec.builder(PROVIDER_METHOD_NAME)
       .addKdoc("Provides $typeDeclarationNameKDocReferencePrecededByIndefiniteArticle.")
       .addModifiers(KModifier.ABSTRACT)

--- a/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/ProvidableProcessor.kt
+++ b/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/ProvidableProcessor.kt
@@ -1,0 +1,199 @@
+package com.jeanbarrossilva.orca.std.providable.processor
+
+import com.google.devtools.ksp.getDeclaredProperties
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.jeanbarrossilva.orca.std.providable.Providable
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.ksp.toTypeName
+import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
+import com.squareup.kotlinpoet.ksp.writeTo
+
+/**
+ * [SymbolProcessor] that generates providers for [Providable]-annotated interfaces.
+ *
+ * @param environment [SymbolProcessorEnvironment] in which the errors will be reported and/or the
+ *   code will be generated.
+ */
+class ProvidableProcessor private constructor(private val environment: SymbolProcessorEnvironment) :
+  SymbolProcessor {
+  /** [SymbolProcessorProvider] that provides a [ProvidableProcessor]. */
+  class Provider : SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): ProvidableProcessor {
+      return ProvidableProcessor(environment)
+    }
+  }
+
+  override fun process(resolver: Resolver): List<KSAnnotated> {
+    val providableDeclarations = resolver.getProvidableDeclarations()
+    reportErrorOnNonInterfaces(providableDeclarations)
+    generateProviders(providableDeclarations)
+    return emptyList()
+  }
+
+  /**
+   * Reports an error for each [Providable] that's not an interface.
+   *
+   * @param providableDeclarations [KSClassDeclaration] of the interfaces annotated with
+   *   [Providable].
+   */
+  private fun reportErrorOnNonInterfaces(providableDeclarations: Sequence<KSClassDeclaration>) {
+    providableDeclarations
+      .filterNot { it.classKind == ClassKind.INTERFACE }
+      .forEach { environment.logger.error("Only interfaces can be providable.", symbol = it) }
+  }
+
+  /**
+   * Generates the providers for each of the [providableDeclarations].
+   *
+   * @param providableDeclarations [KSClassDeclaration] of the interfaces annotated with
+   *   [Providable].
+   */
+  private fun generateProviders(providableDeclarations: Sequence<KSClassDeclaration>) {
+    providableDeclarations.forEach {
+      createProviderFileSpec(it)
+        .writeTo(
+          environment.codeGenerator,
+          Dependencies(aggregating = true, it.requireContainingFile())
+        )
+    }
+  }
+
+  /**
+   * Creates a [FileSpec] in which the provider interface for the given [providableDeclaration] is
+   * declared.
+   *
+   * @param providableDeclaration [KSClassDeclaration] of the [Providable] for which the [FileSpec]
+   *   is.
+   */
+  private fun createProviderFileSpec(providableDeclaration: KSClassDeclaration): FileSpec {
+    val packageName = providableDeclaration.packageName.asString()
+    val name = providableDeclaration.simpleName.asString()
+    val provideMethodParameters = providableDeclaration.getDeclaredProperties()
+    val imports =
+      provideMethodParameters
+        .map(KSPropertyDeclaration::type)
+        .mapNotNull { it.resolve().declaration.qualifiedName?.asString() }
+        .filterNot { providableDeclaration.qualifiedName?.asString()?.let(it::startsWith) ?: true }
+    val interfaceSpec = createProviderInterfaceSpec(providableDeclaration, provideMethodParameters)
+    return FileSpec.builder(packageName, name)
+      .apply { imports.forEach { addImport(it, "") } }
+      .addType(interfaceSpec)
+      .build()
+  }
+
+  /**
+   * Creates an interface [TypeSpec] with a `provide` method for providing an instance of the type
+   * of the [providableDeclaration].
+   *
+   * @param providableDeclaration [KSClassDeclaration] of the [Providable] for which the [TypeSpec]
+   *   is.
+   * @param provideMethodParameters [KSPropertyDeclaration]s to be specified as the parameters of
+   *   the `provide` method to be declared.
+   */
+  private fun createProviderInterfaceSpec(
+    providableDeclaration: KSClassDeclaration,
+    provideMethodParameters: Sequence<KSPropertyDeclaration>
+  ): TypeSpec {
+    val type = providableDeclaration.asStarProjectedType()
+    val typeName = type.toTypeName()
+    val typeDeclarationName = type.declaration.simpleName.asString()
+    val typeDeclarationNameIndefiniteArticle = IndefiniteArticle.of(typeDeclarationName)
+    val typeDeclarationNameKDocReferencePrecededByIndefiniteArticle =
+      "$typeDeclarationNameIndefiniteArticle [$typeDeclarationName]"
+    val typeVariableName = TypeVariableName(PROVIDER_CLASS_TYPE_VARIABLE_NAME)
+    val provideFunSpec =
+      createProvideFunSpec(
+        typeName,
+        typeDeclarationNameKDocReferencePrecededByIndefiniteArticle,
+        providableDeclaration.typeParameters,
+        provideMethodParameters
+      )
+    return TypeSpec.interfaceBuilder(name = typeDeclarationName + "Provider")
+      .addKdoc(
+        """
+          Provides $typeDeclarationNameKDocReferencePrecededByIndefiniteArticle through
+          [$PROVIDER_METHOD_NAME].
+
+          @param $PROVIDER_CLASS_TYPE_VARIABLE_NAME Instance to be provided. 
+        """
+          .trimIndent()
+      )
+      .addModifiers(KModifier.FUN)
+      .addTypeVariable(typeVariableName)
+      .addFunction(provideFunSpec)
+      .build()
+  }
+
+  /**
+   * Creates a [FunSpec] of the `provide` method responsible for providing an instance of a class
+   * annotated with [Providable].
+   *
+   * @param typeName [TypeName] of the annotated interface.
+   * @param typeDeclarationNameKDocReferencePrecededByIndefiniteArticle KDoc reference to the
+   *   [KSDeclaration] of the interface's type containing the appropriate indefinite article at the
+   *   beginning.
+   * @param typeParameters [KSTypeParameter]s of the annotated interface.
+   * @param parameters [KSPropertyDeclaration] to be specified by the method.
+   */
+  private fun createProvideFunSpec(
+    typeName: TypeName,
+    typeDeclarationNameKDocReferencePrecededByIndefiniteArticle: String,
+    typeParameters: List<KSTypeParameter>,
+    parameters: Sequence<KSPropertyDeclaration>
+  ): FunSpec {
+    val parameterSpecs = parameters.map {
+      createProvideFunParameterSpec(it.docString, typeParameters, it)
+    }
+    return FunSpec.builder(PROVIDER_METHOD_NAME)
+      .addKdoc("Provides $typeDeclarationNameKDocReferencePrecededByIndefiniteArticle.")
+      .addModifiers(KModifier.ABSTRACT)
+      .addParameters(parameterSpecs.asIterable())
+      .returns(typeName)
+      .build()
+  }
+
+  /**
+   * Creates a parameter of the `provide` method of a provider.
+   *
+   * @param documentation Documentation to be associated to the parameter.
+   * @param typeParameters [KSTypeParameter]s of the [Providable].
+   * @param parameter [KSPropertyDeclaration] for which the [ParameterSpec] will be created.
+   */
+  private fun createProvideFunParameterSpec(
+    documentation: String?,
+    typeParameters: List<KSTypeParameter>,
+    parameter: KSPropertyDeclaration
+  ): ParameterSpec {
+    val name = parameter.simpleName.asString()
+    val type = parameter.type
+    val typeParameterResolver = typeParameters.toTypeParameterResolver()
+    val typeName = type.toTypeName(typeParameterResolver)
+    return ParameterSpec.builder(name, typeName).apply { documentation?.let(::addKdoc) }.build()
+  }
+
+  companion object {
+    /** Name of the provider interface method. */
+    private const val PROVIDER_METHOD_NAME = "provide"
+
+    /** Name of the variable that represents the [Providable]-annotated type within its provider. */
+    private const val PROVIDER_CLASS_TYPE_VARIABLE_NAME = "T"
+  }
+}

--- a/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/ProvidableProcessor.kt
+++ b/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/ProvidableProcessor.kt
@@ -188,9 +188,9 @@ class ProvidableProcessor private constructor(private val environment: SymbolPro
 
   companion object {
     /** Name of the provider interface method. */
-    private const val PROVIDER_METHOD_NAME = "provide"
+    internal const val PROVIDER_METHOD_NAME = "provide"
 
     /** Name of the variable that represents the [Providable]-annotated type within its provider. */
-    private const val PROVIDER_CLASS_TYPE_VARIABLE_NAME = "T"
+    internal const val PROVIDER_CLASS_TYPE_VARIABLE_NAME = "T"
   }
 }

--- a/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/Resolver.extensions.kt
+++ b/std/providable-processor/src/main/java/com/jeanbarrossilva/orca/std/providable/processor/Resolver.extensions.kt
@@ -1,0 +1,11 @@
+package com.jeanbarrossilva.orca.std.providable.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.jeanbarrossilva.orca.std.providable.Providable
+
+/** Gets the [Providable]-annotated [KSClassDeclaration]s. */
+internal fun Resolver.getProvidableDeclarations(): Sequence<KSClassDeclaration> {
+  return getSymbolsWithAnnotation(Providable::class.java.name)
+    .filterIsInstance<KSClassDeclaration>()
+}

--- a/std/providable-processor/src/test/java/com/jeanbarrossilva/orca/std/providable/processor/IndefiniteArticleTests.kt
+++ b/std/providable-processor/src/test/java/com/jeanbarrossilva/orca/std/providable/processor/IndefiniteArticleTests.kt
@@ -1,0 +1,65 @@
+package com.jeanbarrossilva.orca.std.providable.processor
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+internal class IndefiniteArticleTests {
+  @Test
+  fun aPrecedesEmptyString() {
+    assertThat(IndefiniteArticle.of(" ")).isEqualTo(IndefiniteArticle.A)
+  }
+
+  @Test
+  fun anPrecedesAmpersandLiteral() {
+    assertThat(IndefiniteArticle.of("&")).isEqualTo(IndefiniteArticle.AN)
+  }
+
+  @Test
+  fun aPrecedesSemiColonLiteral() {
+    assertThat(IndefiniteArticle.of(";")).isEqualTo(IndefiniteArticle.A)
+  }
+
+  @Test
+  fun anPrecedesWordsStartingWithNonUVowels() {
+    assertThat(IndefiniteArticle.of("asterisk")).isEqualTo(IndefiniteArticle.AN)
+    assertThat(IndefiniteArticle.of("elevator")).isEqualTo(IndefiniteArticle.AN)
+    assertThat(IndefiniteArticle.of("indicate")).isEqualTo(IndefiniteArticle.AN)
+    assertThat(IndefiniteArticle.of("outdated")).isEqualTo(IndefiniteArticle.AN)
+  }
+
+  @Test
+  fun anPrecedesWordUncharted() {
+    assertThat(IndefiniteArticle.of("uncharted")).isEqualTo(IndefiniteArticle.AN)
+  }
+
+  @Test
+  fun aPrecedesWordUniversity() {
+    assertThat(IndefiniteArticle.of("university")).isEqualTo(IndefiniteArticle.A)
+  }
+
+  @Test
+  fun anPrecedesNflAcronym() {
+    assertThat(IndefiniteArticle.of("NFL")).isEqualTo(IndefiniteArticle.AN)
+  }
+
+  @Test
+  fun aPrecedesDigitOne() {
+    assertThat(IndefiniteArticle.of("1")).isEqualTo(IndefiniteArticle.A)
+  }
+
+  @Test
+  fun aPrecedesWordOne() {
+    assertThat(IndefiniteArticle.of("one")).isEqualTo(IndefiniteArticle.A)
+  }
+
+  @Test
+  fun anPrecedesDigitEight() {
+    assertThat(IndefiniteArticle.of("8")).isEqualTo(IndefiniteArticle.AN)
+  }
+
+  @Test
+  fun anPrecedesWordEight() {
+    assertThat(IndefiniteArticle.of("eight")).isEqualTo(IndefiniteArticle.AN)
+  }
+}

--- a/std/providable-processor/src/test/java/com/jeanbarrossilva/orca/std/providable/processor/ProvidableProcessorTests.kt
+++ b/std/providable-processor/src/test/java/com/jeanbarrossilva/orca/std/providable/processor/ProvidableProcessorTests.kt
@@ -1,0 +1,46 @@
+package com.jeanbarrossilva.orca.std.providable.processor
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.kspWithCompilation
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import kotlin.test.Test
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+internal class ProvidableProcessorTests {
+  @OptIn(ExperimentalCompilerApi::class)
+  @Test
+  fun generatesProvider() {
+    val source =
+      SourceFile.kotlin(
+        "MyInterface.kt",
+        """
+          import com.jeanbarrossilva.orca.std.providable.Providable
+
+          /** My interface. 😎 */
+          @Providable
+          interface MyInterface {
+            /** My [Int]. 🫰🏽 */
+            val myInt: Int
+          }
+        """
+          .trimIndent()
+      )
+    val compilation =
+      KotlinCompilation().apply {
+        inheritClassPath = true
+        kspWithCompilation = true
+        sources = listOf(source)
+        symbolProcessorProviders = listOf(ProvidableProcessor.Provider())
+      }
+    val result = compilation.compile()
+    val providerClass = result.classLoader.loadClass("MyInterfaceProvider")
+    val providerMethod = providerClass.declaredMethods.single()
+    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    assertThat(providerMethod.name).isEqualTo(ProvidableProcessor.PROVIDER_METHOD_NAME)
+    assertThat(providerMethod.parameterTypes).isEqualTo(arrayOf(Int::class.java))
+    assertThat(providerMethod.returnType.name).isEqualTo("MyInterface")
+  }
+}

--- a/std/providable/build.gradle.kts
+++ b/std/providable/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+  alias(libs.plugins.kotlin.jvm)
+
+  `java-library`
+}

--- a/std/providable/src/main/java/com/jeanbarrossilva/orca/std/providable/Providable.kt
+++ b/std/providable/src/main/java/com/jeanbarrossilva/orca/std/providable/Providable.kt
@@ -1,0 +1,25 @@
+package com.jeanbarrossilva.orca.std.providable
+
+/**
+ * Denotes that a provider should be generated for the annotated interface, through which an
+ * instance of it can be obtained.
+ *
+ * For example,
+ * ```kotlin
+ * @Providable
+ * interface MyInterface {
+ *   val prop: Int
+ * }
+ * ```
+ *
+ * will have a respective
+ *
+ * ```kotlin
+ * fun interface MyInterfaceProvider {
+ *   fun provide(param: Int): MyClass
+ * }
+ * ```
+ *
+ * generated for it within the same package.
+ */
+@Target(AnnotationTarget.CLASS) annotation class Providable

--- a/std/providable/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/std/providable/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+com.jeanbarrossilva.orca.std.providable.processor.ProvidableProcessor$Provider


### PR DESCRIPTION
Adds an annotation that allows a provider to be automatically generated for a given interface.