### PR TITLE
Differentiate internal from external links

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
   testImplementation(project(":core:sample"))
   testImplementation(project(":core:sample-test"))
   testImplementation(project(":core-test"))
+  testImplementation(libs.assertk)
   testImplementation(libs.kotlin.coroutines.test)
   testImplementation(libs.kotlin.test)
   testImplementation(libs.turbine)

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/HttpTootEntity.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/cache/storage/HttpTootEntity.kt
@@ -13,10 +13,13 @@ import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Highlig
 import com.jeanbarrossilva.orca.core.feed.profile.toot.reblog.Reblog
 import com.jeanbarrossilva.orca.core.http.feed.profile.cache.storage.style.HttpStyleEntity
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.HttpToot
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.platform.cache.Cache
 import com.jeanbarrossilva.orca.platform.theme.extensions.`if`
 import com.jeanbarrossilva.orca.std.imageloader.Image
 import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
+import com.jeanbarrossilva.orca.std.injector.Injector
 import com.jeanbarrossilva.orca.std.styledstring.StyledString
 import java.net.URL
 import java.time.ZonedDateTime
@@ -74,11 +77,12 @@ internal data class HttpTootEntity(
     imageLoaderProvider: ImageLoader.Provider<URL>
   ): Toot {
     val author = profileCache.get(authorID).toAuthor()
+    val domain = Injector.from<CoreModule>().instanceProvider().provide().domain
     val styles = dao.selectWithStylesByID(id).styles.map(HttpStyleEntity::toStyle)
     val text = StyledString(text, styles)
     val coverLoader = headlineCoverURL?.let { imageLoaderProvider.provide(URL(it)) }
     val content =
-      Content.from(text) {
+      Content.from(domain, text) {
         if (headlineTitle != null && headlineCoverURL != null) {
           Headline(headlineTitle, headlineSubtitle, coverLoader)
         } else {

--- a/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/status/HttpStatus.kt
+++ b/core/http/src/main/java/com/jeanbarrossilva/orca/core/http/feed/profile/toot/status/HttpStatus.kt
@@ -6,10 +6,13 @@ import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
 import com.jeanbarrossilva.orca.core.feed.profile.toot.reblog.Reblog
 import com.jeanbarrossilva.orca.core.http.feed.profile.account.HttpAccount
 import com.jeanbarrossilva.orca.core.http.feed.profile.toot.HttpToot
+import com.jeanbarrossilva.orca.core.module.CoreModule
+import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.platform.theme.extensions.`if`
 import com.jeanbarrossilva.orca.platform.ui.core.style.fromHtml
 import com.jeanbarrossilva.orca.std.imageloader.Image
 import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
+import com.jeanbarrossilva.orca.std.injector.Injector
 import com.jeanbarrossilva.orca.std.styledstring.StyledString
 import java.net.URL
 import java.time.ZonedDateTime
@@ -61,10 +64,11 @@ internal constructor(
   internal fun toToot(imageLoaderProvider: ImageLoader.Provider<URL>): Toot {
     val author =
       reblog?.account?.toAuthor(imageLoaderProvider) ?: account.toAuthor(imageLoaderProvider)
+    val domain = Injector.from<CoreModule>().instanceProvider().provide().domain
     val text = StyledString.fromHtml(reblog?.content ?: content)
     val attachments =
       (reblog?.mediaAttachments ?: mediaAttachments).map(HttpAttachment::toAttachment)
-    val content = Content.from(text, attachments) { card?.toHeadline(imageLoaderProvider) }
+    val content = Content.from(domain, text, attachments) { card?.toHeadline(imageLoaderProvider) }
     val publicationDateTime = ZonedDateTime.parse(reblog?.createdAt ?: createdAt)
     val url = URL(reblog?.url ?: url)
     return HttpToot(

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/Content.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/content/Content.extensions.kt
@@ -3,8 +3,10 @@ package com.jeanbarrossilva.orca.core.sample.feed.profile.toot.content
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Attachment
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Highlight
+import com.jeanbarrossilva.orca.core.instance.domain.Domain
 import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.content.highlight.createSample
 import com.jeanbarrossilva.orca.core.sample.image.SampleImageSource
+import com.jeanbarrossilva.orca.core.sample.instance.domain.sample
 import com.jeanbarrossilva.orca.std.imageloader.Image
 import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
 import com.jeanbarrossilva.orca.std.styledstring.buildStyledString
@@ -21,6 +23,7 @@ fun Content.Companion.createSample(
 ): Content {
   val highlight = Highlight.createSample(imageLoaderProvider)
   return from(
+    Domain.sample,
     buildStyledString {
       +"This is a "
       bold { +"sample" }

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/reblog/Reblog.extensions.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/toot/reblog/Reblog.extensions.kt
@@ -3,10 +3,12 @@ package com.jeanbarrossilva.orca.core.sample.feed.profile.toot.reblog
 import com.jeanbarrossilva.orca.core.feed.profile.toot.Author
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.Content
 import com.jeanbarrossilva.orca.core.feed.profile.toot.reblog.Reblog
+import com.jeanbarrossilva.orca.core.instance.domain.Domain
 import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.SampleToot
 import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.createRamboSample
 import com.jeanbarrossilva.orca.core.sample.feed.profile.toot.createSample
 import com.jeanbarrossilva.orca.core.sample.image.SampleImageSource
+import com.jeanbarrossilva.orca.core.sample.instance.domain.sample
 import com.jeanbarrossilva.orca.std.imageloader.Image
 import com.jeanbarrossilva.orca.std.imageloader.ImageLoader
 import com.jeanbarrossilva.orca.std.styledstring.StyledString
@@ -32,6 +34,7 @@ fun Reblog.Companion.createSample(
       sampleReblogID,
       Author.createRamboSample(imageLoaderProvider),
       Content.from(
+        Domain.sample,
         StyledString(
           "Programming life hack. Looking for real-world examples of how an API is used? Search " +
             "for code on GitHub like so: “APINameHere path:*.extension”. Practical example for a " +

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Content.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/Content.kt
@@ -3,6 +3,9 @@ package com.jeanbarrossilva.orca.core.feed.profile.toot.content
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Headline
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.HeadlineProvider
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Highlight
+import com.jeanbarrossilva.orca.core.instance.Instance
+import com.jeanbarrossilva.orca.core.instance.domain.Domain
+import com.jeanbarrossilva.orca.core.instance.domain.isOfResourceFrom
 import com.jeanbarrossilva.orca.std.styledstring.StyledString
 import com.jeanbarrossilva.orca.std.styledstring.style.type.Link
 import java.util.Objects
@@ -20,13 +23,6 @@ private constructor(
   val attachments: List<Attachment>,
   val highlight: Highlight? = null
 ) {
-  /**
-   * [IllegalArgumentException] thrown if the text has a [Highlight] while a [Headline] hasn't been
-   * provided.
-   */
-  class UnprovidedHeadlineException :
-    IllegalArgumentException("Text has a highlight but no headline was provided.")
-
   override fun equals(other: Any?): Boolean {
     return other is Content && text == other.text && highlight == other.highlight
   }
@@ -43,58 +39,29 @@ private constructor(
     /**
      * Creates [Content] from the given [text].
      *
+     * @param domain [Domain] of the [Instance] from which the [Content] is being created.
      * @param text [String] from which [Content] will be created.
      * @param attachments [Attachment]s containing the attached media.
      * @param headlineProvider [HeadlineProvider] that provides the [Headline].
-     * @throws UnprovidedHeadlineException If the text has a [Highlight] while a [HeadlineProvider]
-     *   hasn't been specified.
      */
-    @Throws(UnprovidedHeadlineException::class)
     fun from(
+      domain: Domain,
       text: StyledString,
       attachments: List<Attachment> = emptyList(),
       headlineProvider: HeadlineProvider
     ): Content {
       val links = text.styles.filterIsInstance<Link>()
-      val highlightLink = links.firstOrNull()
+      val externalLinks = links.filterNot { it.url.isOfResourceFrom(domain) }
+      val highlightLink = externalLinks.firstOrNull()
       val highlightUrl = highlightLink?.url
       val headline = highlightUrl?.let { headlineProvider.provide(it) }
       val highlight = headline?.let { Highlight(it, highlightUrl) }
-      val formattedText =
-        if (
-          links.size == 1 &&
-            highlightLink != null &&
-            text.trimEnd().endsWith(text.substring(highlightLink.indices))
-        ) {
-          text.copy { removeRange(highlightLink.indices).trimEnd() }
-        } else {
-          text
-        }
-      return Content(formattedText, attachments, highlight)
-    }
+      val isHighlightLinkRemovable = text.isHighlightLinkRemovable(externalLinks, highlightLink)
 
-    /**
-     * Ensures the parity of an operation involving the [link] and the [headline], throwing if the
-     * [link] is not `null` and the [headline] is `null`.
-     *
-     * @param link [Link] found in a [StyledString].
-     * @param headline [Headline] with main information about a [Highlight].
-     * @throws UnprovidedHeadlineException If the text has a [Highlight] while the [headline] hasn't
-     *   been specified.
-     */
+      @Suppress("LocalVariableName")
+      val _text = if (isHighlightLinkRemovable) text.withoutHighlightLink(highlightLink) else text
 
-    /*
-     * There's a case in which the link will exist and a headline won't be provided: when the
-     * URL leads to an in-app resource (such as a toot or a profile). Because these links start
-     * with the instance base URL, a solution for obtaining instance-specific URL resources must
-     * be developed in order for parity between the link and the headline to be properly
-     * ensured.
-     */
-    @Throws(UnprovidedHeadlineException::class)
-    private fun ensureParity(link: Link?, headline: Headline?) {
-      if (link != null && headline == null) {
-        throw UnprovidedHeadlineException()
-      }
+      return Content(_text, attachments, highlight)
     }
   }
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/StyledString.extensions.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/StyledString.extensions.kt
@@ -1,0 +1,34 @@
+package com.jeanbarrossilva.orca.core.feed.profile.toot.content
+
+import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Highlight
+import com.jeanbarrossilva.orca.core.instance.domain.Domain
+import com.jeanbarrossilva.orca.std.styledstring.StyledString
+import com.jeanbarrossilva.orca.std.styledstring.style.type.Link
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+/**
+ * Returns whether the [Highlight] link can be removed from this [StyledString].
+ *
+ * @param externalLinks [Link]s that link to resources outside of a given [Domain].
+ * @param highlightLink [Link] considered to be the highlight from the external ones.
+ */
+@OptIn(ExperimentalContracts::class)
+internal fun StyledString.isHighlightLinkRemovable(
+  externalLinks: List<Link>,
+  highlightLink: Link?
+): Boolean {
+  contract { returns() implies (highlightLink != null) }
+  return externalLinks.size == 1 &&
+    highlightLink != null &&
+    trimEnd().endsWith(substring(highlightLink.indices))
+}
+
+/**
+ * Returns this [StyledString] minus the [Highlight] link.
+ *
+ * @param highlightLink [Link] considered to be the highlight from the external ones.
+ */
+internal fun StyledString.withoutHighlightLink(highlightLink: Link): StyledString {
+  return copy { removeRange(highlightLink.indices).trim() }
+}

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/instance/domain/Domain.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/instance/domain/Domain.kt
@@ -1,5 +1,7 @@
 package com.jeanbarrossilva.orca.core.instance.domain
 
+import java.net.URL
+
 /**
  * An instance's unique identifier.
  *
@@ -7,6 +9,10 @@ package com.jeanbarrossilva.orca.core.instance.domain
  */
 @JvmInline
 value class Domain(private val value: String) {
+  /** [URL] that leads to this [Domain]. */
+  val url
+    get() = URL("https", value, "")
+
   /** [IllegalArgumentException] thrown if the [value] is blank. */
   class BlankValueException internal constructor() :
     IllegalArgumentException("Domain cannot be empty.")

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/instance/domain/URL.extensions.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/instance/domain/URL.extensions.kt
@@ -1,0 +1,8 @@
+package com.jeanbarrossilva.orca.core.instance.domain
+
+import java.net.URL
+
+/** Returns whether this [URL] is of a resource that belongs to the [domain]. */
+internal fun URL.isOfResourceFrom(domain: Domain): Boolean {
+  return host == domain.toString() && path.isNotEmpty()
+}

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/ContentTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/toot/content/ContentTests.kt
@@ -2,36 +2,22 @@ package com.jeanbarrossilva.orca.core.feed.profile.toot.content
 
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Headline
 import com.jeanbarrossilva.orca.core.feed.profile.toot.content.highlight.Highlight
+import com.jeanbarrossilva.orca.core.instance.domain.Domain
+import com.jeanbarrossilva.orca.core.sample.instance.domain.sample
 import com.jeanbarrossilva.orca.core.sample.test.feed.profile.toot.content.highlight.sample
 import com.jeanbarrossilva.orca.std.styledstring.StyledString
 import com.jeanbarrossilva.orca.std.styledstring.buildStyledString
-import kotlin.test.Ignore
+import java.net.URL
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 internal class ContentTests {
-  @Ignore("Depends on the implementation of instance-specific URL resources.")
   @Test
-  fun `GIVEN a text with a URL without providing a headline WHEN creating content from it THEN it throws`() {
-    assertFailsWith<Content.UnprovidedHeadlineException> {
-      Content.from(buildStyledString { +Highlight.sample.url.toString() }) { null }
-    }
-  }
-
-  @Test
-  fun `GIVEN a text with a single trailing URL WHEN creating content from it THEN it's removed`() {
-    assertEquals(
-      StyledString("🥸"),
-      Content.from(buildStyledString { +"🥸 ${Highlight.sample.url}" }) { Headline.sample }.text
-    )
-  }
-
-  @Test
-  fun `GIVEN a text with a trailing link WHEN creating content from it THEN `() {
+  fun `GIVEN a text with a trailing link and a headline WHEN creating content from them THEN the link is removed`() {
     assertEquals(
       StyledString("😗"),
       Content.from(
+          Domain.sample,
           buildStyledString {
             +"😗 "
             link(Highlight.sample.url) { +"🔗" }
@@ -44,13 +30,49 @@ internal class ContentTests {
   }
 
   @Test
+  fun `GIVEN a text with a trailing link and no headline WHEN creating content from them THEN the link is kept`() {
+    assertEquals(
+      buildStyledString {
+        link(Highlight.sample.url) { +"Link" }
+        +'!'
+      },
+      Content.from(
+          Domain.sample,
+          buildStyledString {
+            link(Highlight.sample.url) { +"Link" }
+            +'!'
+          }
+        ) {
+          null
+        }
+        .text
+    )
+  }
+
+  @Test
   fun `GIVEN a text with two trailing URLs WHEN creating content from it THEN they're kept`() {
     assertEquals(
       buildStyledString { +"🫨 ${Highlight.sample.url} ${Highlight.sample.url}" },
-      Content.from(buildStyledString { +"🫨 ${Highlight.sample.url} ${Highlight.sample.url}" }) {
+      Content.from(
+          Domain.sample,
+          buildStyledString { +"🫨 ${Highlight.sample.url} ${Highlight.sample.url}" }
+        ) {
           Headline.sample
         }
         .text
     )
+  }
+
+  @Test
+  fun `GIVEN a text with a link to an internal resource and no headline WHEN creating content from them THEN it doesn't throw`() {
+    Content.from(
+      Domain.sample,
+      buildStyledString {
+        link(URL(Domain.sample.url, "resource")) { +"Here" }
+        +'!'
+      }
+    ) {
+      null
+    }
   }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/instance/domain/DomainTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/instance/domain/DomainTests.kt
@@ -1,0 +1,24 @@
+package com.jeanbarrossilva.orca.core.instance.domain
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import com.jeanbarrossilva.orca.core.sample.instance.domain.sample
+import kotlin.test.Test
+
+internal class DomainTests {
+  @Test
+  fun urlProtocolIsHttps() {
+    assertThat(Domain.sample.url.protocol).isEqualTo("https")
+  }
+
+  @Test
+  fun urlHostIsDomain() {
+    assertThat(Domain.sample.url.host).isEqualTo("${Domain.sample}")
+  }
+
+  @Test
+  fun urlDoesNotHavePath() {
+    assertThat(Domain.sample.url.path).isEmpty()
+  }
+}

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/instance/domain/URLExtensionsTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/instance/domain/URLExtensionsTests.kt
@@ -1,0 +1,20 @@
+package com.jeanbarrossilva.orca.core.instance.domain
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import com.jeanbarrossilva.orca.core.sample.instance.domain.sample
+import java.net.URL
+import kotlin.test.Test
+
+internal class URLExtensionsTests {
+  @Test
+  fun isInternalResourceURL() {
+    assertThat(URL(Domain.sample.url, "path").isOfResourceFrom(Domain.sample)).isTrue()
+  }
+
+  @Test
+  fun isExternalResourceURL() {
+    assertThat(URL("https", "google.com", " ").isOfResourceFrom(Domain.sample)).isFalse()
+  }
+}


### PR DESCRIPTION
Posts were treating each link within them equally, and, apart from the limitations that this behavior can impose, it also occasioned a bug in which if the content had two links, an internal and a trailing external one, the latter wouldn't be removed from the text (as it should).

<img src="https://github.com/jeanbarrossilva/Orca/assets/38408390/8020ca22-a726-4a69-ac88-6da657b0bca0" width="256" />
<img src="https://github.com/jeanbarrossilva/Orca/assets/38408390/9683b7ff-37d8-431d-9127-858c6d1349b8" width="256" />
