### PR TITLE
Store `Image` `Pixel`s in an array

### DIFF
--- a/std/image-loader/src/main/java/com/jeanbarrossilva/orca/std/imageloader/Image.kt
+++ b/std/image-loader/src/main/java/com/jeanbarrossilva/orca/std/imageloader/Image.kt
@@ -9,13 +9,7 @@ import java.util.Objects
  * @param height How tall this [Image] is.
  * @param pixels [Pixel]s by which this [Image] is composed.
  */
-class Image private constructor(val width: Int, val height: Int, val pixels: List<Pixel>) {
-  init {
-    if (pixels.size < width * height) {
-      throw IllegalArgumentException("Insufficient amount of pixels for $width x $height.")
-    }
-  }
-
+class Image private constructor(val width: Int, val height: Int, val pixels: Array<Pixel>) {
   /**
    * Smallest addressable element in an [Image].
    *
@@ -44,31 +38,48 @@ class Image private constructor(val width: Int, val height: Int, val pixels: Lis
    * @param height How tall the [Image] is.
    */
   class Builder internal constructor(private val width: Int, private val height: Int) {
+    /** Final size of the [Image] to be built, calculated from the given [width] and [height]. */
+    private val size = width * height
+
     /** [Pixel]s by which the [Image] will be composed. */
-    private val pixels = mutableListOf<Pixel>()
+    private val pixels = arrayOfNulls<Pixel>(size)
+
+    /** Index into which the next [Pixel] to be added will be put. */
+    private var nextPixelIndex = 0
 
     /**
      * Adds a [Pixel] to the next remaining space in the x-axis, jumping to the next column if the
      * row has been filled.
      *
      * @param color [Int] form of the color by which the [Pixel] will be colored.
-     * @throws IllegalStateException If the [Image] cannot have more [Pixel]s added to it.
+     * @throws IllegalArgumentException If the [Image] hasn't been entirely filled or the amount of
+     *   [Pixel]s is greater than the [size].
      */
     fun pixel(color: Int) {
-      val lastPixel = pixels.lastOrNull()
+      val lastPixel = pixels.getOrNull(nextPixelIndex.dec())
       val x = lastPixel?.x?.inc()?.mirror(0, width.dec()) ?: 0
       val y = if (lastPixel != null && x == 0) lastPixel.y.inc() else lastPixel?.y ?: 0
-      if (y >= height) {
-        throw IllegalStateException("Coordinate out of $width x $height bounds: ($x, $y).")
-      }
-      val pixel = Pixel(x, y, color)
-      pixels.add(pixel)
+      require(y < height) { "Coordinate out of $width x $height bounds: ($x, $y)." }
+      pixels[nextPixelIndex++] = Pixel(x, y, color)
     }
 
     /** Builds the [Image] with the provided configurations. */
     internal fun build(): Image {
-      val pixelsAsList = pixels.toList()
-      return Image(width, height, pixelsAsList)
+      ensurePixelSufficiency()
+      nextPixelIndex = 0
+      @Suppress("UNCHECKED_CAST") return Image(width, height, pixels as Array<Pixel>)
+    }
+
+    /**
+     * Ensures that the added amount of [Pixel]s is sufficient for the [size] of the [Image] to be
+     * built.
+     *
+     * @throws IllegalArgumentException If the [Image] hasn't been entirely filled.
+     */
+    private fun ensurePixelSufficiency() {
+      require(nextPixelIndex == pixels.size) {
+        throw IllegalArgumentException("Insufficient amount of pixels for $width x $height.")
+      }
     }
   }
 
@@ -76,7 +87,7 @@ class Image private constructor(val width: Int, val height: Int, val pixels: Lis
     return other is Image &&
       width == other.width &&
       height == other.height &&
-      pixels.containsAll(other.pixels)
+      pixels.contentEquals(other.pixels)
   }
 
   override fun hashCode(): Int {

--- a/std/image-loader/src/test/java/com/jeanbarrossilva/orca/std/imageloader/ImageTests.kt
+++ b/std/image-loader/src/test/java/com/jeanbarrossilva/orca/std/imageloader/ImageTests.kt
@@ -3,27 +3,22 @@ package com.jeanbarrossilva.orca.std.imageloader
 import java.awt.Color
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
-import kotlin.test.assertFailsWith
 
 internal class ImageTests {
-  @Test
+  @Test(expected = IllegalArgumentException::class)
   fun `GIVEN an image WHEN adding an insufficient amount of pixels to it THEN it throws`() {
-    assertFailsWith<IllegalArgumentException> {
-      buildImage(width = 2, height = 2) { pixel(Color.BLACK.rgb) }
-    }
+    buildImage(width = 2, height = 2) { pixel(Color.BLACK.rgb) }
   }
 
-  @Test
+  @Test(expected = IllegalArgumentException::class)
   fun `GIVEN an image WHEN adding more pixels than it can hold THEN it throws`() {
-    assertFailsWith<IllegalStateException> {
-      buildImage(width = 1, height = 1) { repeat(2) { pixel(Color.BLACK.rgb) } }
-    }
+    buildImage(width = 1, height = 1) { repeat(2) { pixel(Color.BLACK.rgb) } }
   }
 
   @Test
   fun `GIVEN an image WHEN adding pixels to it THEN they're placed in the right coordinates`() {
     assertContentEquals(
-      listOf(
+      arrayOf(
         Image.Pixel(x = 0, y = 0, Color.BLACK.rgb),
         Image.Pixel(x = 1, y = 0, Color.BLACK.rgb),
         Image.Pixel(x = 0, y = 1, Color.BLACK.rgb),


### PR DESCRIPTION
Stores the pixels of built images in an array instead of using a list. As a result, the amount of pixel allocations has been reduced by 64.9%.

<img src="https://github.com/jeanbarrossilva/Orca/assets/38408390/3837661f-baaa-4262-aafa-fe422d88b859" />
<img src="https://github.com/jeanbarrossilva/Orca/assets/38408390/59427175-403c-49e5-a6ad-5e1ac00a7dc5" />
