### PR TITLE
Unblock main thread on image loading

### DIFF
--- a/std/image-loader/build.gradle.kts
+++ b/std/image-loader/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
 }
 
 dependencies {
+  implementation(libs.kotlin.coroutines.core)
+
   testImplementation(libs.assertk)
+  testImplementation(libs.kotlin.coroutines.test)
   testImplementation(libs.kotlin.test)
 }

--- a/std/image-loader/compose/src/main/java/com/jeanbarrossilva/orca/std/imageloader/compose/Image.extensions.kt
+++ b/std/image-loader/compose/src/main/java/com/jeanbarrossilva/orca/std/imageloader/compose/Image.extensions.kt
@@ -3,8 +3,15 @@ package com.jeanbarrossilva.orca.std.imageloader.compose
 import android.graphics.Bitmap
 import androidx.core.graphics.createBitmap
 import com.jeanbarrossilva.orca.std.imageloader.Image
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 
 /** Converts this [Image] into a [Bitmap]. */
-internal fun Image.toBitmap(): Bitmap {
-  return createBitmap(width, height).apply { pixels.forEach { setPixel(it.x, it.y, it.color) } }
+internal suspend fun Image.toBitmap(): Bitmap {
+  return createBitmap(width, height).apply {
+    withContext(Dispatchers.IO) {
+      coroutineScope { pixels.forEach { setPixel(it.x, it.y, it.color) } }
+    }
+  }
 }

--- a/std/image-loader/local/build.gradle.kts
+++ b/std/image-loader/local/build.gradle.kts
@@ -19,5 +19,4 @@ dependencies {
   api(project(":std:image-loader"))
 
   implementation(libs.android.core)
-  implementation(libs.kotlin.coroutines.core)
 }

--- a/std/image-loader/local/build.gradle.kts
+++ b/std/image-loader/local/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
   api(project(":std:image-loader"))
 
   implementation(libs.android.core)
+  implementation(libs.kotlin.coroutines.core)
 }

--- a/std/image-loader/local/src/main/java/com/jeanbarrossilva/orca/std/imageloader/local/Bitmap.extensions.kt
+++ b/std/image-loader/local/src/main/java/com/jeanbarrossilva/orca/std/imageloader/local/Bitmap.extensions.kt
@@ -3,25 +3,18 @@ package com.jeanbarrossilva.orca.std.imageloader.local
 import android.graphics.Bitmap
 import com.jeanbarrossilva.orca.std.imageloader.Image
 import com.jeanbarrossilva.orca.std.imageloader.buildImage
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.withContext
 
 /** Converts this [Bitmap] into an [Image]. */
 suspend fun Bitmap.toImage(): Image {
-  return withContext(Dispatchers.IO) {
-    coroutineScope {
-      buildImage(width, height) {
-        val nonHardwareBitmap =
-          if (config == Bitmap.Config.HARDWARE) {
-            copy(Bitmap.Config.ARGB_8888, false)
-          } else {
-            this@toImage
-          }
-        IntArray(size = width * height)
-          .also { nonHardwareBitmap.getPixels(it, 0, width, 0, 0, width, height) }
-          .forEach(::pixel)
+  return buildImage(width, height) {
+    val nonHardwareBitmap =
+      if (config == Bitmap.Config.HARDWARE) {
+        copy(Bitmap.Config.ARGB_8888, false)
+      } else {
+        this@toImage
       }
-    }
+    IntArray(size = width * height)
+      .also { nonHardwareBitmap.getPixels(it, 0, width, 0, 0, width, height) }
+      .forEach(::pixel)
   }
 }

--- a/std/image-loader/local/src/main/java/com/jeanbarrossilva/orca/std/imageloader/local/Bitmap.extensions.kt
+++ b/std/image-loader/local/src/main/java/com/jeanbarrossilva/orca/std/imageloader/local/Bitmap.extensions.kt
@@ -3,18 +3,25 @@ package com.jeanbarrossilva.orca.std.imageloader.local
 import android.graphics.Bitmap
 import com.jeanbarrossilva.orca.std.imageloader.Image
 import com.jeanbarrossilva.orca.std.imageloader.buildImage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 
 /** Converts this [Bitmap] into an [Image]. */
-fun Bitmap.toImage(): Image {
-  return buildImage(width, height) {
-    val nonHardwareBitmap =
-      if (config == Bitmap.Config.HARDWARE) {
-        copy(Bitmap.Config.ARGB_8888, false)
-      } else {
-        this@toImage
+suspend fun Bitmap.toImage(): Image {
+  return withContext(Dispatchers.IO) {
+    coroutineScope {
+      buildImage(width, height) {
+        val nonHardwareBitmap =
+          if (config == Bitmap.Config.HARDWARE) {
+            copy(Bitmap.Config.ARGB_8888, false)
+          } else {
+            this@toImage
+          }
+        IntArray(size = width * height)
+          .also { nonHardwareBitmap.getPixels(it, 0, width, 0, 0, width, height) }
+          .forEach(::pixel)
       }
-    IntArray(size = width * height)
-      .also { nonHardwareBitmap.getPixels(it, 0, width, 0, 0, width, height) }
-      .forEach(::pixel)
+    }
   }
 }

--- a/std/image-loader/src/main/java/com/jeanbarrossilva/orca/std/imageloader/Image.extensions.kt
+++ b/std/image-loader/src/main/java/com/jeanbarrossilva/orca/std/imageloader/Image.extensions.kt
@@ -1,5 +1,9 @@
 package com.jeanbarrossilva.orca.std.imageloader
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+
 /**
  * Builds an [Image].
  *
@@ -7,6 +11,8 @@ package com.jeanbarrossilva.orca.std.imageloader
  * @param height How tall the [Image] is.
  * @param build Configures the [Image] to be built.
  */
-fun buildImage(width: Int, height: Int, build: Image.Builder.() -> Unit): Image {
-  return Image.Builder(width, height).apply(build).build()
+suspend fun buildImage(width: Int, height: Int, build: Image.Builder.() -> Unit): Image {
+  return withContext(Dispatchers.IO) {
+    coroutineScope { Image.Builder(width, height).apply(build).build() }
+  }
 }

--- a/std/image-loader/src/test/java/com/jeanbarrossilva/orca/std/imageloader/ImageTests.kt
+++ b/std/image-loader/src/test/java/com/jeanbarrossilva/orca/std/imageloader/ImageTests.kt
@@ -5,38 +5,45 @@ import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
 import java.awt.Color
 import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
 
 internal class ImageTests {
   @Test(expected = IllegalArgumentException::class)
   fun throwsWhenPixelsAreInsufficient() {
-    buildImage(width = 2, height = 2) { pixel(Color.BLACK.rgb) }
+    runTest { buildImage(width = 2, height = 2) { pixel(Color.BLACK.rgb) } }
   }
 
   @Test(expected = IllegalArgumentException::class)
   fun throwsWhenAddingMorePixelsThanTheSizeCanHold() {
-    buildImage(width = 1, height = 1) { repeat(2) { pixel(Color.BLACK.rgb) } }
+    runTest { buildImage(width = 1, height = 1) { repeat(2) { pixel(Color.BLACK.rgb) } } }
   }
 
   @Test
   fun addsPixelsToTheCoordinateThatSucceedsThePreviousOne() {
-    assertThat(buildImage(width = 2, height = 2) { repeat(4) { pixel(Color.BLACK.rgb) } }.pixels)
-      .containsExactly(
-        Image.Pixel(x = 0, y = 0, Color.BLACK.rgb),
-        Image.Pixel(x = 1, y = 0, Color.BLACK.rgb),
-        Image.Pixel(x = 0, y = 1, Color.BLACK.rgb),
-        Image.Pixel(x = 1, y = 1, Color.BLACK.rgb)
-      )
+    runTest {
+      assertThat(buildImage(width = 2, height = 2) { repeat(4) { pixel(Color.BLACK.rgb) } }.pixels)
+        .containsExactly(
+          Image.Pixel(x = 0, y = 0, Color.BLACK.rgb),
+          Image.Pixel(x = 1, y = 0, Color.BLACK.rgb),
+          Image.Pixel(x = 0, y = 1, Color.BLACK.rgb),
+          Image.Pixel(x = 1, y = 1, Color.BLACK.rgb)
+        )
+    }
   }
 
   @Test
   fun widthIsTheSameAsSpecifiedWhenBuildingTheImage() {
-    assertThat(buildImage(width = 2, height = 1) { repeat(2) { pixel(Color.BLACK.rgb) } }.width)
-      .isEqualTo(2)
+    runTest {
+      assertThat(buildImage(width = 2, height = 1) { repeat(2) { pixel(Color.BLACK.rgb) } }.width)
+        .isEqualTo(2)
+    }
   }
 
   @Test
   fun heightIsTheSameAsSpecifiedWhenBuildingTheImage() {
-    assertThat(buildImage(width = 1, height = 2) { repeat(2) { pixel(Color.BLACK.rgb) } }.height)
-      .isEqualTo(2)
+    runTest {
+      assertThat(buildImage(width = 1, height = 2) { repeat(2) { pixel(Color.BLACK.rgb) } }.height)
+        .isEqualTo(2)
+    }
   }
 }


### PR DESCRIPTION
Moves the work of copying pixels from an [`Image`](https://github.com/jeanbarrossilva/Orca/blob/6cc18e78251b386d07c33e9cd70126037b71537f/std/image-loader/src/main/java/com/jeanbarrossilva/orca/std/imageloader/Image.kt) into a [`Bitmap`](https://developer.android.com/reference/android/graphics/Bitmap) and vice-versa to a new coroutine with an [IO context](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-dispatchers/-i-o.html).