### PR TITLE
Fix crash and loop on HTTP auth flow

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,7 +57,9 @@ dependencies {
   "androidTestDemoImplementation"(libs.android.compose.ui.test.junit)
   "androidTestDemoImplementation"(libs.android.test.core)
   "androidTestDemoImplementation"(libs.android.test.espresso.intents)
-  "androidTestDemoImplementation"(libs.android.test.runner)
+
+  androidTestImplementation(libs.android.test.runner)
+  androidTestImplementation(libs.assertk)
 
   ksp(project(":std:injector-processor"))
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,12 +19,7 @@ android {
     viewBinding = true
   }
 
-  buildTypes {
-    release {
-      isMinifyEnabled = true
-      signingConfig = signingConfigs.getByName("debug")
-    }
-  }
+  buildTypes { release { isMinifyEnabled = true } }
 
   compileOptions {
     sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
@@ -41,10 +36,11 @@ android {
   }
 
   productFlavors {
-    create("default")
+    register("default") { dimension = Dimensions.VERSION }
 
-    create("demo") {
+    register("demo") {
       applicationIdSuffix = ".demo"
+      dimension = Dimensions.VERSION
       versionNameSuffix = "-demo"
     }
   }
@@ -52,13 +48,14 @@ android {
 
 dependencies {
   "androidTestDemoImplementation"(project(":core:sample-test"))
-  "androidTestDemoImplementation"(project(":platform:ui-test"))
+  "androidTestDemoImplementation"(project(":platform:ui"))
   "androidTestDemoImplementation"(libs.android.activity.ktx)
   "androidTestDemoImplementation"(libs.android.compose.ui.test.junit)
+  "androidTestDemoImplementation"(libs.assertk)
 
+  androidTestImplementation(project(":platform:ui-test"))
   androidTestImplementation(libs.android.test.core)
   androidTestImplementation(libs.android.test.runner)
-  androidTestImplementation(libs.assertk)
   androidTestImplementation(libs.android.test.espresso.intents)
 
   ksp(project(":std:injector-processor"))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,15 +55,13 @@ dependencies {
   "androidTestDemoImplementation"(project(":platform:ui-test"))
   "androidTestDemoImplementation"(libs.android.activity.ktx)
   "androidTestDemoImplementation"(libs.android.compose.ui.test.junit)
-  "androidTestDemoImplementation"(libs.android.test.core)
-  "androidTestDemoImplementation"(libs.android.test.espresso.intents)
 
+  androidTestImplementation(libs.android.test.core)
   androidTestImplementation(libs.android.test.runner)
   androidTestImplementation(libs.assertk)
+  androidTestImplementation(libs.android.test.espresso.intents)
 
   ksp(project(":std:injector-processor"))
-
-  "demoImplementation"(project(":core-test"))
 
   implementation(project(":core:http"))
   implementation(project(":core:sample"))

--- a/app/src/androidTest/java/com/jeanbarrossilva/orca/app/OrcaActivityTests.kt
+++ b/app/src/androidTest/java/com/jeanbarrossilva/orca/app/OrcaActivityTests.kt
@@ -1,10 +1,9 @@
 package com.jeanbarrossilva.orca.app
 
-import androidx.test.core.app.launchActivity
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.rule.IntentsRule
-import com.jeanbarrossilva.orca.app.test.TestOrcaActivity
+import com.jeanbarrossilva.orca.app.test.launchOrcaActivity
 import com.jeanbarrossilva.orca.core.http.auth.authorization.HttpAuthorizationActivity
 import org.junit.Rule
 import org.junit.Test
@@ -14,7 +13,7 @@ internal class OrcaActivityTests {
 
   @Test
   fun navigatesToAuthorization() {
-    launchActivity<TestOrcaActivity>().use {
+    launchOrcaActivity().use {
       intended(hasComponent(HttpAuthorizationActivity::class.qualifiedName))
     }
   }

--- a/app/src/androidTest/java/com/jeanbarrossilva/orca/app/OrcaActivityTests.kt
+++ b/app/src/androidTest/java/com/jeanbarrossilva/orca/app/OrcaActivityTests.kt
@@ -1,0 +1,20 @@
+package com.jeanbarrossilva.orca.app
+
+import androidx.test.core.app.launchActivity
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.rule.IntentsRule
+import com.jeanbarrossilva.orca.core.http.auth.authorization.HttpAuthorizationActivity
+import org.junit.Rule
+import org.junit.Test
+
+internal class OrcaActivityTests {
+  @get:Rule val intentsRule = IntentsRule()
+
+  @Test
+  fun navigatesToAuthorization() {
+    launchActivity<OrcaActivity>().use {
+      intended(hasComponent(HttpAuthorizationActivity::class.qualifiedName))
+    }
+  }
+}

--- a/app/src/androidTest/java/com/jeanbarrossilva/orca/app/OrcaActivityTests.kt
+++ b/app/src/androidTest/java/com/jeanbarrossilva/orca/app/OrcaActivityTests.kt
@@ -4,6 +4,7 @@ import androidx.test.core.app.launchActivity
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.rule.IntentsRule
+import com.jeanbarrossilva.orca.app.test.TestOrcaActivity
 import com.jeanbarrossilva.orca.core.http.auth.authorization.HttpAuthorizationActivity
 import org.junit.Rule
 import org.junit.Test
@@ -13,7 +14,7 @@ internal class OrcaActivityTests {
 
   @Test
   fun navigatesToAuthorization() {
-    launchActivity<OrcaActivity>().use {
+    launchActivity<TestOrcaActivity>().use {
       intended(hasComponent(HttpAuthorizationActivity::class.qualifiedName))
     }
   }

--- a/app/src/androidTest/java/com/jeanbarrossilva/orca/app/test/ActivityScenario.extensions.kt
+++ b/app/src/androidTest/java/com/jeanbarrossilva/orca/app/test/ActivityScenario.extensions.kt
@@ -1,0 +1,13 @@
+package com.jeanbarrossilva.orca.app.test
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.launchActivity
+import androidx.test.platform.app.InstrumentationRegistry
+import com.jeanbarrossilva.orca.platform.ui.core.Intent
+
+/** Launches a [TestOrcaActivity]. */
+internal fun launchOrcaActivity(): ActivityScenario<TestOrcaActivity> {
+  val context = InstrumentationRegistry.getInstrumentation().targetContext
+  val intent = Intent<TestOrcaActivity>(context)
+  return launchActivity(intent)
+}

--- a/app/src/androidTest/java/com/jeanbarrossilva/orca/app/test/TestOrcaActivity.kt
+++ b/app/src/androidTest/java/com/jeanbarrossilva/orca/app/test/TestOrcaActivity.kt
@@ -1,9 +1,9 @@
-package com.jeanbarrossilva.orca.app.demo.test
+package com.jeanbarrossilva.orca.app.test
 
-import com.jeanbarrossilva.orca.app.demo.DemoOrcaActivity
+import com.jeanbarrossilva.orca.app.OrcaActivity
 import com.jeanbarrossilva.orca.platform.ui.test.core.requestFocus
 
-internal class TestDemoOrcaActivity : DemoOrcaActivity() {
+internal class TestOrcaActivity : OrcaActivity() {
   override fun onWindowFocusChanged(hasFocus: Boolean) {
     super.onWindowFocusChanged(hasFocus)
     requestFocus(hasFocus)

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -6,11 +6,6 @@
         <!--suppress AndroidDomInspection-->
         <activity
             android:exported="true"
-            android:name=".test.TestOrcaActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+            android:name=".test.TestOrcaActivity" />
     </application>
 </manifest>

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <application tools:ignore="MissingApplicationIcon">
+        <!--suppress AndroidDomInspection-->
+        <activity
+            android:exported="true"
+            android:name=".test.TestOrcaActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/demo/java/com/jeanbarrossilva/orca/app/demo/module/core/DemoCoreModule.kt
+++ b/app/src/demo/java/com/jeanbarrossilva/orca/app/demo/module/core/DemoCoreModule.kt
@@ -11,10 +11,15 @@ import com.jeanbarrossilva.orca.std.injector.Injector
 
 internal object DemoCoreModule :
   CoreModule(
-    instanceProvider = {
-      val context = Injector.get<Context>()
-      val imageLoaderProvider = ImageLoader.Provider.createSample(context)
-      InstanceProvider.createSample(imageLoaderProvider)
-    },
+    { DemoCoreModule.instanceProvider },
+    { DemoCoreModule.instanceProvider.provide().authenticationLock },
     { SampleTermMuter() }
-  )
+  ) {
+  private val instanceProvider by lazy { InstanceProvider.createSample(imageLoaderProvider) }
+
+  private val imageLoaderProvider
+    get() = ImageLoader.Provider.createSample(context)
+
+  private val context
+    get() = Injector.get<Context>()
+}

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/core/MainHttpModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/core/MainHttpModule.kt
@@ -1,6 +1,10 @@
 package com.jeanbarrossilva.orca.app.module.core
 
+import android.content.Context
+import com.jeanbarrossilva.orca.core.auth.AuthenticationLock
 import com.jeanbarrossilva.orca.core.http.HttpModule
+import com.jeanbarrossilva.orca.core.http.auth.authentication.HttpAuthenticator
+import com.jeanbarrossilva.orca.core.http.auth.authorization.HttpAuthorizer
 import com.jeanbarrossilva.orca.core.http.instance.HttpInstanceProvider
 import com.jeanbarrossilva.orca.core.sharedpreferences.actor.SharedPreferencesActorProvider
 import com.jeanbarrossilva.orca.core.sharedpreferences.feed.profile.toot.content.SharedPreferencesTermMuter
@@ -12,9 +16,26 @@ internal object MainHttpModule :
     {
       HttpInstanceProvider(
         context = Injector.get(),
-        SharedPreferencesActorProvider(context = Injector.get()),
-        CoilImageLoader.Provider(context = Injector.get())
+        MainHttpModule.actorProvider,
+        MainHttpModule.authenticationLock,
+        CoilImageLoader.Provider(MainHttpModule.context)
       )
     },
-    { SharedPreferencesTermMuter(context = Injector.get()) }
-  )
+    { MainHttpModule.authenticationLock },
+    { SharedPreferencesTermMuter(MainHttpModule.context) }
+  ) {
+  private val authenticationLock
+    get() = AuthenticationLock(authenticator, actorProvider)
+
+  private val authenticator
+    get() = HttpAuthenticator(context, authorizer, actorProvider)
+
+  private val actorProvider
+    get() = SharedPreferencesActorProvider(context)
+
+  private val authorizer
+    get() = HttpAuthorizer(context)
+
+  private val context
+    get() = Injector.get<Context>()
+}

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/core/MainHttpModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/core/MainHttpModule.kt
@@ -16,25 +16,22 @@ internal object MainHttpModule :
     {
       HttpInstanceProvider(
         context = Injector.get(),
+        MainHttpModule.authorizer,
+        MainHttpModule.authenticator,
         MainHttpModule.actorProvider,
         MainHttpModule.authenticationLock,
+        MainHttpModule.termMuter,
         CoilImageLoader.Provider(MainHttpModule.context)
       )
     },
     { MainHttpModule.authenticationLock },
-    { SharedPreferencesTermMuter(MainHttpModule.context) }
+    { MainHttpModule.termMuter }
   ) {
-  private val authenticationLock
-    get() = AuthenticationLock(authenticator, actorProvider)
-
-  private val authenticator
-    get() = HttpAuthenticator(context, authorizer, actorProvider)
-
-  private val actorProvider
-    get() = SharedPreferencesActorProvider(context)
-
-  private val authorizer
-    get() = HttpAuthorizer(context)
+  private val actorProvider by lazy { SharedPreferencesActorProvider(context) }
+  private val authorizer by lazy { HttpAuthorizer(context) }
+  private val authenticator by lazy { HttpAuthenticator(context, authorizer, actorProvider) }
+  private val authenticationLock by lazy { AuthenticationLock(authenticator, actorProvider) }
+  private val termMuter by lazy { SharedPreferencesTermMuter(context) }
 
   private val context
     get() = Injector.get<Context>()

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/navigation/BottomNavigation.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/navigation/BottomNavigation.kt
@@ -3,7 +3,7 @@ package com.jeanbarrossilva.orca.app.navigation
 import androidx.annotation.IdRes
 import com.jeanbarrossilva.orca.app.R
 import com.jeanbarrossilva.orca.core.module.CoreModule
-import com.jeanbarrossilva.orca.core.module.instanceProvider
+import com.jeanbarrossilva.orca.core.module.authenticationLock
 import com.jeanbarrossilva.orca.feature.feed.FeedFragment
 import com.jeanbarrossilva.orca.feature.profiledetails.ProfileDetailsFragment
 import com.jeanbarrossilva.orca.feature.profiledetails.navigation.BackwardsNavigationState
@@ -45,7 +45,7 @@ internal enum class BottomNavigation {
   @get:IdRes protected abstract val id: Int
 
   protected val authenticationLock
-    get() = Injector.from<CoreModule>().instanceProvider().provide().authenticationLock
+    get() = Injector.from<CoreModule>().authenticationLock()
 
   protected abstract suspend fun getDestination(): Navigator.Navigation.Destination<*>
 

--- a/core-module/src/main/java/com/jeanbarrossilva/orca/core/module/CoreModule.kt
+++ b/core-module/src/main/java/com/jeanbarrossilva/orca/core/module/CoreModule.kt
@@ -1,5 +1,7 @@
 package com.jeanbarrossilva.orca.core.module
 
+import com.jeanbarrossilva.orca.core.auth.AuthenticationLock
+import com.jeanbarrossilva.orca.core.auth.SomeAuthenticationLock
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.TermMuter
 import com.jeanbarrossilva.orca.core.instance.Instance
@@ -12,9 +14,12 @@ import com.jeanbarrossilva.orca.std.injector.module.Module
  *
  * @param instanceProvider [InstanceProvider] that will provide the [Instance] in which the
  *   currently [authenticated][Actor.Authenticated] [Actor] is.
+ * @param authenticationLock [AuthenticationLock] that will lock authentication-dependent
+ *   functionality behind a "wall".
  * @param termMuter [TermMuter] by which terms will be muted.
  */
 open class CoreModule(
   @Inject internal val instanceProvider: Module.() -> InstanceProvider,
+  @Inject internal val authenticationLock: Module.() -> SomeAuthenticationLock,
   @Inject internal val termMuter: Module.() -> TermMuter
 ) : Module()

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/HttpModule.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/HttpModule.kt
@@ -1,9 +1,9 @@
 package com.jeanbarrossilva.orca.core.http
 
 import com.jeanbarrossilva.orca.core.auth.AuthenticationLock
+import com.jeanbarrossilva.orca.core.auth.SomeAuthenticationLock
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.TermMuter
-import com.jeanbarrossilva.orca.core.http.auth.authentication.HttpAuthenticator
 import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.core.instance.InstanceProvider
 import com.jeanbarrossilva.orca.core.module.CoreModule
@@ -21,6 +21,6 @@ import com.jeanbarrossilva.orca.std.injector.module.Module
  */
 open class HttpModule(
   @Inject internal val instanceProvider: Module.() -> InstanceProvider,
-  @Inject internal val authenticationLock: Module.() -> AuthenticationLock<HttpAuthenticator>,
+  @Inject internal val authenticationLock: Module.() -> SomeAuthenticationLock,
   @Inject internal val termMuter: Module.() -> TermMuter
 ) : CoreModule(instanceProvider, authenticationLock, termMuter)

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/HttpModule.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/HttpModule.kt
@@ -1,7 +1,9 @@
 package com.jeanbarrossilva.orca.core.http
 
+import com.jeanbarrossilva.orca.core.auth.AuthenticationLock
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.TermMuter
+import com.jeanbarrossilva.orca.core.http.auth.authentication.HttpAuthenticator
 import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.core.instance.InstanceProvider
 import com.jeanbarrossilva.orca.core.module.CoreModule
@@ -12,10 +14,13 @@ import com.jeanbarrossilva.orca.std.injector.module.Module
  * [CoreModule] into which core HTTP structures are injected.
  *
  * @param termMuter [TermMuter] by which terms will be muted.
+ * @param authenticationLock [AuthenticationLock] that will lock authentication-dependent
+ *   functionality behind a "wall".
  * @param instanceProvider [InstanceProvider] that will provide the [Instance] in which the
  *   currently [authenticated][Actor.Authenticated] [Actor] is.
  */
 open class HttpModule(
   @Inject internal val instanceProvider: Module.() -> InstanceProvider,
+  @Inject internal val authenticationLock: Module.() -> AuthenticationLock<HttpAuthenticator>,
   @Inject internal val termMuter: Module.() -> TermMuter
-) : CoreModule(instanceProvider, termMuter)
+) : CoreModule(instanceProvider, authenticationLock, termMuter)

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationToken.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationToken.kt
@@ -1,9 +1,10 @@
 package com.jeanbarrossilva.orca.core.http.auth.authentication
 
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.instance.SomeHttpInstance
 import com.jeanbarrossilva.orca.core.http.instanceProvider
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.std.injector.Injector
 import io.ktor.client.call.body
 import io.ktor.client.request.bearerAuth
@@ -23,7 +24,7 @@ internal data class HttpAuthenticationToken(val accessToken: String) {
    */
   suspend fun toActor(): Actor.Authenticated {
     val id =
-      (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+      (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance)
         .client
         .get("/api/v1/accounts/verify_credentials") { bearerAuth(accessToken) }
         .body<HttpAuthenticationVerification>()

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationViewModel.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/HttpAuthenticationViewModel.kt
@@ -8,11 +8,12 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.R
 import com.jeanbarrossilva.orca.core.http.auth.Mastodon
 import com.jeanbarrossilva.orca.core.http.instance.SomeHttpInstance
 import com.jeanbarrossilva.orca.core.http.instanceProvider
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.std.injector.Injector
 import io.ktor.client.call.body
 import io.ktor.client.request.forms.submitForm
@@ -39,7 +40,7 @@ private constructor(application: Application, private val authorizationCode: Str
     val scheme = application.getString(R.string.scheme)
     val redirectUri = application.getString(R.string.redirect_uri, scheme)
     viewModelScope.launch {
-      (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+      (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance)
         .client
         .submitForm(
           "/oauth/token",

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/activity/HttpAuthenticationActivity.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authentication/activity/HttpAuthenticationActivity.kt
@@ -5,11 +5,11 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.auth.authentication.HttpAuthentication
 import com.jeanbarrossilva.orca.core.http.auth.authentication.HttpAuthenticationViewModel
 import com.jeanbarrossilva.orca.core.http.instance.ContextualHttpInstance
-import com.jeanbarrossilva.orca.core.http.instanceProvider
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.platform.ui.core.composable.ComposableActivity
 import com.jeanbarrossilva.orca.platform.ui.core.on
 import com.jeanbarrossilva.orca.std.injector.Injector
@@ -19,8 +19,8 @@ import com.jeanbarrossilva.orca.std.injector.Injector
  * that takes place when this is created and automatically finishes itself when it's done.
  */
 class HttpAuthenticationActivity : ComposableActivity() {
-  /** [HttpModule] into which core-HTTP-related dependencies have been injected. */
-  private val module by lazy { Injector.from<HttpModule>() }
+  /** [CoreModule] into which core-HTTP-related dependencies have been injected. */
+  private val module by lazy { Injector.from<CoreModule>() }
 
   /** Code provided by the API when the user was authorized. */
   private val authorizationCode by extra<String>(AUTHORIZATION_CODE_KEY)

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpAuthorizationActivity.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/HttpAuthorizationActivity.kt
@@ -5,10 +5,11 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.runtime.Composable
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.auth.authorization.viewmodel.HttpAuthorizationViewModel
 import com.jeanbarrossilva.orca.core.http.instance.ContextualHttpInstance
 import com.jeanbarrossilva.orca.core.http.instanceProvider
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.platform.ui.core.composable.ComposableActivity
 import com.jeanbarrossilva.orca.std.injector.Injector
 import io.ktor.http.Url
@@ -60,7 +61,7 @@ class HttpAuthorizationActivity internal constructor() :
   @Throws(UnprovidedAccessTokenException::class)
   private fun sendAccessTokenToAuthorizer(deepLink: Uri) {
     val accessToken = deepLink.getQueryParameter("code") ?: throw UnprovidedAccessTokenException()
-    (Injector.from<HttpModule>().instanceProvider().provide() as ContextualHttpInstance)
+    (Injector.from<CoreModule>().instanceProvider().provide() as ContextualHttpInstance)
       .authorizer
       .receive(accessToken)
     finish()

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/viewmodel/HttpAuthorizationViewModel.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/auth/authorization/viewmodel/HttpAuthorizationViewModel.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.flow.loadable
 import com.jeanbarrossilva.loadable.ifLoaded
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.R
 import com.jeanbarrossilva.orca.core.http.auth.Mastodon
 import com.jeanbarrossilva.orca.core.http.auth.authorization.HttpDomainsProvider
@@ -24,6 +23,8 @@ import com.jeanbarrossilva.orca.core.http.instance.SomeHttpInstance
 import com.jeanbarrossilva.orca.core.http.instanceProvider
 import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.core.instance.domain.Domain
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.std.injector.Injector
 import io.ktor.http.URLBuilder
 import io.ktor.http.Url
@@ -90,7 +91,7 @@ private constructor(
     get() =
       URLBuilder()
         .takeFrom(
-          (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance).url
+          (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance).url
         )
         .appendPathSegments("oauth", "authorize")
         .apply {

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/client/CoreHttpClient.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/client/CoreHttpClient.kt
@@ -2,8 +2,9 @@ package com.jeanbarrossilva.orca.core.http.client
 
 import com.jeanbarrossilva.orca.core.auth.AuthenticationLock
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.instanceProvider
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.std.injector.Injector
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
@@ -46,7 +47,7 @@ import kotlinx.serialization.json.JsonNamingStrategy
  */
 @PublishedApi
 internal val authenticationLock
-  get() = Injector.from<HttpModule>().instanceProvider().provide().authenticationLock
+  get() = Injector.from<CoreModule>().instanceProvider().provide().authenticationLock
 
 /**
  * [HttpClient] through which [HttpRequest]s can be performed.

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/FeedTootPaginateSource.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/FeedTootPaginateSource.kt
@@ -2,8 +2,11 @@ package com.jeanbarrossilva.orca.core.http.feed
 
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.HttpToot
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.pagination.HttpTootPaginateSource
+import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
+import java.net.URL
 
 /** [HttpTootPaginateSource] that paginates through [HttpToot]s of the feed. */
-internal object FeedTootPaginateSource : HttpTootPaginateSource() {
+internal class FeedTootPaginateSource(override val imageLoaderProvider: ImageLoader.Provider<URL>) :
+  HttpTootPaginateSource() {
   override val route = "/api/v1/timelines/home"
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/HttpFeedProvider.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/HttpFeedProvider.kt
@@ -9,15 +9,24 @@ import com.jeanbarrossilva.orca.core.feed.profile.toot.content.TermMuter
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.pagination.HttpTootPaginateSource
 import kotlinx.coroutines.flow.Flow
 
-/** [FeedProvider] that requests the feed's [Toot]s to the API. */
+/**
+ * [FeedProvider] that requests the feed's [Toot]s to the API.
+ *
+ * @param actorProvider [ActorProvider] by which the current [Actor] will be provided.
+ * @param tootPaginateSource [FeedTootPaginateSource] that will paginate through the [Toot]s in the
+ *   feed.
+ */
 class HttpFeedProvider
-internal constructor(private val actorProvider: ActorProvider, override val termMuter: TermMuter) :
-  FeedProvider() {
+internal constructor(
+  private val actorProvider: ActorProvider,
+  override val termMuter: TermMuter,
+  private val tootPaginateSource: FeedTootPaginateSource
+) : FeedProvider() {
   /** [Flow] of paginated [Toot]s to be provided. */
-  private val flow = FeedTootPaginateSource.loadAllPagesItems(HttpTootPaginateSource.DEFAULT_COUNT)
+  private val flow = tootPaginateSource.loadAllPagesItems(HttpTootPaginateSource.DEFAULT_COUNT)
 
   override suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>> {
-    FeedTootPaginateSource.paginateTo(page)
+    tootPaginateSource.paginateTo(page)
     return flow
   }
 

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/ProfileTootPaginateSource.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/ProfileTootPaginateSource.kt
@@ -2,13 +2,18 @@ package com.jeanbarrossilva.orca.core.http.feed.profile
 
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.pagination.HttpTootPaginateSource
+import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
+import java.net.URL
 
 /**
  * [HttpTootPaginateSource] that paginates through an [HttpProfile]'s [Toot]s.
  *
  * @param id ID of the [HttpProfile].
  */
-internal class ProfileTootPaginateSource(id: String) : HttpTootPaginateSource() {
+internal class ProfileTootPaginateSource(
+  override val imageLoaderProvider: ImageLoader.Provider<URL>,
+  id: String
+) : HttpTootPaginateSource() {
   override val route = "/api/v1/accounts/$id/statuses"
 
   /** Provides a [ProfileTootPaginateSource] through [provide]. */

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/cache/HttpProfileFetcher.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/cache/HttpProfileFetcher.kt
@@ -2,13 +2,14 @@ package com.jeanbarrossilva.orca.core.http.feed.profile.cache
 
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.client.authenticateAndGet
 import com.jeanbarrossilva.orca.core.http.feed.profile.HttpProfile
 import com.jeanbarrossilva.orca.core.http.feed.profile.ProfileTootPaginateSource
 import com.jeanbarrossilva.orca.core.http.feed.profile.account.HttpAccount
 import com.jeanbarrossilva.orca.core.http.instance.SomeHttpInstance
 import com.jeanbarrossilva.orca.core.http.instanceProvider
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.platform.cache.Fetcher
 import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
 import com.jeanbarrossilva.orca.std.injector.Injector
@@ -28,7 +29,7 @@ internal class HttpProfileFetcher(
   private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
 ) : Fetcher<Profile>() {
   override suspend fun onFetch(key: String): Profile {
-    return (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+    return (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance)
       .client
       .authenticateAndGet("/api/v1/accounts/$key")
       .body<HttpAccount>()

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/HttpProfileSearchResultsFetcher.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/search/cache/HttpProfileSearchResultsFetcher.kt
@@ -3,13 +3,14 @@ package com.jeanbarrossilva.orca.core.http.feed.profile.search.cache
 import com.jeanbarrossilva.orca.core.feed.profile.search.ProfileSearchResult
 import com.jeanbarrossilva.orca.core.feed.profile.search.toProfileSearchResult
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.client.authenticateAndGet
 import com.jeanbarrossilva.orca.core.http.feed.profile.HttpProfile
 import com.jeanbarrossilva.orca.core.http.feed.profile.ProfileTootPaginateSource
 import com.jeanbarrossilva.orca.core.http.feed.profile.account.HttpAccount
 import com.jeanbarrossilva.orca.core.http.instance.SomeHttpInstance
 import com.jeanbarrossilva.orca.core.http.instanceProvider
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.platform.cache.Fetcher
 import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
 import com.jeanbarrossilva.orca.std.injector.Injector
@@ -30,7 +31,7 @@ internal class HttpProfileSearchResultsFetcher(
   private val tootPaginateSourceProvider: ProfileTootPaginateSource.Provider
 ) : Fetcher<List<ProfileSearchResult>>() {
   override suspend fun onFetch(key: String): List<ProfileSearchResult> {
-    return (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+    return (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance)
       .client
       .authenticateAndGet("/api/v1/accounts/search") { parameter("q", key) }
       .body<List<HttpAccount>>()

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/HttpToot.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/HttpToot.kt
@@ -6,6 +6,8 @@ import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.stat.CommentStat
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.stat.FavoriteStat
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.stat.ReblogStat
+import com.jeanbarrossilva.orca.std.imageloader.Image
+import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
 import io.ktor.client.request.HttpRequest
 import java.net.URL
 import java.time.ZonedDateTime
@@ -13,6 +15,8 @@ import java.time.ZonedDateTime
 /**
  * [Toot] whose actions perform an [HttpRequest] and communicate with the Mastodon API.
  *
+ * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which
+ *   [Image]s will be loaded from a [URL].
  * @param commentCount Amount of comments that this [HttpToot] has received.
  * @param favoriteCount Amount of times that this [HttpToot] has been marked as favorite.
  * @param reblogCount Amount of times that this [HttpToot] has been reblogged.
@@ -22,13 +26,14 @@ internal constructor(
   override val id: String,
   override val author: Author,
   override val content: Content,
+  private val imageLoaderProvider: ImageLoader.Provider<URL>,
   override val publicationDateTime: ZonedDateTime,
   private val commentCount: Int,
   private val favoriteCount: Int,
   private val reblogCount: Int,
   override val url: URL
 ) : Toot() {
-  override val comment = CommentStat(id, commentCount)
+  override val comment = CommentStat(id, commentCount, imageLoaderProvider)
   override val favorite = FavoriteStat(id, favoriteCount)
   override val reblog = ReblogStat(id, reblogCount)
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/HttpTootFetcher.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/HttpTootFetcher.kt
@@ -1,22 +1,32 @@
 package com.jeanbarrossilva.orca.core.http.feed.profile.toot.cache
 
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.client.authenticateAndGet
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.status.HttpStatus
 import com.jeanbarrossilva.orca.core.http.instance.SomeHttpInstance
 import com.jeanbarrossilva.orca.core.http.instanceProvider
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.platform.cache.Fetcher
+import com.jeanbarrossilva.orca.std.imageloader.Image
+import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
 import com.jeanbarrossilva.orca.std.injector.Injector
 import io.ktor.client.call.body
+import java.net.URL
 
-/** [Fetcher] that requests [Toot]s to the API. */
-internal object HttpTootFetcher : Fetcher<Toot>() {
+/**
+ * [Fetcher] that requests [Toot]s to the API.
+ *
+ * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which
+ *   [Image]s will be loaded from a [URL].
+ */
+internal class HttpTootFetcher(private val imageLoaderProvider: ImageLoader.Provider<URL>) :
+  Fetcher<Toot>() {
   override suspend fun onFetch(key: String): Toot {
-    return (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+    return (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance)
       .client
       .authenticateAndGet("/api/v1/statuses/$key")
       .body<HttpStatus>()
-      .toToot()
+      .toToot(imageLoaderProvider)
   }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/HttpTootStorage.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/HttpTootStorage.kt
@@ -2,11 +2,15 @@ package com.jeanbarrossilva.orca.core.http.feed.profile.toot.cache.storage
 
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Highlight
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.cache.storage.style.HttpStyleEntity
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.cache.storage.style.HttpStyleEntityDao
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.cache.storage.style.toHttpStyleEntity
 import com.jeanbarrossilva.orca.platform.cache.Cache
 import com.jeanbarrossilva.orca.platform.cache.Storage
+import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
+import java.net.URL
 
 /**
  * [Storage] for [Toot]s.
@@ -17,11 +21,15 @@ import com.jeanbarrossilva.orca.platform.cache.Storage
  *   [HTTP toot entities][HttpTootEntity].
  * @param styleEntityDao [HttpStyleEntityDao] for inserting and deleting
  *   [HTTP style entities][HttpStyleEntity].
+ * @param coverLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which a
+ *   [Toot]'s [content][Toot.content]'s [highlight][Content.highlight]'s
+ *   [headline][Highlight.headline] cover will be loaded from a [URL].
  */
 internal class HttpTootStorage(
   private val profileCache: Cache<Profile>,
   private val tootEntityDao: HttpTootEntityDao,
-  private val styleEntityDao: HttpStyleEntityDao
+  private val styleEntityDao: HttpStyleEntityDao,
+  private val coverLoaderProvider: ImageLoader.Provider<URL>
 ) : Storage<Toot>() {
   override suspend fun onStore(key: String, value: Toot) {
     val tootEntity = HttpTootEntity.from(value)
@@ -35,7 +43,7 @@ internal class HttpTootStorage(
   }
 
   override suspend fun onGet(key: String): Toot {
-    return tootEntityDao.selectByID(key).toToot(profileCache, tootEntityDao)
+    return tootEntityDao.selectByID(key).toToot(profileCache, tootEntityDao, coverLoaderProvider)
   }
 
   override suspend fun onRemove(key: String) {

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/pagination/HttpTootPaginateSource.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/pagination/HttpTootPaginateSource.kt
@@ -5,16 +5,19 @@ import com.chrynan.paginate.core.PageDirection
 import com.chrynan.paginate.core.PageInfo
 import com.chrynan.paginate.core.PagedResult
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.client.authenticateAndGet
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.status.HttpStatus
 import com.jeanbarrossilva.orca.core.http.instance.SomeHttpInstance
 import com.jeanbarrossilva.orca.core.http.instanceProvider
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
+import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
 import com.jeanbarrossilva.orca.std.injector.Injector
 import io.ktor.client.call.body
 import io.ktor.client.request.HttpRequest
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.Url
+import java.net.URL
 
 /** [BasePaginateSource] that requests and paginates through [Toot]s. */
 internal abstract class HttpTootPaginateSource internal constructor() :
@@ -24,6 +27,12 @@ internal abstract class HttpTootPaginateSource internal constructor() :
     set(index) {
       field = minOf(0, index)
     }
+
+  /**
+   * [ImageLoader.Provider] that provides the [ImageLoader] by which [Image]s will be loaded from a
+   * [URL].
+   */
+  protected abstract val imageLoaderProvider: ImageLoader.Provider<URL>
 
   /** URL [String] to which the [HttpRequest] should be sent. */
   protected abstract val route: String
@@ -37,7 +46,7 @@ internal abstract class HttpTootPaginateSource internal constructor() :
     val response = getStatusesResponse(key)
     val headerLinks = response.headers.links
     val nextUrl = headerLinks.getOrNull(1)?.uri?.let(::Url)
-    val toots = response.body<List<HttpStatus>>().map(HttpStatus::toToot)
+    val toots = response.body<List<HttpStatus>>().map { it.toToot(imageLoaderProvider) }
     val firstKey = toots.firstOrNull()?.url?.toString()?.let(::Url)
     val lastKey = toots.lastOrNull()?.url?.toString()?.let(::Url)
     val pageInfo =
@@ -84,7 +93,7 @@ internal abstract class HttpTootPaginateSource internal constructor() :
    * @param url [Url] to which the [HttpRequest] will be made.
    */
   private suspend fun getStatusesResponse(url: Url?): HttpResponse {
-    return (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+    return (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance)
       .client
       .authenticateAndGet(url?.toString() ?: route)
   }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/stat/Stat.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/stat/Stat.extensions.kt
@@ -2,15 +2,18 @@ package com.jeanbarrossilva.orca.core.http.feed.profile.toot.stat
 
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
 import com.jeanbarrossilva.orca.core.feed.profile.toot.stat.Stat
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.client.authenticateAndGet
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.HttpContext
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.HttpToot
-import com.jeanbarrossilva.orca.core.http.feed.profile.toot.status.HttpStatus
 import com.jeanbarrossilva.orca.core.http.instance.SomeHttpInstance
 import com.jeanbarrossilva.orca.core.http.instanceProvider
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
+import com.jeanbarrossilva.orca.std.imageloader.Image
+import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
 import com.jeanbarrossilva.orca.std.injector.Injector
 import io.ktor.client.call.body
+import java.net.URL
 import kotlinx.coroutines.flow.flow
 
 /**
@@ -18,18 +21,24 @@ import kotlinx.coroutines.flow.flow
  *
  * @param id ID of the [HttpToot] for which the [Stat] is.
  * @param count Amount of comments that the [HttpToot] has received.
+ * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which
+ *   [Image]s will be loaded from a [URL].
  */
 @Suppress("FunctionName")
-internal fun CommentStat(id: String, count: Int): Stat<Toot> {
+internal fun CommentStat(
+  id: String,
+  count: Int,
+  imageLoaderProvider: ImageLoader.Provider<URL>
+): Stat<Toot> {
   return Stat(count) {
     get {
       flow {
-        (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+        (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance)
           .client
           .authenticateAndGet("/api/v1/statuses/$id/context")
           .body<HttpContext>()
           .descendants
-          .map(HttpStatus::toToot)
+          .map { it.toToot(imageLoaderProvider) }
           .also { emit(it) }
       }
     }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/stat/ToggleableStat.extensions.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/stat/ToggleableStat.extensions.kt
@@ -2,11 +2,12 @@ package com.jeanbarrossilva.orca.core.http.feed.profile.toot.stat
 
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
 import com.jeanbarrossilva.orca.core.feed.profile.toot.stat.toggleable.ToggleableStat
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.client.authenticateAndPost
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.HttpToot
 import com.jeanbarrossilva.orca.core.http.instance.SomeHttpInstance
 import com.jeanbarrossilva.orca.core.http.instanceProvider
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.std.injector.Injector
 
 /**
@@ -25,7 +26,7 @@ internal fun FavoriteStat(id: String, count: Int): ToggleableStat<Profile> {
         } else {
           @Suppress("SpellCheckingInspection") "/api/v1/statuses/$id/unfavourite"
         }
-      (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+      (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance)
         .client
         .authenticateAndPost(route)
     }
@@ -43,7 +44,7 @@ internal fun ReblogStat(id: String, count: Int): ToggleableStat<Profile> {
   return ToggleableStat(count) {
     setEnabled { isEnabled ->
       val route = if (isEnabled) "/api/v1/statuses/$id/reblog" else "/api/v1/statuses/$id/unreblog"
-      (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+      (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance)
         .client
         .authenticateAndPost(route)
     }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/status/HttpCard.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/status/HttpCard.kt
@@ -1,9 +1,7 @@
 package com.jeanbarrossilva.orca.core.http.feed.profile.toot.status
 
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Headline
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
-import com.jeanbarrossilva.orca.std.injector.Injector
 import java.net.URL
 import kotlinx.serialization.Serializable
 
@@ -25,15 +23,16 @@ internal data class HttpCard(
   /**
    * Converts this [HttpCard] into a [Headline].
    *
+   * @param coverLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which the
+   *   cover will be loaded from a [URL].
    * @return Resulting [Headline] or `null` if the [image] is unavailable.
    */
-  fun toHeadline(): Headline? {
+  fun toHeadline(coverLoaderProvider: ImageLoader.Provider<URL>): Headline? {
     return image?.let {
       Headline(
         title,
         subtitle = description.ifEmpty { null },
-        coverLoader =
-          Injector.from<HttpModule>().get<ImageLoader.Provider<URL>>().provide(URL(image))
+        coverLoader = coverLoaderProvider.provide(URL(image))
       )
     }
   }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/type/editable/HttpEditor.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/type/editable/HttpEditor.kt
@@ -1,11 +1,12 @@
 package com.jeanbarrossilva.orca.core.http.feed.profile.type.editable
 
 import com.jeanbarrossilva.orca.core.feed.profile.type.editable.Editor
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.client.authenticateAndSubmitForm
 import com.jeanbarrossilva.orca.core.http.client.authenticateAndSubmitFormWithBinaryData
 import com.jeanbarrossilva.orca.core.http.instance.SomeHttpInstance
 import com.jeanbarrossilva.orca.core.http.instanceProvider
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.std.imageloader.SomeImageLoader
 import com.jeanbarrossilva.orca.std.injector.Injector
 import com.jeanbarrossilva.orca.std.styledstring.StyledString
@@ -30,19 +31,19 @@ internal class HttpEditor : Editor {
     val contentDisposition = "form-data; name=\"avatar\" filename=\"${file.name}\""
     val headers = Headers.build { append(HttpHeaders.ContentDisposition, contentDisposition) }
     val formData = formData { append("avatar", inputProvider, headers) }
-    (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+    (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance)
       .client
       .authenticateAndSubmitFormWithBinaryData(ROUTE, formData)
   }
 
   override suspend fun setName(name: String) {
-    (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+    (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance)
       .client
       .authenticateAndSubmitForm(ROUTE, parametersOf("display_name", name))
   }
 
   override suspend fun setBio(bio: StyledString) {
-    (Injector.from<HttpModule>().instanceProvider().provide() as SomeHttpInstance)
+    (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance)
       .client
       .authenticateAndSubmitForm(ROUTE, parametersOf("note", "$bio"))
   }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/HttpInstanceProvider.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/HttpInstanceProvider.kt
@@ -4,14 +4,14 @@ import android.content.Context
 import com.jeanbarrossilva.orca.core.auth.AuthenticationLock
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.auth.actor.ActorProvider
-import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.auth.authentication.HttpAuthenticator
 import com.jeanbarrossilva.orca.core.http.auth.authorization.HttpAuthorizer
 import com.jeanbarrossilva.orca.core.http.auth.authorization.viewmodel.HttpAuthorizationViewModel
-import com.jeanbarrossilva.orca.core.http.termMuter
 import com.jeanbarrossilva.orca.core.instance.InstanceProvider
 import com.jeanbarrossilva.orca.core.instance.SomeInstance
 import com.jeanbarrossilva.orca.core.instance.domain.Domain
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.termMuter
 import com.jeanbarrossilva.orca.std.imageloader.Image
 import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
 import com.jeanbarrossilva.orca.std.injector.Injector
@@ -23,33 +23,33 @@ import java.net.URL
  * @param context [Context] through which the [Domain] of the [ContextualHttpInstance] will
  *   retrieved.
  * @param actorProvider [ActorProvider] that provides the [Actor].
+ * @param authenticationLock [AuthenticationLock] that will lock authentication-dependent
+ *   functionality behind a "wall".
  * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which
  *   [Image] will be loaded.
  */
 class HttpInstanceProvider(
   private val context: Context,
   private val actorProvider: ActorProvider,
+  private val authenticationLock: AuthenticationLock<HttpAuthenticator>,
   private val imageLoaderProvider: ImageLoader.Provider<URL>
 ) : InstanceProvider {
-  private val module by lazy { Injector.from<HttpModule>() }
-  private val domain by lazy { HttpAuthorizationViewModel.getInstanceDomain(context) }
+  private val module by lazy { Injector.from<CoreModule>() }
   private val authorizer by lazy { HttpAuthorizer(context) }
   private val authenticator by lazy { HttpAuthenticator(context, authorizer, actorProvider) }
-  private val authenticationLock by lazy { AuthenticationLock(authenticator, actorProvider) }
-  private val instance by lazy {
-    ContextualHttpInstance(
+
+  private val termMuter by lazy { module.termMuter() }
+
+  override fun provide(): SomeInstance {
+    return ContextualHttpInstance(
       context,
-      domain,
+      HttpAuthorizationViewModel.getInstanceDomain(context),
       authorizer,
       authenticator,
       actorProvider,
       authenticationLock,
-      module.termMuter(),
+      termMuter,
       imageLoaderProvider
     )
-  }
-
-  override fun provide(): SomeInstance {
-    return instance
   }
 }

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/HttpInstanceProvider.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/instance/HttpInstanceProvider.kt
@@ -4,17 +4,16 @@ import android.content.Context
 import com.jeanbarrossilva.orca.core.auth.AuthenticationLock
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.auth.actor.ActorProvider
+import com.jeanbarrossilva.orca.core.feed.profile.toot.Toot
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.TermMuter
 import com.jeanbarrossilva.orca.core.http.auth.authentication.HttpAuthenticator
 import com.jeanbarrossilva.orca.core.http.auth.authorization.HttpAuthorizer
 import com.jeanbarrossilva.orca.core.http.auth.authorization.viewmodel.HttpAuthorizationViewModel
 import com.jeanbarrossilva.orca.core.instance.InstanceProvider
 import com.jeanbarrossilva.orca.core.instance.SomeInstance
 import com.jeanbarrossilva.orca.core.instance.domain.Domain
-import com.jeanbarrossilva.orca.core.module.CoreModule
-import com.jeanbarrossilva.orca.core.module.termMuter
 import com.jeanbarrossilva.orca.std.imageloader.Image
 import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
-import com.jeanbarrossilva.orca.std.injector.Injector
 import java.net.URL
 
 /**
@@ -22,24 +21,24 @@ import java.net.URL
  *
  * @param context [Context] through which the [Domain] of the [ContextualHttpInstance] will
  *   retrieved.
+ * @param authorizer [HttpAuthorizer] by which the user will be authorized.
+ * @param authenticator [HttpAuthenticator] for authenticating the user.
  * @param actorProvider [ActorProvider] that provides the [Actor].
  * @param authenticationLock [AuthenticationLock] that will lock authentication-dependent
  *   functionality behind a "wall".
+ * @param termMuter [TermMuter] by which [Toot]s with muted terms will be filtered out.
  * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which
  *   [Image] will be loaded.
  */
 class HttpInstanceProvider(
   private val context: Context,
+  private val authorizer: HttpAuthorizer,
+  private val authenticator: HttpAuthenticator,
   private val actorProvider: ActorProvider,
   private val authenticationLock: AuthenticationLock<HttpAuthenticator>,
+  private val termMuter: TermMuter,
   private val imageLoaderProvider: ImageLoader.Provider<URL>
 ) : InstanceProvider {
-  private val module by lazy { Injector.from<CoreModule>() }
-  private val authorizer by lazy { HttpAuthorizer(context) }
-  private val authenticator by lazy { HttpAuthenticator(context, authorizer, actorProvider) }
-
-  private val termMuter by lazy { module.termMuter() }
-
   override fun provide(): SomeInstance {
     return ContextualHttpInstance(
       context,

--- a/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/TestScope.extensions.kt
+++ b/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/TestScope.extensions.kt
@@ -108,7 +108,10 @@ private fun <T : Actor> runCoreHttpClientTest(
   val authenticationLock = AuthenticationLock(authenticator, actorProvider)
   val instance = TestHttpInstance(authorizer, authenticator, authenticationLock)
   val module =
-    HttpModule({ TestHttpInstanceProvider(authorizer, authenticator, authenticationLock) }) {
+    HttpModule(
+      { TestHttpInstanceProvider(authorizer, authenticator, authenticationLock) },
+      { authenticationLock }
+    ) {
       SampleTermMuter()
     }
   Injector.register(module)

--- a/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/TestScope.extensions.kt
+++ b/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/TestScope.extensions.kt
@@ -5,7 +5,6 @@ import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.auth.actor.ActorProvider
 import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.client.CoreHttpClient
-import com.jeanbarrossilva.orca.core.http.client.authenticateAndGet
 import com.jeanbarrossilva.orca.core.http.client.test.instance.TestHttpInstance
 import com.jeanbarrossilva.orca.core.http.client.test.instance.TestHttpInstanceProvider
 import com.jeanbarrossilva.orca.core.module.CoreModule
@@ -19,7 +18,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.HttpRequest
 import io.ktor.http.HttpMethod
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 
@@ -117,7 +115,6 @@ private fun <T : Actor> runCoreHttpClientTest(
     ) {
       SampleTermMuter()
     }
-  runBlocking { instance.client.authenticateAndGet("") {} }
   Injector.register<CoreModule>(module)
   runTest { CoreHttpClientTestScope(delegate = this, instance.client, actor).body() }
   Injector.unregister<CoreModule>()

--- a/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/TestScope.extensions.kt
+++ b/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/TestScope.extensions.kt
@@ -7,6 +7,7 @@ import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.client.CoreHttpClient
 import com.jeanbarrossilva.orca.core.http.client.test.instance.TestHttpInstance
 import com.jeanbarrossilva.orca.core.http.client.test.instance.TestHttpInstanceProvider
+import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.core.sample.auth.actor.sample
 import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.content.SampleTermMuter
 import com.jeanbarrossilva.orca.core.test.TestActorProvider
@@ -114,7 +115,7 @@ private fun <T : Actor> runCoreHttpClientTest(
     ) {
       SampleTermMuter()
     }
-  Injector.register(module)
+  Injector.register<CoreModule>(module)
   runTest { CoreHttpClientTestScope(delegate = this, instance.client, actor).body() }
-  Injector.unregister<HttpModule>()
+  Injector.unregister<CoreModule>()
 }

--- a/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/TestScope.extensions.kt
+++ b/core/http/src/test/java/com/jeanbarrossilva/orca/core/http/client/test/TestScope.extensions.kt
@@ -5,6 +5,7 @@ import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.auth.actor.ActorProvider
 import com.jeanbarrossilva.orca.core.http.HttpModule
 import com.jeanbarrossilva.orca.core.http.client.CoreHttpClient
+import com.jeanbarrossilva.orca.core.http.client.authenticateAndGet
 import com.jeanbarrossilva.orca.core.http.client.test.instance.TestHttpInstance
 import com.jeanbarrossilva.orca.core.http.client.test.instance.TestHttpInstanceProvider
 import com.jeanbarrossilva.orca.core.module.CoreModule
@@ -18,6 +19,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.HttpRequest
 import io.ktor.http.HttpMethod
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 
@@ -115,6 +117,7 @@ private fun <T : Actor> runCoreHttpClientTest(
     ) {
       SampleTermMuter()
     }
+  runBlocking { instance.client.authenticateAndGet("") {} }
   Injector.register<CoreModule>(module)
   runTest { CoreHttpClientTestScope(delegate = this, instance.client, actor).body() }
   Injector.unregister<CoreModule>()

--- a/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/core/Activity.extensions.kt
+++ b/platform/ui-test/src/main/java/com/jeanbarrossilva/orca/platform/ui/test/core/Activity.extensions.kt
@@ -1,0 +1,22 @@
+package com.jeanbarrossilva.orca.platform.ui.test.core
+
+import android.app.Activity
+import android.view.View
+import androidx.core.view.children
+import com.jeanbarrossilva.orca.platform.ui.core.content
+
+/**
+ * Requests this [Activity] to be focused if it isn't.
+ *
+ * @param isFocused Whether this [Activity] is currently focused.
+ * @throws IllegalStateException If this [Activity] isn't focused but doesn't have any content
+ *   [View]s.
+ * @see Activity.addContentView
+ * @see Activity.setContentView
+ */
+fun Activity.requestFocus(isFocused: Boolean) {
+  if (!isFocused) {
+    content.children.firstOrNull()?.requestFocus()
+      ?: throw IllegalStateException("Cannot request focus to an Activity without content views.")
+  }
+}


### PR DESCRIPTION
Fixes:

1. A crash that happened when opening the app, as soon as navigation to the authorization screen (the one with the domains to be selected) was performed.
2. A bug in the authorization/authentication loop in which the user would be taken back to the authorization screen after "being authenticated"; that's within quotes because they weren't really being authenticated, as the core HTTP structures responsible for such operations had multiple instances of themselves created.