### PR TITLE
Fix crash after selecting an instance to sign in into

### DIFF
--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/core/MainHttpModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/core/MainHttpModule.kt
@@ -15,7 +15,7 @@ internal class MainHttpModule :
     { HttpAuthenticator(context = Injector.get(), authorizer = get(), actorProvider = get()) },
     { SharedPreferencesActorProvider(context = Injector.get()) },
     { AuthenticationLock(authenticator = get(), actorProvider = get()) },
-    { SharedPreferencesTermMuter(context = get()) },
+    { SharedPreferencesTermMuter(context = Injector.get()) },
     { HttpInstanceProvider(context = Injector.get()) },
     { AsyncImageLoaderProvider(context = Injector.get()) }
   )


### PR DESCRIPTION
Fixes a crash that happened after selecting an instance from the core HTTP authorization screen due to a dependency retrieval from a module into which it hadn't been injected.

<img src="https://github.com/jeanbarrossilva/Orca/assets/38408390/c3a5066b-16e8-4736-ae72-174750493dac" width="256" />
